### PR TITLE
[docs]: Update contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please try to keep your PR as small and focused as possible, and don’t include
 
 If your PR adds new features or changes existing code, please attempt to write tests covering the new behavior.
 
-For a PR to be accepted, it must fulfill each item in the checklist provided in the [pull request template](./.github/PULL_REQUEST_TEMPLATE.md).
+For a PR to be accepted, it must fulfill each item in the checklist provided in the [pull request template](./.github/PULL_REQUEST_TEMPLATE.md), and all authors must sign the [Contributor License Agreement ("CLA")](https://cla-assistant.io/mineral-ui/mineral-ui).
 
 
 ## Getting Started
@@ -69,10 +69,6 @@ npm update
 
 
 ### Developing
-
-<!--
-This project uses [??????????]() for styling.
--->
 
 - We use [Prettier](https://github.com/prettier/prettier), so you can write your code in whichever style you’re most comfortable and convert it to our standard before you commit:
 


### PR DESCRIPTION
### Description
Update contributing docs as I am testing [cla-assistant](http://cla-assistant.io) integration.

__Additional Notes:__

* greenkeeper bot imported into cla-assistant
* If desired, can import other team members so that they do not have to accept
* Applied to whole org so affects all repos
* CA CLA obtained from APIM - and now lives at https://gist.github.com/mineral-ci/e9763fc3bc762425ff0d408658fbfd82
* Added link to CLA to Contributing.md
* Login with mineral-ci user at https://cla-assistant.io/

### Motivation and context
For legal reasons, contributors need to sign a contributor license agreement

connects #42

### How has this been tested?
Manual testing on existing PR's

### Types of changes
- Other (provide details below)
documentation and 3rd party service integration

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Better call Saul](https://media.giphy.com/media/11jkrpPYTQkaU8/giphy.gif)
