### PR TITLE
[Website] Improve styles of LiveEditor errors for readability

### DIFF
--- a/src/website/app/ComponentDocExample.js
+++ b/src/website/app/ComponentDocExample.js
@@ -57,7 +57,25 @@ const styles = {
   liveEditor: ({ theme }) => ({
     fontSize: theme.fontSize_ui,
     maxHeight: `${parseFloat(theme.spacing_quad) * 10}em`,
-    overflow: 'auto'
+    overflow: 'auto',
+
+    '& + .react-live-error': {
+      backgroundColor: '#fce3e3', // color.red_10
+      color: theme.color_text_danger,
+      fontFamily: theme.fontFamily_monospace,
+      fontSize: theme.fontSize_mouse,
+      lineHeight: theme.lineHeight_prose,
+      padding: theme.spacing_single,
+      whiteSpace: 'pre',
+
+      '&:first-line': {
+        fontFamily: theme.fontFamily,
+        fontWeight: theme.fontWeight_semiBold,
+        // Can't use margin/padding here, so this is to space off the heading
+        // from the code
+        lineHeight: 2 * theme.lineHeight_prose
+      }
+    }
   }),
   title: ({ theme }) => ({
     margin: `${parseFloat(theme.spacing_single) * 8}em 0 ${theme.spacing_quad}`


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
Improve the styles of the errors that appear below the LiveEditor, for readability.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Just look at the before/after, below:

### Screenshots or videos, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

http://improve-live-editor-error-styles--mineral-ui.netlify.com/

**Before**
![screen shot 2017-09-29 at 2 06 44 pm](https://user-images.githubusercontent.com/486540/31034006-76659608-a51f-11e7-8fe9-30f24941001e.png)

**After**
![screen shot 2017-09-29 at 2 06 17 pm](https://user-images.githubusercontent.com/486540/31034008-7b8932d4-a51f-11e7-8cf4-7a3ff048eb20.png)

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. Open the site and navigate to a [component page](http://improve-live-editor-error-styles--mineral-ui.netlify.com/components/button)
2. Edit one of the examples such that you get an error
3. Confirm that it's _so_ much more readable and useful and nice now

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Docs

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![I am error](https://media.giphy.com/media/f0BaErqmljUd2/giphy.gif)
