### PR TITLE
[README] Update imports to avoid airbnb/eslint conflict: "import/no-unresolved"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ _ES2015_
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Hello from '@mineral-ui/Hello';
-import World from '@mineral-ui/World';
+import Hello from '@mineral-ui/hello';
+import World from '@mineral-ui/world';
 
 const App = () => (
   <div>


### PR DESCRIPTION
### Description
Due to the casing here:
```
import Hello from '@mineral-ui/Hello';
import World from '@mineral-ui/World';
```
I'm seeing an eslint error related to `import/no-unresolved`, which is a part of `eslint-config-airbnb`.

It's a quick fix, which just involves either converting the casing of `@mineral-ui/Hello` to `@mineral-ui/hello` or renaming your component folders to be capitalized(the solution I'd recommend).

### Motivation and context
Within the Phoenix console, we utilize the [`eslint-config`](https://github.com/CAAPIM/eslint-config-ca/)  package that we, the Web Client Team, made. This configuration extends functionality from `eslint-config-airbnb` and includes other widely accepted eslint rules. 

The `Mineral-UI` project should work with(and probably use) our `eslint-config` package, as it enforces many widely adopted practices used by front-end development stacks.

### How has this been tested?
* This has been tested by running `eslint` within the Phoenix project.

### Types of changes
* Bug fix: change casing on `ES6` imports within the `README.md`

### Checklist
* [X] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [X] Automated tests written and passing
* [X] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [X] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [X] Documentation created or updated