### PR TITLE
[SITE] Add support for site routing on gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pack-ls": "lerna run pack-ls",
     "postbuild": "npm run flow:restart",
     "prebuild": "npm run clean && npm run bootstrap",
-    "predeploy": "npm run prerelease",
+    "predeploy:site": "npm run prerelease",
     "prerelease": "npm run build && npm run test",
     "release": "lerna publish --message='chore(publish): Publish'",
     "release:semantic": "npm run release -- --conventional-commits && npm run deploy:site",

--- a/packages/site/public/404.html
+++ b/packages/site/public/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width">
+    <title>Mineral UI</title>
+    <script>
+      window.sessionStorage.redirect = window.location.href;
+    </script>
+    <meta http-equiv="refresh" content="0;URL='/'"></meta>
+  </head>
+  <body>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  </body>
+</html>

--- a/packages/site/src/web/index.js
+++ b/packages/site/src/web/index.js
@@ -29,6 +29,13 @@ import demos from '{{DEMO_LIST_PATH}}';
 // Enable Glamor simulate helper
 simulations(true);
 
+// Github 404 page hack to support SPA hosting
+const { redirect } = window.sessionStorage;
+delete window.sessionStorage.redirect;
+if (redirect && redirect !== window.location.href) {
+  window.history.replaceState(null, '', redirect);
+}
+
 render(
   <BrowserRouter>
     <ThemeProvider>

--- a/utils/makeWebpackConfig.js
+++ b/utils/makeWebpackConfig.js
@@ -106,7 +106,9 @@ function getDevServer({ packagePath }) {
       compress: true,
       disableHostCheck: true,
       host: '0.0.0.0',
-      historyApiFallback: true
+      historyApiFallback: {
+        index: '/404.html'
+      }
     };
   }
 


### PR DESCRIPTION
### Description
Add support for site routing on gh-pages.  This should only be considered a temporary solution until we either prerender the site and/or switch to Netlify.

### Motivation and context

Our site package is currently deployed to Github pages as an SPA with client side routing.  With this naive approach, users must visit the root url and navigate using the in-app navigation alone.  They cannot navigate directly to a route, `components/button`, for example.  Github will give them a 404 page instead.  This PR introduces a hack that uses Github's support for a custom 404 page to capture the attempted URL, then redirect back to the root and use the saved url for routing the request.

closes #28 

### How has this been tested?

Verified locally - the 404 page is now used locally by webpack instead of just redirecting to /index.html.  While not fully necessary, and likely a tad slower, it allows us to validate the behavior locally.

I deployed the site and it is also working on mineral-ui.com.  You can try it too.  Click this link and if it takes you to the button docs, it worked.  http://mineral-ui.com/components/button

Tested cross browser.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

Is it a feature or a bug fix?  Not really sure.  I called it a bug fix.

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?
![hack](https://media.giphy.com/media/TOWeGr70V2R1K/giphy.gif)
