### PR TITLE
ci(bootstrap): stop bootstrapping twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 before_script:
 - set -e
-- npm run bootstrap
 - npm run build
 notifications:
   flowdock:


### PR DESCRIPTION
the `build` script already runs `bootstrap` so this will save us 3.5s on each ci run

:)