### PR TITLE
[Build]: Add —-no-cache flag to jest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "flow": "flow",
     "flow:restart": "npm run flow -- stop; npm run flow",
     "format": "node ./scripts/format.js && eslint --fix .",
-    "jest": "jest",
+    "jest": "jest --no-cache",
     "lerna": "lerna",
     "link-parent-bin": "link-parent-bin -c packages",
     "lint": "npm run eslint",


### PR DESCRIPTION
### Description

Add `--no-cache` flag to `jest` script

### Motivation and context

I have been running into problems where jest will not detect changes and thus will not catch changes for snapshot tests, though CI has been catching them.

I am not 100% sure that this is not a local issue, but it seems a bit dangerous to leave as is, just in case.

Here is more background.
https://facebook.github.io/jest/docs/troubleshooting.html#caching-issues

Note that this likely slows down test runs though.

### How has this been tested?

* Locally, jest picks up changes properly with the `--no-cache` flag set, otherwise it does not.

### Types of changes

- Other (provide details below)

Update package scripts

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “ - [n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?

![simpsons](https://user-images.githubusercontent.com/202773/28474142-9f95abdc-6e04-11e7-9f38-4916a95d1bf8.gif)

