### PR TITLE
Update polished to version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lodash.upperfirst": "4.3.1",
     "material-design-icons": "3.0.1",
     "mustache": "2.3.0",
-    "polished": "1.2.0",
+    "polished": "1.3.0",
     "prepend-file": "1.3.1",
     "prettier": "1.4.4",
     "pretty-bytes": "4.0.2",

--- a/packages/button/src/__tests__/__snapshots__/Button.spec.js.snap
+++ b/packages/button/src/__tests__/__snapshots__/Button.spec.js.snap
@@ -101,8 +101,8 @@ exports[`Button Button 1`] = `
   border: 0;
 }
 
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -275,7 +275,7 @@ exports[`Button Button 1`] = `
                     size="medium"
                   >
                     <span
-                      className="css-y37dx1"
+                      className="css-thf8bj"
                     >
                       Do Something
                     </span>
@@ -292,8 +292,8 @@ exports[`Button Button 1`] = `
 `;
 
 exports[`Button Danger 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -787,7 +787,7 @@ exports[`Button Danger 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -813,7 +813,7 @@ exports[`Button Danger 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -839,7 +839,7 @@ exports[`Button Danger 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -858,8 +858,8 @@ exports[`Button Danger 1`] = `
 `;
 
 exports[`Button Disabled 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -1342,7 +1342,7 @@ exports[`Button Disabled 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -1370,7 +1370,7 @@ exports[`Button Disabled 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -1398,7 +1398,7 @@ exports[`Button Disabled 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -1417,8 +1417,8 @@ exports[`Button Disabled 1`] = `
 `;
 
 exports[`Button Full Width 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -1695,7 +1695,7 @@ exports[`Button Full Width 1`] = `
                     size="medium"
                   >
                     <span
-                      className="css-y37dx1"
+                      className="css-thf8bj"
                     >
                       Do Something
                     </span>
@@ -1712,8 +1712,8 @@ exports[`Button Full Width 1`] = `
 `;
 
 exports[`Button Minimal 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -1988,7 +1988,7 @@ exports[`Button Minimal 1`] = `
                     size="medium"
                   >
                     <span
-                      className="css-y37dx1"
+                      className="css-thf8bj"
                     >
                       Do Something
                     </span>
@@ -2005,8 +2005,8 @@ exports[`Button Minimal 1`] = `
 `;
 
 exports[`Button Primary 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -2287,7 +2287,7 @@ exports[`Button Primary 1`] = `
                     size="medium"
                   >
                     <span
-                      className="css-y37dx1"
+                      className="css-thf8bj"
                     >
                       Do Something
                     </span>
@@ -2404,8 +2404,8 @@ exports[`Button Sizes 1`] = `
   border: 0;
 }
 
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -2520,8 +2520,8 @@ exports[`Button Sizes 1`] = `
   border: 0;
 }
 
-.css-hl6ge6,
-[data-css-hl6ge6] {
+.css-6poabx,
+[data-css-6poabx] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -2806,7 +2806,7 @@ exports[`Button Sizes 1`] = `
                         size="small"
                       >
                         <span
-                          className="css-hl6ge6"
+                          className="css-6poabx"
                         >
                           Small
                         </span>
@@ -2828,7 +2828,7 @@ exports[`Button Sizes 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Medium
                         </span>
@@ -2852,7 +2852,7 @@ exports[`Button Sizes 1`] = `
                         size="large"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Large
                         </span>
@@ -2971,8 +2971,8 @@ exports[`Button States 1`] = `
   border: 0;
 }
 
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -5009,7 +5009,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -5034,7 +5034,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -5059,7 +5059,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -5087,7 +5087,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -5115,7 +5115,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -5143,7 +5143,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -5171,7 +5171,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -5199,7 +5199,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -5227,7 +5227,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -5258,7 +5258,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -5289,7 +5289,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -5320,7 +5320,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -5351,7 +5351,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -5382,7 +5382,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -5413,7 +5413,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -5441,7 +5441,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -5469,7 +5469,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -5497,7 +5497,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -5525,7 +5525,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -5553,7 +5553,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -5581,7 +5581,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -5608,7 +5608,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -5634,7 +5634,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -5660,7 +5660,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -5689,7 +5689,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -5718,7 +5718,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -5747,7 +5747,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -5776,7 +5776,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -5805,7 +5805,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -5834,7 +5834,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -5866,7 +5866,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -5898,7 +5898,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -5930,7 +5930,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -5962,7 +5962,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -5994,7 +5994,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -6026,7 +6026,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -6055,7 +6055,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -6084,7 +6084,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -6113,7 +6113,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -6142,7 +6142,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -6171,7 +6171,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -6200,7 +6200,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -6227,7 +6227,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -6253,7 +6253,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -6279,7 +6279,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -6308,7 +6308,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -6337,7 +6337,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -6366,7 +6366,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -6395,7 +6395,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -6424,7 +6424,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -6453,7 +6453,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -6485,7 +6485,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -6517,7 +6517,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -6549,7 +6549,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -6581,7 +6581,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -6613,7 +6613,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -6645,7 +6645,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -6674,7 +6674,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -6703,7 +6703,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -6732,7 +6732,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -6761,7 +6761,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -6790,7 +6790,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -6819,7 +6819,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -6846,7 +6846,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -6872,7 +6872,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -6898,7 +6898,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -6927,7 +6927,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -6956,7 +6956,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -6985,7 +6985,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Hover
                         </span>
@@ -7014,7 +7014,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -7043,7 +7043,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -7072,7 +7072,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus
                         </span>
@@ -7104,7 +7104,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -7136,7 +7136,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -7168,7 +7168,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Hover
                         </span>
@@ -7200,7 +7200,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -7232,7 +7232,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -7264,7 +7264,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Focus & Active
                         </span>
@@ -7293,7 +7293,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -7322,7 +7322,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -7351,7 +7351,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Active
                         </span>
@@ -7380,7 +7380,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -7409,7 +7409,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -7438,7 +7438,7 @@ exports[`Button States 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Disabled
                         </span>
@@ -7459,8 +7459,8 @@ exports[`Button States 1`] = `
 `;
 
 exports[`Button Success 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -7954,7 +7954,7 @@ exports[`Button Success 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -7980,7 +7980,7 @@ exports[`Button Success 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -8006,7 +8006,7 @@ exports[`Button Success 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>
@@ -8125,8 +8125,8 @@ exports[`Button Truncation 1`] = `
   border: 0;
 }
 
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -8312,7 +8312,7 @@ exports[`Button Truncation 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Do Something
                         </span>
@@ -8331,8 +8331,8 @@ exports[`Button Truncation 1`] = `
 `;
 
 exports[`Button Warning 1`] = `
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -8826,7 +8826,7 @@ exports[`Button Warning 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Regular
                         </span>
@@ -8852,7 +8852,7 @@ exports[`Button Warning 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Primary
                         </span>
@@ -8878,7 +8878,7 @@ exports[`Button Warning 1`] = `
                         size="medium"
                       >
                         <span
-                          className="css-y37dx1"
+                          className="css-thf8bj"
                         >
                           Minimal
                         </span>

--- a/packages/card/src/__tests__/__snapshots__/Card.spec.js.snap
+++ b/packages/card/src/__tests__/__snapshots__/Card.spec.js.snap
@@ -164,8 +164,8 @@ exports[`Card Arbitrary children 1`] = `
   border: 0;
 }
 
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -384,7 +384,7 @@ exports[`Card Arbitrary children 1`] = `
                                   size="medium"
                                 >
                                   <span
-                                    className="css-y37dx1"
+                                    className="css-thf8bj"
                                   >
                                     Button
                                   </span>
@@ -566,8 +566,8 @@ exports[`Card Arbitrary children 2`] = `
   border: 0;
 }
 
-.css-y37dx1,
-[data-css-y37dx1] {
+.css-thf8bj,
+[data-css-thf8bj] {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
@@ -801,7 +801,7 @@ exports[`Card Arbitrary children 2`] = `
                                         size="medium"
                                       >
                                         <span
-                                          className="css-y37dx1"
+                                          className="css-thf8bj"
                                         >
                                           Button
                                         </span>


### PR DESCRIPTION
### Description

Update polished dependency to latest version

### Motivation and context

Our current version of polished uses traditional dashed css property names and causes some console warnings in the browser.  Everyone that reviews our components is distracted and thrown off by them.  The latest version of polished now uses camel cased names, which will eliminate the console warnings.

Closes #95

### How has this been tested?

* Verified locally in dev tools that no warnings appear in the browser console.
* Verified that polished functionality still works.
* Verified that polished is still excluded from bundles.

NOTE: I had to run jest with the `--no-cache` flag in order for it to pick up these changes locally.  CI caught the updates.  We likely need to address jest caching separately.  https://facebook.github.io/jest/docs/troubleshooting.html#caching-issues

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

Chore, I guess really - thanks greenkeeper

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “ - [n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]