### PR TITLE
Update changelog generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
 <a name="0.1.0-alpha.0"></a>
 # 0.1.0-alpha.0 (2017-09-05)
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -65,8 +65,12 @@ exec('cp package.json _package.json');
 exec(`npm --no-git-tag-version version ${nextVersion}`);
 
 // Generate changelog
+const changelogConfigFile = path.resolve(
+  __dirname,
+  '../utils/changelogConfig.js'
+);
 exec(
-  'conventional-changelog --preset angular --infile CHANGELOG.md --same-file --append'
+  `conventional-changelog --preset angular --infile CHANGELOG.md --same-file --config ${changelogConfigFile}`
 );
 // Check if a changelog has been generated
 // Note: tmpfile used to get output from git status command

--- a/utils/changelogConfig.js
+++ b/utils/changelogConfig.js
@@ -1,0 +1,5 @@
+module.exports = {
+  gitRawCommitsOpts: {
+    from: 'e293ace5ce534fe5a57306eb737db57943aa99e4' // Since mineral-ui package created
+  }
+};


### PR DESCRIPTION
### Description

Update changelog generation
* Only include things from `mineral-ui` package, not previous `@mineral-ui` packages
* Remove changelog header, as it is more trouble than it is worth
* Don’t append entries. While that kept the header, it sorted commits in reverse

### Motivation and context

I created the changelog following recent commits and it still included all previous commits from the history of the repo, which is not what we want.  We only want to show entries since the creation of the `mineral-ui` package.

### How to test

1. `npm run release`
2. When prompted to publish, select **no**
3. View changelog - it should have new entries only
4. Revert local changes caused by release script.  "a git tag and 2 commits"


### Types of changes

- Other (provide details below)

build - update release script for changelog generation

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - [n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - [n/a]
