### PR TITLE
[don't merge] chore(package): update react-dom to version 15.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "glamor": "^2.0.0",
     "glamorous": "^3.0.0",
     "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react-dom": "^15.6.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
this PR shows a commit where greenkeeper updated peerdependencies. this PR should not be merged. unfortunately I don't have the original PR since I force pushed over this commit to work around this issue. 

this has been logged with the greenkeeper project
https://github.com/greenkeeperio/greenkeeper/issues/151#issuecomment-309818212