### PR TITLE
[Site] make the propDoc optional

### DIFF
--- a/src/website/app/pages/ComponentDoc/DocProps.js
+++ b/src/website/app/pages/ComponentDoc/DocProps.js
@@ -22,7 +22,7 @@ import PropTable from '../../PropTable';
 import Section from '../../Section';
 
 type Props = {|
-  propDoc: Object,
+  propDoc?: Object,
   title: string
 |};
 


### PR DESCRIPTION
### Description
some components like CardBlock don't have props of their own, and the propDocs are not generated by react-docgen. This would cause a warning in the browser console. This fix makes the prop optional.

### Motivation and context
This fix makes flowtypes consistent with documentation behavior.

### How to test

1. Navigate to `/components/card-block` in dev mode.
2. There should be no warning in the console.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) [n/a]
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Alt text here](https://media.giphy.com/media/ID4NXWnwuLnLq/giphy.gif)
