### PR TITLE
Icon doc

### DIFF
--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -23,18 +23,20 @@ a generic Icon component to which you can provide your own SVG.
 
 ```jsx
 import React from 'react';
-import IconHelp from '@mineral-ui/icon/lib/IconHelp';
+import { IconFingerprint } from '@mineral-ui/icon'; // see note on treeshaking below
+import IconHelp from '@mineral-ui/icon/dist/es/lib/IconHelp';
 
 export default function MyComponent() {
   return (
     <div>
+      <IconFingerprint />
       <IconHelp />
     </div>
   );
 }
 ```
 
-> Note that in the example above, we suggest importing the icon directly from the lib folder rather than destructuring from the package index.  While destructuring from the index may work, caution must be taken that your module bundler tree-shaking is configured and working properly otherwise you could inadvertently import all of the icons and bloat your bundle size unnecessarily.
+> Note that in the example above, there are two ways to import icons, directly from lib, and by destructuring the index. If you choose to destructure, please ensure your module bundler is configured to tree-shake properly so that you don't accidentally import all the icons and bloat your bundle size. If you can't be bothered to do so, we recommend importing each icon you need directly from lib.
 
 ### Custom Icon
 
@@ -48,7 +50,7 @@ export default function MyComponent() {
       <Icon>
         <svg>
           <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-        </svg>      
+        </svg>
       </Icon>
     </div>
   );

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -23,26 +23,26 @@ a generic Icon component to which you can provide your own SVG.
 
 ```jsx
 import React from 'react';
-import { IconFingerprint } from '@mineral-ui/icon'; // see note on treeshaking below
 import IconHelp from '@mineral-ui/icon/dist/es/lib/IconHelp';
+import { IconFingerprint } from '@mineral-ui/icon'; // see note on treeshaking below
 
 export default function MyComponent() {
   return (
     <div>
-      <IconFingerprint />
       <IconHelp />
+      <IconFingerprint />
     </div>
   );
 }
 ```
 
-> Note that in the example above, there are two ways to import icons, directly from lib, and by destructuring the index. If you choose to destructure, please ensure your module bundler is configured to tree-shake properly so that you don't accidentally import all the icons and bloat your bundle size. If you can't be bothered to do so, we recommend importing each icon you need directly from lib.
+> Note that in the example above, there are two ways to import icons, directly from `icons/dist/es/lib`, and by destructuring the index. At the current time, we cannot recommend the destructured import because something about the way we are re-exporting in the index is preventing webpack from being able to treeshake properly and you will end up with all of the icons in your bundle. It's possible that you may be able to get this to work better using rollup, but if you are using webpack, we recommend importing the icons you need directly from `icon/dist/es/lib`.
 
 ### Custom Icon
 
 ```jsx
 import React from 'react';
-import Icon from '@mineral-ui/icon';
+import Icon from '@mineral-ui/icon/dist/es/Icon';
 
 export default function MyComponent() {
   return (


### PR DESCRIPTION
<!--
NOTE: We’re just getting started. While we appreciate any feedback, we’re not yet ready to accept public contributions.

Thank you for your contribution! Here’s a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
update icon README to describe how to use the mineral icon package

closes #214 

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->

The old instructions had the wrong import path for `Icon`s. The import path was to the index, which is no longer the recommended way of importing. We have to recommend people use the direct file path because the way we export our components breaks webpack's flaky tree shaking ability. If people import the wrong way, they're going to get all the icons in their bundle whether they're using them or not.

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->

docs

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated

<!-- If any of the above need further details, you should include those here. -->

