### PR TITLE
[Site]: Use Icon component for GitHub icon

### DIFF
--- a/packages/site/src/components/ComponentDoc.js
+++ b/packages/site/src/components/ComponentDoc.js
@@ -17,6 +17,7 @@
 /* @flow */
 import React from 'react';
 import { createStyledComponent } from '@mineral-ui/component-utils';
+import Icon from '@mineral-ui/icon';
 import ComponentDocExample from './ComponentDocExample';
 import Link from './Link';
 import styleReset from './styleReset';
@@ -101,20 +102,13 @@ const H3 = createStyledComponent('h3', styles.h3);
 const SubNav = createStyledComponent('nav', styles.subnav);
 const NavElement = createStyledComponent(Link, styles.navElement);
 
-function GithubIcon() {
+function IconGithub() {
   return (
-    <svg
-      aria-hidden="true"
-      height="32"
-      version="1.1"
-      viewBox="0 0 16 16"
-      width="32">
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-      />
-    </svg>
+    <Icon size="32px" color="currentColor">
+      <svg viewBox="0 0 16 16">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+      </svg>
+    </Icon>
   );
 }
 
@@ -139,7 +133,7 @@ export default function ComponentDoc({
         <Link
           href={`https://github.com/mineral-ui/mineral-ui/tree/master/packages/${slug}`}
           aria-label="View on GitHub">
-          <GithubIcon />
+          <IconGithub />
         </Link>
         {description}
       </Header>


### PR DESCRIPTION
### Description

Use Icon component for GitHub icon

### Motivation and context

We should build the site using mineral components as they become available

### How has this been tested?

Verified locally.

### Types of changes

- Other (provide details below)

refactor

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “ - [n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?

![giphy-1](https://user-images.githubusercontent.com/202773/28473358-6cd756f8-6e01-11e7-9604-09e1d5932719.gif)

