### PR TITLE
[Webite] Filter out @Private props from PropTable

### DIFF
--- a/src/website/app/PropTable.js
+++ b/src/website/app/PropTable.js
@@ -98,6 +98,11 @@ function getPropTableRows(propDoc) {
   return Object.keys(propDoc).sort().map(name => {
     const propDescription = propDoc[name];
 
+    // Filter out private props
+    if (propDescription.description.startsWith('@Private')) {
+      return null;
+    }
+
     return (
       <PropTableRow
         key={name}

--- a/src/website/app/demos/Menu/index.js
+++ b/src/website/app/demos/Menu/index.js
@@ -28,9 +28,6 @@ const menuDividerDoc = require('!!react-docgen-loader!../../../../Menu/MenuDivid
 const menuGroupDoc = require('!!react-docgen-loader!../../../../Menu/MenuGroup');
 const menuItemDoc = require('!!react-docgen-loader!../../../../Menu/MenuItem');
 
-// Removing @Private props from the doc
-menuDoc && menuDoc.props && delete menuDoc.props.getItemProps;
-
 export default [
   {
     doc: menuDoc,

--- a/src/website/app/demos/Popover/index.js
+++ b/src/website/app/demos/Popover/index.js
@@ -21,10 +21,6 @@ import examples from './examples';
 
 const doc = require('!!react-docgen-loader!../../../../Popover/Popover');
 
-// Removing @Private props from the doc
-doc && doc.props && delete doc.props.trigger;
-doc && doc.props && delete doc.props.triggerRef;
-
 export default {
   bestPractices,
   componentTheme,


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
Adds an early return to `PropTable`’s `getPropTableRows` function that filters out any prop with a description that starts with "`@Private`".

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Every once in a while, we need to pass a prop around between components that we don’t want to draw attention to by including in our prop table. We currently do this by simply deleting the prop from the `propDoc` object before passing it to `ComponentDoc`. This change makes it a more natural and less manual process.

### Screenshots or videos, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

http://hide-private-props--mineral-ui.netlify.com/components/menu#api-and-theme

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. Open the site and navigate to [Menu](http://hide-private-props--mineral-ui.netlify.com/components/menu#api-and-theme)
2. Confirm that `getItemProps` (Menu’s only private prop as of this writing) does not display in the prop table
3. Navigate to Popover and confirm that `trigger` and `triggerRef` are also hidden

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Docs

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Hiding kitten](https://media.giphy.com/media/dxqOkrl29R8ac/giphy.gif)
