### PR TITLE
feat(site): Add sub-nav to component doc page

### DIFF
--- a/packages/archetype/src/__demo__/index.js
+++ b/packages/archetype/src/__demo__/index.js
@@ -20,7 +20,10 @@ import examples from './examples';
 const doc = require('!!react-docgen-loader!../Archetype.js');
 
 export default {
+  behavior: 'behavior dummy text for the archetype component',
+  design: 'design theory about the archetype component',
   doc,
   examples,
+  howToUse: 'how to install the archetype component',
   title: 'Archetype'
 };

--- a/packages/hello-world/src/__demo__/index.js
+++ b/packages/hello-world/src/__demo__/index.js
@@ -20,7 +20,10 @@ import examples from './examples';
 const doc = require('!!react-docgen-loader!../HelloWorld.js');
 
 export default {
+  behavior: 'behavior dummy text for the HelloWorld component',
+  design: 'Lofty design theory about the helloworld',
   doc,
   examples,
+  howToUse: 'how to install the HelloWorld component',
   title: 'HelloWorld'
 };

--- a/packages/hello/src/__demo__/index.js
+++ b/packages/hello/src/__demo__/index.js
@@ -20,7 +20,10 @@ import examples from './examples';
 const doc = require('!!react-docgen-loader!../Hello.js');
 
 export default {
+  behavior: 'behavior dummy text for the hello component',
+  design: 'Lofty design theory about hello',
   doc,
   examples,
+  howToUse: 'how to install the hello component',
   title: 'Hello'
 };

--- a/packages/site/src/components/ComponentDoc.js
+++ b/packages/site/src/components/ComponentDoc.js
@@ -34,6 +34,9 @@ type Props = {
   doc: Object,
   examples?: Array<Example>,
   slug: string,
+  behavior: MnrlReactNode,
+  design: MnrlReactNode,
+  howToUse: string,
   title: string
 };
 
@@ -62,17 +65,35 @@ const styles = {
     lineHeight: '1.5',
     margin: '0'
   }),
-  heading: (props, theme) => ({
-    margin: `0 0 ${theme.measurement_c}`,
+  h2: (props, theme) => ({
+    margin: `${theme.measurement_d} 0 ${theme.measurement_c} 0`,
     fontSize: theme.font_size_c
-  })
+  }),
+  h3: (props, theme) => ({
+    margin: `${theme.measurement_d} 0 ${theme.measurement_c} 0`
+  }),
+  h4: () => ({}),
+  subnav: (props, theme) => ({
+    borderBottom: `1px solid ${theme.color_gray}`,
+    marginBottom: '2rem'
+  }),
+  navElement: {
+    display: 'inline-block',
+    marginRight: '1.5rem',
+    paddingBottom: '0.5rem',
+    borderBottom: '3px solid transparent',
+    cursor: 'pointer'
+  }
 };
 
 const Root = createStyledComponent('section', styles.componentDoc);
 const Header = createStyledComponent('header', styles.header);
 const Title = createStyledComponent('h1', styles.title);
 const Graf = createStyledComponent('p', styles.graf);
-const Heading = createStyledComponent('h2', styles.heading);
+const H2 = createStyledComponent('h2', styles.h2);
+const H3 = createStyledComponent('h3', styles.h3);
+const SubNav = createStyledComponent('nav', styles.subnav);
+const NavElement = createStyledComponent(Link, styles.navElement);
 
 function GithubIcon() {
   return (
@@ -92,9 +113,12 @@ function GithubIcon() {
 }
 
 export default function ComponentDoc({
+  behavior,
   className,
+  design,
   doc,
   examples,
+  howToUse,
   slug,
   title
 }: Props) {
@@ -114,7 +138,29 @@ export default function ComponentDoc({
         </Link>
         {description}
       </Header>
-      {examples && renderExamples(examples, slug, propDoc)}
+      <SubNav>
+        <NavElement href="#development">Development</NavElement>
+        <NavElement href="#design">Design</NavElement>
+        <NavElement href="#how-to-use">How to Use</NavElement>
+        <NavElement
+          href={`https://github.com/mineral-ui/mineral-ui/blob/master/packages/${slug}/CHANGELOG.md`}>
+          Changelog
+        </NavElement>
+      </SubNav>
+      <div>
+        <H2 id="development">Development</H2>
+        <div>
+          <H3>Behavior</H3>
+          <p>{behavior}</p>
+          <H3>Props</H3>
+          <p>{"we'll move the prop table here"}</p>
+          {examples && renderExamples(examples, slug, propDoc)}
+        </div>
+        <H2 id="design">Design</H2>
+        <p>{design}</p>
+        <H2 id="how-to-use">How to Use</H2>
+        <p>{howToUse}</p>
+      </div>
     </Root>
   );
 }
@@ -126,7 +172,7 @@ function renderExamples(
 ) {
   return (
     <div>
-      <Heading>{examples.length === 1 ? 'Example' : 'Examples'}</Heading>
+      <H3>{examples.length === 1 ? 'Example' : 'Examples'}</H3>
       {examples.map((example, idx) => {
         return (
           <ComponentDocExample

--- a/packages/site/src/components/PropList.js
+++ b/packages/site/src/components/PropList.js
@@ -21,6 +21,7 @@ import { createStyledComponent } from '@mineral-ui/style-utils';
 const styles = {
   codeValue: (props, theme) => ({
     color: theme.color_text,
+    fontSize: '1.2rem',
     fontFamily: theme.fontFamily_monospace
   }),
   heading: (props, theme) => ({
@@ -38,7 +39,8 @@ const styles = {
     margin: 0
   },
   propName: (props, theme) => ({
-    fontFamily: theme.fontFamily_monospace
+    fontFamily: theme.fontFamily_monospace,
+    fontSize: '1.2rem'
   }),
   propRequired: (props, theme) => ({
     color: theme.color_gray,

--- a/packages/site/src/components/__tests__/__snapshots__/App.spec.js.snap
+++ b/packages/site/src/components/__tests__/__snapshots__/App.spec.js.snap
@@ -13,6 +13,8 @@ exports[`App renders correctly 1`] = `
       demos={
         Object {
           "hello": Object {
+            "behavior": "behavior dummy text for the hello component",
+            "design": "Lofty design theory about hello",
             "doc": Object {
               "default": Object {},
             },
@@ -23,9 +25,12 @@ exports[`App renders correctly 1`] = `
                 "title": "Default",
               },
             ],
+            "howToUse": "how to install the hello component",
             "title": "Hello",
           },
           "hello-world": Object {
+            "behavior": "behavior dummy text for the HelloWorld component",
+            "design": "Lofty design theory about the helloworld",
             "doc": Object {
               "default": Object {},
             },
@@ -36,9 +41,12 @@ exports[`App renders correctly 1`] = `
                 "title": "Default",
               },
             ],
+            "howToUse": "how to install the HelloWorld component",
             "title": "HelloWorld",
           },
           "style-utils": Object {
+            "behavior": "some cool behavior info",
+            "design": "Lofty design theory about the style-utils",
             "doc": Object {
               "description": "Sample implentations of various methods of styling and style overrides.",
             },
@@ -106,9 +114,12 @@ exports[`App renders correctly 1`] = `
                 "title": "Style override via createStyledComponent",
               },
             ],
+            "howToUse": "how to install the style-utils package",
             "title": "StyleUtils",
           },
           "world": Object {
+            "behavior": "behavior dummy text for the world component",
+            "design": "Lofty design theory about the world",
             "doc": Object {
               "default": Object {},
             },
@@ -125,6 +136,7 @@ exports[`App renders correctly 1`] = `
                 "title": "Custom Text",
               },
             ],
+            "howToUse": "how to install the world",
             "title": "World",
           },
         }

--- a/packages/style-utils/src/__demo__/index.js
+++ b/packages/style-utils/src/__demo__/index.js
@@ -18,10 +18,13 @@
 import examples from './examples';
 
 export default {
+  behavior: 'some cool behavior info',
+  design: 'Lofty design theory about the style-utils',
   doc: {
     description:
       'Sample implentations of various methods of styling and style overrides.'
   },
   examples,
+  howToUse: 'how to install the style-utils package',
   title: 'StyleUtils'
 };

--- a/packages/world/src/__demo__/index.js
+++ b/packages/world/src/__demo__/index.js
@@ -21,7 +21,10 @@ import examples from './examples';
 const doc = require('!!react-docgen-loader!../World.js');
 
 export default {
+  behavior: 'behavior dummy text for the world component',
+  design: 'Lofty design theory about the world',
   doc,
   examples,
+  howToUse: 'how to install the world',
   title: 'World'
 };


### PR DESCRIPTION
Added a SubNav element and re-organized all sections into one content area.

### Description
Getting started with the re-layout according to @kylegach's style updates. We added some flags to each demo object like `behavior`, `design`, and `howToUse` that will render for each component page. 

### Motivation and context
Getting everything in place for continued PRs in this vein.

### Types of changes
- New feature (non-breaking change which adds functionality

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [ ] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [ ] Automated tests written and passing
* [ ] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [ ] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [ ] Documentation created or updated

<!-- If any of the above need further details, you should include those here. -->
