### PR TITLE
[Website] Display markdown typography according to spec

### DIFF
--- a/src/website/app/Heading.js
+++ b/src/website/app/Heading.js
@@ -31,6 +31,12 @@ type Props = {
 };
 
 const componentTheme = baseTheme => ({
+  Heading_color_1: baseTheme.color_text,
+  Heading_color_2: baseTheme.color_gray_80,
+  Heading_color_3: baseTheme.color_text,
+  Heading_color_4: baseTheme.color_text,
+  Heading_color_5: baseTheme.color_text,
+  Heading_color_6: baseTheme.color_gray_80,
   Heading_fontSize_1: baseTheme.fontSize_h1,
   Heading_fontSize_2: baseTheme.fontSize_h2,
   Heading_fontSize_3: baseTheme.fontSize_h3,
@@ -57,6 +63,7 @@ const headingStyles = ({ level, theme: baseTheme }) => {
   let theme = componentTheme(baseTheme);
 
   return {
+    color: theme[`Heading_color_${level}`],
     fontSize: theme[`Heading_fontSize_${level}`],
     fontWeight: theme[`Heading_fontWeight_${level}`],
     margin: `${theme[`Heading_marginMultiplier_${level}`] *

--- a/src/website/app/Markdown.js
+++ b/src/website/app/Markdown.js
@@ -19,6 +19,7 @@ import React, { createElement } from 'react';
 import marksy from 'marksy/components';
 import { createStyledComponent } from '../../utils';
 import Heading from './Heading';
+import Paragraph from './Paragraph';
 import Link from './Link';
 import prism from './utils/prism';
 
@@ -188,6 +189,13 @@ export default function Markdown({ children, className, scope }: Props) {
       },
       h6({ id, children }) {
         return replaceHeading(6, children, { id });
+      },
+      p({ children }) {
+        return (
+          <Paragraph variant="prose">
+            {children}
+          </Paragraph>
+        );
       }
     },
     components: {

--- a/src/website/app/Paragraph.js
+++ b/src/website/app/Paragraph.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import { createStyledComponent } from '../../utils';
+
+type Props = {
+  /* rendered chilren */
+  children: MnrlReactNode,
+  /* available font variants */
+  variant?: 'ui' | 'prose' | 'mouse'
+};
+
+const componentTheme = baseTheme => ({
+  Paragraph_color: baseTheme.color_text,
+  Paragraph_fontSize_mouse: baseTheme.fontSize_mouse,
+  Paragraph_fontSize_prose: baseTheme.fontSize_prose,
+  Paragraph_fontSize_ui: baseTheme.fontSize_ui,
+
+  Paragraph_lineHeight_normal: baseTheme.lineHeight,
+  Paragraph_lineHeight_prose: baseTheme.lineHeight_prose,
+
+  ...baseTheme
+});
+
+const Root = createStyledComponent('p', ({ variant, theme: baseTheme }) => {
+  let theme = componentTheme(baseTheme);
+
+  return {
+    color: theme.Paragraph_color,
+    fontSize: theme[`Paragraph_fontSize_${variant}`],
+    lineHeight:
+      variant === 'prose'
+        ? theme.Paragraph_lineHeight_prose
+        : theme.Paragraph_lineHeight_normal
+  };
+});
+
+export default function Paragraph({
+  children,
+  variant = 'ui',
+  ...restProps
+}: Props) {
+  return (
+    <Root variant={variant} {...restProps}>
+      {children}
+    </Root>
+  );
+}

--- a/src/website/index.html
+++ b/src/website/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i,800,800i&subset=cyrillic,greek" rel="stylesheet">
     <title>Mineral UI</title>
   </head>
   <body>


### PR DESCRIPTION
### Description
Added proper shades of gray to Heading component and create a Paragraph element per the design spec.

Also add Cyrillic and Greek glyph support to Open Sans, since the site needs it in a couple of places.

### Motivation and context
We need visual consistency when comparing our Guidelines pages, and only #328 had the typography updates. This PR pulls those changes out so that there are fewer facets to think about when discussing hierarchy on the content pages.

### How to test

1. `cd mineral-ui && npm start`
2. Navigate to Guidelines > Theming
3. see that the h1 is "Mineral black" instead of `#000`, and the h2 is gray.
4. Markdown-generated body copy is now the `prose` font style.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
![Alt text here](https://media.giphy.com/media/WMPQ6NTg9X8Zy/giphy.gif)
