### PR TITLE
feat(site): move proptypes tables to top level of component page

### DIFF
--- a/packages/hello-world/src/HelloWorld.js
+++ b/packages/hello-world/src/HelloWorld.js
@@ -20,6 +20,7 @@ import Hello from '@mineral-ui/hello';
 import World from '@mineral-ui/world';
 
 type Props = {|
+  /** a classname for adding styles */
   className?: string
 |};
 

--- a/packages/hello/src/Hello.js
+++ b/packages/hello/src/Hello.js
@@ -19,7 +19,9 @@ import React from 'react';
 import { createStyledComponent } from '@mineral-ui/component-utils';
 
 type Props = {|
+  /** a classname for adding styles */
   className?: string,
+  /** how to say hello this time */
   text?: string
 |};
 

--- a/packages/site/src/components/ComponentDoc.js
+++ b/packages/site/src/components/ComponentDoc.js
@@ -20,6 +20,7 @@ import { createStyledComponent } from '@mineral-ui/component-utils';
 import ComponentDocExample from './ComponentDocExample';
 import Link from './Link';
 import styleReset from './styleReset';
+import PropTable from './PropTable';
 
 type Example = {
   component: MnrlReactComponent,
@@ -71,7 +72,6 @@ const styles = {
   h3: (props, theme) => ({
     margin: `${theme.measurement_d} 0 ${theme.measurement_c} 0`
   }),
-  h4: () => ({}),
   subnav: (props, theme) => ({
     borderBottom: `1px solid ${theme.color_gray}`,
     marginBottom: '2rem'
@@ -153,8 +153,7 @@ export default function ComponentDoc({
         <div>
           <H3>Behavior</H3>
           <p>{behavior}</p>
-          <H3>Props</H3>
-          <p>{"we'll move the prop table here"}</p>
+          {propDoc && renderPropDoc(propDoc)}
           {examples && renderExamples(examples, slug, propDoc)}
         </div>
         <H2 id="design">Design</H2>
@@ -183,4 +182,8 @@ function renderExamples(
       })}
     </div>
   );
+}
+
+function renderPropDoc(propDoc: Object) {
+  return [<H3 key={0}>Props</H3>, <PropTable key={1} propDoc={propDoc} />];
 }

--- a/packages/site/src/components/ComponentDocExample.js
+++ b/packages/site/src/components/ComponentDocExample.js
@@ -16,7 +16,6 @@
 
 /* @flow */
 import React, { Component } from 'react';
-// import PropList from './PropList';
 import { createStyledComponent } from '@mineral-ui/component-utils';
 import styleReset from './styleReset';
 
@@ -25,16 +24,15 @@ const styles = {
     ...styleReset(theme),
     '& + &': {
       borderTop: `1px solid ${theme.color_gray}`,
-      marginTop: theme.measurement_d,
-      paddingTop: theme.measurement_d
+      marginTop: theme.measurement_d
     }
   }),
   resizable: (props, theme) => ({
     border: `1px solid ${theme.color_gray}`,
     padding: theme.measurement_c
   }),
-  title: (props, theme) => ({
-    margin: `0 0 ${theme.measurement_b}`,
+  h4: (props, theme) => ({
+    margin: `${theme.measurement_d} 0 ${theme.measurement_c} 0`,
     fontSize: theme.font_size_b
   }),
   graf: (props, theme) => ({
@@ -54,7 +52,7 @@ const styles = {
 
 const Root = createStyledComponent('div', styles.componentDocExample);
 const Resizable = createStyledComponent('div', styles.resizable);
-const Title = createStyledComponent('h2', styles.title);
+const H4 = createStyledComponent('h4', styles.h4);
 const Graf = createStyledComponent('p', styles.graf);
 
 function getDefaultValue(propDescription: Object): any {
@@ -120,60 +118,23 @@ type Props = {
 
 export default class ComponentDocExample extends Component {
   props: Props;
-  state: {
-    exampleProps: Array<Object>
-  };
-
-  constructor(props: Props, context: Object) {
-    super(props, context);
-
-    this.state = {
-      exampleProps: getExampleProps(props.propDoc, props.propValues)
-    };
-    // $FlowFixMe
-    this.onPropChange = this.onPropChange.bind(this);
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.setState({
-      exampleProps: getExampleProps(nextProps.propDoc, nextProps.propValues)
-    });
-  }
 
   render() {
     const { className, component: Component, description, title } = this.props;
-    const componentProps = getComponentProps(this.state.exampleProps);
+    const componentProps = getComponentProps(
+      getExampleProps(this.props.propDoc, this.props.propValues)
+    );
 
     return (
       <Root className={className}>
-        <Title>{title}</Title>
+        <H4>{title}</H4>
         {typeof description === 'string'
           ? <Graf>{description}</Graf>
           : description}
         <Resizable>
           <Component {...componentProps} />
         </Resizable>
-        {/* <PropList
-          exampleProps={this.state.exampleProps}
-          onPropChange={this.onPropChange}
-        /> */}
       </Root>
     );
-  }
-
-  onPropChange(propDescription: Object, newValue: any) {
-    const propName = propDescription.name;
-    const exampleProps = this.state.exampleProps.map(propDescription => {
-      if (propDescription.name === propName) {
-        return {
-          ...propDescription,
-          exampleValue: newValue
-        };
-      }
-
-      return propDescription;
-    });
-
-    this.setState({ exampleProps });
   }
 }

--- a/packages/site/src/components/siteTheme.js
+++ b/packages/site/src/components/siteTheme.js
@@ -18,6 +18,7 @@
 export default {
   backgroundColor: '#fff',
   color_gray: '#d8d8d8',
+  color_grayMedium: '#929496',
   color_grayLight: '#f6f6f6',
   color_interactive: '#53bbd4',
   color_text: '#333',


### PR DESCRIPTION
<!--
NOTE: We’re just getting started. While we appreciate any feedback, we’re not yet ready to accept public contributions.

Thank you for your contribution! Here’s a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->

move proptypes tables to top level of component page

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->

the proptables used to be rendered per example, now they're only rendered once per component at the top of the page

connects #53 

### Screenshots or videos, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes beyond automated tests. -->

ran the demo

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->

- Other (provide details below)

refactor

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![hamburger](https://media.giphy.com/media/3o85xJx8kj5ryC9aEg/giphy.gif)


