### PR TITLE
chore(eslint): Avoid conflicts between eslint and prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,10 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
-    "plugin:flowtype/recommended"
+    "plugin:flowtype/recommended",
+    "prettier",
+    "prettier/flowtype",
+    "prettier/react",
   ],
   "parser": "babel-eslint",
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "enzyme": "2.8.2",
     "enzyme-to-json": "1.5.1",
     "eslint": "3.19.0",
+    "eslint-config-prettier": "2.1.1",
     "eslint-plugin-flowtype": "2.34.0",
     "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-prettier": "2.1.1",


### PR DESCRIPTION
### Description
Add and configure [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) package

### Motivation and context
Sometimes `eslint` and `prettier` get confused and caught in a loop where one of them will always report an error and want to update some formatting.  Fixing the formatting will then cause the other one to report an error.

This package disables all rules that are unnecessary or might conflict with prettier.

### How has this been tested?
I found a conflicting situation, then enabled this plugin and it worked as expected.

### Types of changes
- Other (provide details below)
Added a new package that only affects development/build environment

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?
![lint](https://media.giphy.com/media/36wFjYXcNClzi/200w_d.gif)
