### PR TITLE
feat(site): Site deploy now includes public assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-preset-react": "6.23.0",
     "commitizen": "2.9.6",
     "conventional-commit-types": "2.1.0",
+    "copy-webpack-plugin": "4.0.1",
     "css-loader": "0.28.1",
     "cz-conventional-changelog": "2.0.0",
     "enzyme": "2.8.0",

--- a/packages/site/public/CNAME
+++ b/packages/site/public/CNAME
@@ -1,0 +1,1 @@
+mineral-ui.com

--- a/packages/site/webpack.config.js
+++ b/packages/site/webpack.config.js
@@ -13,8 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const webpackMerge = require('webpack-merge');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const makeWebpackConfig = require('../../utils/makeWebpackConfig');
 
-module.exports = makeWebpackConfig({
+const baseConfig = makeWebpackConfig({
   packagePath: __dirname
 });
+
+let config = baseConfig;
+config = webpackMerge(baseConfig, {
+  plugins: [
+    new CopyWebpackPlugin([
+      {
+        context: './public',
+        from: '**/*'
+      }
+    ])
+  ]
+});
+
+module.exports = config;


### PR DESCRIPTION
### Description

Site deploy now includes public assets
* Add CNAME to site public assets
* Update site webpack to copy all files from public to dist

### Motivation and context
closes #23 

### How has this been tested?
* I ran `npm run build` in the site package and verified that the `dist` directory contains the CNAME file.
* I ran `npm run deploy:site` and verified that the `mineral-ui.github.io` repo contains the CNAME file

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?
![whatever](https://media.giphy.com/media/cwTtbmUwzPqx2/giphy.gif)
