### PR TITLE
style(site): alphabetize prop names

### DIFF
--- a/packages/site/src/components/ComponentDoc.js
+++ b/packages/site/src/components/ComponentDoc.js
@@ -30,13 +30,13 @@ type Example = {
 };
 
 type Props = {
+  behavior: MnrlReactNode,
   className?: string,
+  design: MnrlReactNode,
   doc: Object,
   examples?: Array<Example>,
-  slug: string,
-  behavior: MnrlReactNode,
-  design: MnrlReactNode,
   howToUse: string,
+  slug: string,
   title: string
 };
 


### PR DESCRIPTION
I missed a place where I needed to alphabetize prop order

### Description
Nothing really changed, I just forgot that my editor doesn't auto-save and I missed adding some changes from an earlier PR.

### Types of changes
- formatting change to some prop definitions

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Alt text here](https://media.giphy.com/media/xxxxxxxxx/giphy.gif)
