### PR TITLE
build(*): Don’t build es modules in site package

### DIFF
--- a/scripts/package/build.sh
+++ b/scripts/package/build.sh
@@ -3,7 +3,9 @@
 NODE_ENV="${NODE_ENV:-production}"
 
 # es modules
-NODE_ENV=$NODE_ENV babel src --out-dir dist/es --ignore *.spec.js,__demo__ --source-maps --minified
+if [ "$TARGET" != 'site' ]; then
+  NODE_ENV=$NODE_ENV babel src --out-dir dist/es --ignore *.spec.js,__demo__ --source-maps --minified
+fi
 
 # umd
 TARGET=$TARGET NODE_ENV=$NODE_ENV webpack


### PR DESCRIPTION
### Description
Update build script to NOT build es modules for the site package as they are unnecessary

### Motivation and context
closes #24 

### How has this been tested?
* Ran `npm run build` at root level and verified that `site` package no longer contains `dist/es` folder, but other packages still do.
* Automated tests passing
* Site demo works locally

### Types of changes
- Other (provide details below)

Update to build script

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?
![whatever](https://media.giphy.com/media/cwTtbmUwzPqx2/giphy.gif)
