### PR TITLE
[Site] Force new routed navigations to scroll to top

### DIFF
--- a/src/website/app/App.js
+++ b/src/website/app/App.js
@@ -15,7 +15,9 @@
  */
 
 /* @flow */
-import React from 'react';
+import React, { Component } from 'react';
+import { withRouter } from 'react-router';
+import { canUseDOM } from 'exenv';
 import { createStyledComponent } from '../../utils';
 import ComponentDoc from './pages/ComponentDoc';
 import createKeyMap from './utils/createKeyMap';
@@ -24,8 +26,10 @@ import _Nav from './Nav';
 import Router from './Router';
 
 type Props = {|
+  children?: any,
   className?: string,
-  demos: Object | Array<Object>
+  demos: Object | Array<Object>,
+  location?: any
 |};
 
 const styles = {
@@ -64,22 +68,38 @@ const Root = createStyledComponent('div', styles.app, {
 const Nav = createStyledComponent(_Nav, styles.nav);
 const Main = createStyledComponent('main', styles.main);
 
-export default function App({ className, demos }: Props) {
-  if (!Array.isArray(demos) && demos.slug) {
-    return <ComponentDoc {...demos} />;
+class App extends Component {
+  props: Props;
+
+  componentDidUpdate(prevProps) {
+    if (canUseDOM && this.props.location !== prevProps.location) {
+      global.window.scrollTo(0, 0);
+    }
   }
 
-  const siteDemos = Array.isArray(demos) ? createKeyMap(demos, 'slug') : demos;
+  render() {
+    const { className, demos } = this.props;
 
-  return (
-    <div>
-      <Root className={className}>
-        <Nav demos={siteDemos} />
-        <Main>
-          <Router demos={siteDemos} />
-          <Footer />
-        </Main>
-      </Root>
-    </div>
-  );
+    if (!Array.isArray(demos) && demos.slug) {
+      return <ComponentDoc {...demos} />;
+    }
+
+    const siteDemos = Array.isArray(demos)
+      ? createKeyMap(demos, 'slug')
+      : demos;
+
+    return (
+      <div>
+        <Root className={className}>
+          <Nav demos={siteDemos} />
+          <Main>
+            <Router demos={siteDemos} />
+            <Footer />
+          </Main>
+        </Root>
+      </div>
+    );
+  }
 }
+
+export default withRouter(App);


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
Wrap the app in a `ScrollToTop` component (code from [react-router's site](https://reacttraining.com/react-router/web/guides/scroll-restoration)) that does exactly what it says on the tin.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Navigating to a new page in our site would, frustratingly, remember your scroll position rather than scrolling to the top automatically, as everyone expects. This fixes that.

### Demo
<!-- To record and share a video: http://recordit.co/ -->

http://router-scrolling--mineral-ui.netlify.com/getting-started

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. Open the site
2. Scroll down a bit and note what is visible
3. Navigate to another page
4. Confirm that the new page is automatically scrolled to the top
5. Hit the back button
6. Confirm that your scroll position was remembered for the previous page

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Docs

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) **See note**
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->
In Edge & IE 11, the scroll position is not remembered when going back; it auto-scrolls to the top. This is a regression from normal behavior (though arguably better than our site's current behavior), based on some testing on outside websites.

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Pleased or satisfied](https://media.giphy.com/media/l0MYNOMQOTn9JKc5q/giphy.gif)
