### PR TITLE
[Site]: Document passthrough props behavior

### DIFF
--- a/packages/component-utils/src/__demo__/index.js
+++ b/packages/component-utils/src/__demo__/index.js
@@ -25,6 +25,7 @@ export default {
       'Sample implementations of various methods of styling and style overrides.'
   },
   examples,
+  hidePropDoc: true,
   slug: 'component-utils',
   title: 'ComponentUtils'
 };

--- a/packages/site/src/components/ComponentDoc.js
+++ b/packages/site/src/components/ComponentDoc.js
@@ -39,6 +39,7 @@ type Props = {
   className?: string,
   design: MnrlReactNode,
   doc: Object,
+  hidePropDoc?: boolean,
   examples?: Array<Example>,
   slug: string,
   title: string
@@ -100,6 +101,9 @@ const styles = {
     paddingBottom: theme.spacing_single,
     borderBottom: '3px solid transparent',
     cursor: 'pointer'
+  }),
+  propsComment: () => ({
+    fontStyle: 'italic'
   })
 };
 
@@ -113,6 +117,7 @@ const H2 = createStyledComponent('h2', styles.h2);
 const H3 = createStyledComponent('h3', styles.h3);
 const SubNav = createStyledComponent('nav', styles.subnav);
 const NavElement = createStyledComponent(Link, styles.navElement);
+const PropsComment = createStyledComponent('p', styles.propsComment);
 
 function IconGithub() {
   return (
@@ -130,6 +135,7 @@ export default function ComponentDoc({
   design,
   doc,
   examples,
+  hidePropDoc,
   slug,
   title
 }: Props) {
@@ -160,7 +166,7 @@ export default function ComponentDoc({
       </SubNav>
       <div>
         <H2 id="code">Code & Examples</H2>
-        {renderPropDoc(propDoc)}
+        {renderPropDoc(propDoc, hidePropDoc)}
         {renderExamples(examples, slug, propDoc)}
         <H2 id="usage">Usage Guidelines</H2>
         <p>
@@ -180,26 +186,34 @@ function renderExamples(
   slug: string,
   propDoc: Object
 ) {
-  return (
-    examples && [
-      <H3 key={0}>
-        {examples.length === 1 ? 'Example' : 'Examples'}
-      </H3>,
-      examples.map((example, idx) => {
-        return (
+  if (examples) {
+    return (
+      <div>
+        <H3>
+          {examples.length === 1 ? 'Example' : 'Examples'}
+        </H3>
+        {examples.map((example, index) =>
           <ComponentDocExample
-            key={`${slug}:${idx}`}
+            key={`${slug}:${index}`}
             propDoc={propDoc}
             {...example}
           />
-        );
-      })
-    ]
-  );
+        )}
+      </div>
+    );
+  }
 }
 
-function renderPropDoc(propDoc: Object) {
-  return (
-    propDoc && [<H3 key={0}>Props</H3>, <PropTable key={1} propDoc={propDoc} />]
-  );
+function renderPropDoc(propDoc: Object, hidePropDoc?: boolean) {
+  if (!hidePropDoc) {
+    return (
+      <div>
+        <H3>Props</H3>
+        {propDoc && <PropTable propDoc={propDoc} />}
+        <PropsComment>
+          Undocumented properties will be applied to the root element.
+        </PropsComment>
+      </div>
+    );
+  }
 }

--- a/packages/site/src/components/__tests__/__snapshots__/App.spec.js.snap
+++ b/packages/site/src/components/__tests__/__snapshots__/App.spec.js.snap
@@ -837,6 +837,7 @@ exports[`App renders correctly 1`] = `
               "title": "Style override via createStyledComponent",
             },
           ],
+          "hidePropDoc": true,
           "slug": "component-utils",
           "title": "ComponentUtils",
         },


### PR DESCRIPTION
### Description

Add note about undocumented props underneath the props table

The props section will now appear regardless if there are props specified for a component.  For packages that are not components, there is now a flag to hide the prop doc, called `hidePropDoc`.  Also tweaked `renderExamples` to not render as an array as it is less readable than just using a wrapper div and I could find no specific layout/css reasons to avoid it.

### Motivation and context

This is important information that consumers will want/need to know.

closes #209 

### Screenshots or videos, if appropriate

<img width="494" alt="screen shot 2017-08-14 at 2 38 22 pm" src="https://user-images.githubusercontent.com/202773/29290704-565c9270-80fe-11e7-9b5b-347330708f3b.png">
<img width="526" alt="screen shot 2017-08-14 at 2 38 33 pm" src="https://user-images.githubusercontent.com/202773/29290705-565f39b2-80fe-11e7-8158-ea800e19883f.png">


### How to test

Try it out in the demo.

### Types of changes

- Other (provide details below)

Minor update to site

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “ - [n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - [n/a]