### PR TITLE
[build] Module resolution

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -52,7 +52,7 @@
           {
             "cwd": "babelrc",
             "alias": {
-              "^@mineral-ui/([^\/]+)(\/.*)?": "./packages/\\1/src\\2"
+              "^@mineral-ui\/([^\/]+)(\/dist\/es)?(\/.*)?": "./packages/\\1/src\\3"
             }
           }
         ]
@@ -69,7 +69,7 @@
           {
             "cwd": "babelrc",
             "alias": {
-              "^@mineral-ui/([^\/]+)(\/.*)?": "./packages/\\1/src\\2"
+              "^@mineral-ui\/([^\/]+)(\/dist\/es)?(\/.*)?": "./packages/\\1/src\\3"
             }
           }
         ]


### PR DESCRIPTION
### Description

Update babel module resolution mapping

### Motivation and context

* Allows importing components from `dist/es`. e.g.`import IconHelp from '@mineral-ui/icon/dist/es/lib/IconHelp'`
* Currently needed so that mineral components like TextField can import specific icons and not bundle ALL of them

connects #137

### How to test

1. npm test
2. npm run build
3. Try importing an Icon using the dist/es/lib pathing and then try build/start/test scripts.
4. There should be no errors

How I tested:

* Updated Icon import paths in Button demo and it still works
* `npm run build` works at project root and in button package
* `npm test` works at project root and in button package
* `npm start` in button package works
* Also tried in my text-input branch and verified that only the respective icons were bundled

### Types of changes

- Other (provide details below)

* build update - updates babel config

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Don't ask](https://media.giphy.com/media/yow6i0Zmp7G24/giphy.gif)
