### PR TITLE
[popover] Adjust default modifiers for rendering improvements on small screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     }
   },
   "dependencies": {
+    "@mineral-ui/react-popper": "0.7.2-fix-popper-hide",
     "exenv": "1.2.2",
-    "immutability-helper": "2.3.1",
-    "react-popper": "0.7.2"
+    "immutability-helper": "2.3.1"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -19,7 +19,7 @@ import React, { PureComponent } from 'react';
 import { findDOMNode } from 'react-dom';
 import { canUseDOM } from 'exenv';
 import update from 'immutability-helper';
-import { Manager } from 'react-popper';
+import { Manager } from '@mineral-ui/react-popper';
 import { createStyledComponent } from '../utils';
 import PopoverTrigger from './PopoverTrigger';
 import PopoverContent from './PopoverContent';
@@ -96,12 +96,10 @@ export default class Popover extends PureComponent {
     hasArrow: true,
     modifiers: {
       flip: {
-        boundariesElement: 'viewport',
-        flipVariations: true
+        boundariesElement: 'viewport'
       },
       preventOverflow: {
-        boundariesElement: 'viewport',
-        escapeWithReference: true
+        boundariesElement: 'viewport'
       }
     },
     placement: 'bottom',

--- a/src/Popover/PopoverArrow.js
+++ b/src/Popover/PopoverArrow.js
@@ -16,7 +16,7 @@
 
 /* @flow */
 import React from 'react';
-import { Arrow } from 'react-popper';
+import { Arrow } from '@mineral-ui/react-popper';
 import { createStyledComponent } from '../utils';
 import { componentTheme as popoverContentComponentTheme } from './PopoverContent';
 

--- a/src/Popover/PopoverContent.js
+++ b/src/Popover/PopoverContent.js
@@ -16,7 +16,7 @@
 
 /* @flow */
 import React, { PureComponent } from 'react';
-import { Popper } from 'react-popper';
+import { Popper } from '@mineral-ui/react-popper';
 import { createStyledComponent, createThemedComponent } from '../utils';
 import { CardBlock, CardTitle } from '../Card';
 import PopoverArrow from './PopoverArrow';

--- a/src/Popover/PopoverTrigger.js
+++ b/src/Popover/PopoverTrigger.js
@@ -16,7 +16,7 @@
 
 /* @flow */
 import React, { Children, PureComponent } from 'react';
-import { Target } from 'react-popper';
+import { Target } from '@mineral-ui/react-popper';
 import { createStyledComponent } from '../utils';
 
 type Props = {

--- a/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -276,11 +276,9 @@ exports[`Popover demo examples basic 1`] = `
                 Object {
                   "flip": Object {
                     "boundariesElement": "viewport",
-                    "flipVariations": true,
                   },
                   "preventOverflow": Object {
                     "boundariesElement": "viewport",
-                    "escapeWithReference": true,
                   },
                 }
               }
@@ -818,11 +816,9 @@ exports[`Popover demo examples boundaries 1`] = `
                               Object {
                                 "flip": Object {
                                   "boundariesElement": "scrollParent",
-                                  "flipVariations": true,
                                 },
                                 "preventOverflow": Object {
                                   "boundariesElement": "scrollParent",
-                                  "escapeWithReference": true,
                                 },
                               }
                             }
@@ -896,11 +892,9 @@ exports[`Popover demo examples boundaries 1`] = `
                                       Object {
                                         "flip": Object {
                                           "boundariesElement": "scrollParent",
-                                          "flipVariations": true,
                                         },
                                         "preventOverflow": Object {
                                           "boundariesElement": "scrollParent",
-                                          "escapeWithReference": true,
                                         },
                                       }
                                     }
@@ -911,11 +905,9 @@ exports[`Popover demo examples boundaries 1`] = `
                                         Object {
                                           "flip": Object {
                                             "boundariesElement": "scrollParent",
-                                            "flipVariations": true,
                                           },
                                           "preventOverflow": Object {
                                             "boundariesElement": "scrollParent",
-                                            "escapeWithReference": true,
                                           },
                                         }
                                       }
@@ -930,11 +922,9 @@ exports[`Popover demo examples boundaries 1`] = `
                                           Object {
                                             "flip": Object {
                                               "boundariesElement": "scrollParent",
-                                              "flipVariations": true,
                                             },
                                             "preventOverflow": Object {
                                               "boundariesElement": "scrollParent",
-                                              "escapeWithReference": true,
                                             },
                                           }
                                         }
@@ -1561,11 +1551,9 @@ exports[`Popover demo examples controlled 1`] = `
                       Object {
                         "flip": Object {
                           "boundariesElement": "scrollParent",
-                          "flipVariations": true,
                         },
                         "preventOverflow": Object {
                           "boundariesElement": "scrollParent",
-                          "escapeWithReference": true,
                         },
                       }
                     }
@@ -1945,11 +1933,9 @@ exports[`Popover demo examples disabled 1`] = `
                 Object {
                   "flip": Object {
                     "boundariesElement": "scrollParent",
-                    "flipVariations": true,
                   },
                   "preventOverflow": Object {
                     "boundariesElement": "scrollParent",
-                    "escapeWithReference": true,
                   },
                 }
               }
@@ -2345,11 +2331,9 @@ exports[`Popover demo examples focus 1`] = `
                     Object {
                       "flip": Object {
                         "boundariesElement": "scrollParent",
-                        "flipVariations": true,
                       },
                       "preventOverflow": Object {
                         "boundariesElement": "scrollParent",
-                        "escapeWithReference": true,
                       },
                     }
                   }
@@ -2426,11 +2410,9 @@ exports[`Popover demo examples focus 1`] = `
                     Object {
                       "flip": Object {
                         "boundariesElement": "scrollParent",
-                        "flipVariations": true,
                       },
                       "preventOverflow": Object {
                         "boundariesElement": "scrollParent",
-                        "escapeWithReference": true,
                       },
                     }
                   }
@@ -2507,11 +2489,9 @@ exports[`Popover demo examples focus 1`] = `
                     Object {
                       "flip": Object {
                         "boundariesElement": "scrollParent",
-                        "flipVariations": true,
                       },
                       "preventOverflow": Object {
                         "boundariesElement": "scrollParent",
-                        "escapeWithReference": true,
                       },
                     }
                   }
@@ -2588,11 +2568,9 @@ exports[`Popover demo examples focus 1`] = `
                     Object {
                       "flip": Object {
                         "boundariesElement": "scrollParent",
-                        "flipVariations": true,
                       },
                       "preventOverflow": Object {
                         "boundariesElement": "scrollParent",
-                        "escapeWithReference": true,
                       },
                     }
                   }
@@ -3006,11 +2984,9 @@ exports[`Popover demo examples overflow 1`] = `
                       Object {
                         "flip": Object {
                           "boundariesElement": "viewport",
-                          "flipVariations": true,
                         },
                         "preventOverflow": Object {
                           "boundariesElement": "viewport",
-                          "escapeWithReference": true,
                         },
                       }
                     }
@@ -3088,11 +3064,9 @@ exports[`Popover demo examples overflow 1`] = `
                               Object {
                                 "flip": Object {
                                   "boundariesElement": "viewport",
-                                  "flipVariations": true,
                                 },
                                 "preventOverflow": Object {
                                   "boundariesElement": "viewport",
-                                  "escapeWithReference": true,
                                 },
                               }
                             }
@@ -3103,11 +3077,9 @@ exports[`Popover demo examples overflow 1`] = `
                                 Object {
                                   "flip": Object {
                                     "boundariesElement": "viewport",
-                                    "flipVariations": true,
                                   },
                                   "preventOverflow": Object {
                                     "boundariesElement": "viewport",
-                                    "escapeWithReference": true,
                                   },
                                 }
                               }
@@ -3122,11 +3094,9 @@ exports[`Popover demo examples overflow 1`] = `
                                   Object {
                                     "flip": Object {
                                       "boundariesElement": "viewport",
-                                      "flipVariations": true,
                                     },
                                     "preventOverflow": Object {
                                       "boundariesElement": "viewport",
-                                      "escapeWithReference": true,
                                     },
                                   }
                                 }
@@ -3684,11 +3654,9 @@ exports[`Popover demo examples placement 1`] = `
                       Object {
                         "flip": Object {
                           "boundariesElement": "viewport",
-                          "flipVariations": true,
                         },
                         "preventOverflow": Object {
                           "boundariesElement": "viewport",
-                          "escapeWithReference": true,
                         },
                       }
                     }
@@ -3767,11 +3735,9 @@ exports[`Popover demo examples placement 1`] = `
                               Object {
                                 "flip": Object {
                                   "boundariesElement": "viewport",
-                                  "flipVariations": true,
                                 },
                                 "preventOverflow": Object {
                                   "boundariesElement": "viewport",
-                                  "escapeWithReference": true,
                                 },
                               }
                             }
@@ -3782,11 +3748,9 @@ exports[`Popover demo examples placement 1`] = `
                                 Object {
                                   "flip": Object {
                                     "boundariesElement": "viewport",
-                                    "flipVariations": true,
                                   },
                                   "preventOverflow": Object {
                                     "boundariesElement": "viewport",
-                                    "escapeWithReference": true,
                                   },
                                 }
                               }
@@ -3801,11 +3765,9 @@ exports[`Popover demo examples placement 1`] = `
                                   Object {
                                     "flip": Object {
                                       "boundariesElement": "viewport",
-                                      "flipVariations": true,
                                     },
                                     "preventOverflow": Object {
                                       "boundariesElement": "viewport",
-                                      "escapeWithReference": true,
                                     },
                                   }
                                 }
@@ -4390,11 +4352,9 @@ exports[`Popover demo examples title 1`] = `
                       Object {
                         "flip": Object {
                           "boundariesElement": "viewport",
-                          "flipVariations": true,
                         },
                         "preventOverflow": Object {
                           "boundariesElement": "viewport",
-                          "escapeWithReference": true,
                         },
                       }
                     }
@@ -4474,11 +4434,9 @@ exports[`Popover demo examples title 1`] = `
                               Object {
                                 "flip": Object {
                                   "boundariesElement": "viewport",
-                                  "flipVariations": true,
                                 },
                                 "preventOverflow": Object {
                                   "boundariesElement": "viewport",
-                                  "escapeWithReference": true,
                                 },
                               }
                             }
@@ -4491,11 +4449,9 @@ exports[`Popover demo examples title 1`] = `
                                 Object {
                                   "flip": Object {
                                     "boundariesElement": "viewport",
-                                    "flipVariations": true,
                                   },
                                   "preventOverflow": Object {
                                     "boundariesElement": "viewport",
-                                    "escapeWithReference": true,
                                   },
                                 }
                               }
@@ -4510,11 +4466,9 @@ exports[`Popover demo examples title 1`] = `
                                   Object {
                                     "flip": Object {
                                       "boundariesElement": "viewport",
-                                      "flipVariations": true,
                                     },
                                     "preventOverflow": Object {
                                       "boundariesElement": "viewport",
-                                      "escapeWithReference": true,
                                     },
                                   }
                                 }


### PR DESCRIPTION
### Description

Adjust default modifiers for rendering improvements on small screens
* Uses @mineral-ui/react-popper fork until issue resolved
* Still does not flip on viewport as expected/desired

### Motivation and context

Improve rendered popover placement on small screens

### How to test

* Ensure basically works like before.
* Open browser devtools and switch to mobile mode.
* Open the first popover example and see that it now renders in the page, rather than off the page

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - [n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [ ] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - [n/a]

