### PR TITLE
[component-utils]: Add generateId and resetId utils

### DIFF
--- a/packages/component-utils/src/__tests__/generateId.spec.js
+++ b/packages/component-utils/src/__tests__/generateId.spec.js
@@ -15,11 +15,24 @@
  */
 
 /* @flow */
-export { default as createStyledComponent } from './createStyledComponent';
-export { default as createThemedComponent } from './createThemedComponent';
-export { default as ThemeProvider } from './ThemeProvider';
+import { generateId, resetId } from '../index';
 
-export { default as mineralTheme } from './mineralTheme';
-export { default as styleVariables } from './styleVariables';
+describe('generateId', () => {
+  let id;
 
-export { generateId, resetId } from './generateId';
+  it('generates an id', () => {
+    id = generateId();
+    expect(id).toBe('1');
+  });
+
+  it('increments generated id', () => {
+    id = generateId();
+    expect(id).toBe('2');
+  });
+
+  it('resets generated id', () => {
+    resetId();
+    id = generateId();
+    expect(id).toBe('1');
+  });
+});

--- a/packages/component-utils/src/generateId.js
+++ b/packages/component-utils/src/generateId.js
@@ -15,11 +15,13 @@
  */
 
 /* @flow */
-export { default as createStyledComponent } from './createStyledComponent';
-export { default as createThemedComponent } from './createThemedComponent';
-export { default as ThemeProvider } from './ThemeProvider';
+let currentId = 0;
 
-export { default as mineralTheme } from './mineralTheme';
-export { default as styleVariables } from './styleVariables';
+export function generateId() {
+  currentId += 1;
+  return currentId.toString();
+}
 
-export { generateId, resetId } from './generateId';
+export function resetId() {
+  currentId = 0;
+}


### PR DESCRIPTION
### Description

 Add `generateId` and `resetId` utils

### Motivation and context

Extracted from icon development branch.  

Immediately useful for generating unique id's for component instances, which can be used for a variety of purposes.  The `Icon` component, for example, uses it to insert a unique `id` html attribute on a child `title` element that is then targeted by an `aria-labelledby` attribute on the parent `svg` tag.

It may also prove useful in the future when doing server side rendering and ids need to be kept in sync between client and server.

### How has this been tested?

* Works on the icon branch
* Automated tests added

### Types of changes

- New feature (non-breaking change which adds functionality)

Added new utils to component-utils

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “ - [n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [ ] Documentation created or updated

I did not document these utils as the package is currently documented a little strangely in the demo and in the readme.  We'll need to figure this out in a followup.

### How does this PR make you feel?

![boring](https://media.giphy.com/media/3o6Mbjr8YBdQqKJh04/giphy.gif)
