### PR TITLE
[Site]: Adjust editor styles to avoid page scrollbars

### DIFF
--- a/packages/site/src/web/index.html
+++ b/packages/site/src/web/index.html
@@ -10,6 +10,10 @@
       body {
         margin: 0;
       }
+      pre.prism-code {
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
### Description

Adjust editor styles to avoid undesired page scrollbars.

### Motivation and context

Allows the content of the editor pre tags to wrap, thus avoiding the problem entirely.

closes #184

### How has this been tested?

Manual cross browser testing.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?

![seriously?](https://media.giphy.com/media/l3q2SaisWTeZnV9wk/giphy.gif)
