### PR TITLE
[Site] Add routed page for each demo example

### DIFF
--- a/src/website/app/App.js
+++ b/src/website/app/App.js
@@ -17,6 +17,7 @@
 /* @flow */
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { canUseDOM } from 'exenv';
 import { createStyledComponent } from '../../utils';
 import ComponentDoc from './pages/ComponentDoc';
@@ -90,13 +91,28 @@ class App extends Component {
 
     return (
       <div>
-        <Root className={className}>
-          <Nav demos={siteDemos} />
-          <Main>
-            <Router demos={siteDemos} />
-            <Footer />
-          </Main>
-        </Root>
+        <Switch>
+          <Route
+            exact
+            strict
+            path="/:url*"
+            render={props => <Redirect to={`${props.location.pathname}/`} />}
+          />
+          <Route
+            render={route => {
+              const isChromeless = route.location.search === '?chromeless';
+              return isChromeless
+                ? <Router demos={siteDemos} />
+                : <Root className={className}>
+                    <Nav demos={siteDemos} />
+                    <Main>
+                      <Router demos={siteDemos} />
+                      <Footer />
+                    </Main>
+                  </Root>;
+            }}
+          />
+        </Switch>
       </div>
     );
   }

--- a/src/website/app/ComponentDocExample.js
+++ b/src/website/app/ComponentDocExample.js
@@ -15,12 +15,12 @@
  */
 
 /* @flow */
-import React, { Component } from 'react';
-import dedent from 'dedent';
-import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
-import { createStyledComponent } from '../../utils';
+import React from 'react';
+import { createStyledComponent, getNormalizedValue } from '../../utils';
 import Callout from './Callout';
 import Heading from './Heading';
+import Link from './Link';
+import LiveProvider from './LiveProvider';
 import Markdown from './Markdown';
 
 type Props = {
@@ -35,92 +35,60 @@ type Props = {
 };
 
 const styles = {
-  anchor: ({ theme }) => ({
-    color: theme.color_caption,
-    fontWeight: theme.fontWeight_semiBold,
-    visibility: 'hidden'
-  }),
   componentDocExample: ({ theme }) => ({
+    paddingBottom: `${parseFloat(theme.spacing_single) * 8}em`,
+
     '& + &': {
-      borderTop: `1px solid ${theme.borderColor}`,
-      marginTop: theme.spacing_quad
+      borderTop: `1px solid ${theme.borderColor}`
     }
   }),
   description: ({ theme }) => ({
     margin: `0 0 ${theme.spacing_quad}`
   }),
-  livePreview: ({ backgroundColor, theme }) => ({
-    backgroundColor,
-    border: `1px solid ${theme.borderColor}`,
-    padding: theme.spacing_double
-  }),
-  liveEditor: ({ theme }) => ({
-    fontSize: theme.fontSize_ui,
-    maxHeight: `${parseFloat(theme.spacing_quad) * 10}em`,
-    overflow: 'auto',
-
-    '& + .react-live-error': {
-      backgroundColor: '#fce3e3', // color.red_10
-      color: theme.color_text_danger,
-      fontFamily: theme.fontFamily_monospace,
-      fontSize: theme.fontSize_mouse,
-      lineHeight: theme.lineHeight_prose,
-      padding: theme.spacing_single,
-      whiteSpace: 'pre',
-
-      '&:first-line': {
-        fontFamily: theme.fontFamily,
-        fontWeight: theme.fontWeight_semiBold,
-        // Can't use margin/padding here, so this is to space off the heading
-        // from the code
-        lineHeight: 2 * theme.lineHeight_prose
-      }
-    }
-  }),
   title: ({ theme }) => ({
-    margin: `${parseFloat(theme.spacing_single) * 8}em 0 ${theme.spacing_quad}`
+    margin: `0 0 ${getNormalizedValue(theme.spacing_quad, theme.fontSize_h3)}`,
+    paddingTop: `${parseFloat(
+      getNormalizedValue(theme.spacing_single, theme.fontSize_h3)
+    ) * 8}em`
+  }),
+  titleLink: ({ theme }) => ({
+    color: theme.color_gray_80 // h2
   })
 };
 
 const Root = createStyledComponent('div', styles.componentDocExample);
 const Description = createStyledComponent(Markdown, styles.description);
-const MyLivePreview = createStyledComponent(LivePreview, styles.livePreview, {
-  rootEl: 'div'
-});
-const MyLiveEditor = createStyledComponent(LiveEditor, styles.liveEditor);
 const Title = createStyledComponent(Heading, styles.title);
+const TitleLink = createStyledComponent(Link, styles.titleLink);
 
-export default class ComponentDocExample extends Component {
-  props: Props;
+export default function ComponentDocExample({
+  backgroundColor,
+  className,
+  description,
+  hideSource,
+  id,
+  scope,
+  source,
+  title
+}: Props) {
+  const liveProviderProps = {
+    backgroundColor,
+    hideSource,
+    scope,
+    source
+  };
 
-  render() {
-    const {
-      backgroundColor,
-      className,
-      description,
-      hideSource,
-      id,
-      scope,
-      source,
-      title
-    } = this.props;
-
-    return (
-      <Root className={className} id={id}>
-        <Title level={3} id={id}>
+  return (
+    <Root className={className}>
+      <Title level={3} id={id}>
+        <TitleLink to={id}>
           {title}
-        </Title>
-        <Description scope={{ Callout }}>
-          {description || ''}
-        </Description>
-        <LiveProvider
-          code={dedent(source)}
-          scope={scope}
-          mountStylesheet={false}>
-          <MyLivePreview backgroundColor={backgroundColor} />
-          {!hideSource && [<MyLiveEditor key={0} />, <LiveError key={1} />]}
-        </LiveProvider>
-      </Root>
-    );
-  }
+        </TitleLink>
+      </Title>
+      <Description scope={{ Callout }}>
+        {description || ''}
+      </Description>
+      <LiveProvider {...liveProviderProps} />
+    </Root>
+  );
 }

--- a/src/website/app/LiveProvider.js
+++ b/src/website/app/LiveProvider.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import dedent from 'dedent';
+import {
+  LiveProvider as ReactLiveProvider,
+  LiveEditor,
+  LiveError,
+  LivePreview
+} from 'react-live';
+import { createStyledComponent } from '../../utils';
+
+type Props = {
+  backgroundColor?: string,
+  hideSource?: boolean,
+  chromeless?: boolean,
+  scope: Object,
+  source: string
+};
+
+const styles = {
+  livePreview: ({ backgroundColor, chromeless, theme }) => {
+    return chromeless
+      ? { padding: '1rem' }
+      : {
+          backgroundColor,
+          border: `1px solid ${theme.borderColor}`,
+          padding: theme.spacing_double
+        };
+  },
+  liveEditor: ({ theme }) => ({
+    fontSize: theme.fontSize_ui,
+    maxHeight: `${parseFloat(theme.spacing_quad) * 10}em`,
+    overflow: 'auto'
+  })
+};
+
+const MyLivePreview = createStyledComponent(LivePreview, styles.livePreview, {
+  rootEl: 'div'
+});
+const MyLiveEditor = createStyledComponent(LiveEditor, styles.liveEditor);
+
+export default function LiveProvider({
+  backgroundColor,
+  hideSource,
+  chromeless,
+  scope,
+  source
+}: Props) {
+  return (
+    <ReactLiveProvider
+      code={dedent(source)}
+      scope={scope}
+      mountStylesheet={false}>
+      <MyLivePreview
+        backgroundColor={backgroundColor}
+        chromeless={chromeless}
+      />
+      {!hideSource && [<MyLiveEditor key={0} />, <LiveError key={1} />]}
+    </ReactLiveProvider>
+  );
+}

--- a/src/website/app/Router.js
+++ b/src/website/app/Router.js
@@ -17,7 +17,11 @@
 /* @flow */
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
+import IconArrowBack from '../../Icon/IconArrowBack';
 import ComponentDoc from './pages/ComponentDoc';
+import ComponentDocExample from './ComponentDocExample';
+import Link from './Link';
+import LiveProvider from './LiveProvider';
 import pages from './pages';
 
 type Props = {|
@@ -53,6 +57,31 @@ export default function Router({ demos }: Props) {
   return (
     <Switch>
       {routes}
+      <Route
+        path="/components/:componentId/:exampleId"
+        render={route => {
+          const { componentId, exampleId } = route.match.params;
+          const selectedDemo = demos[componentId];
+          const selectedExample = selectedDemo.examples.filter(
+            example => example.id === exampleId
+          )[0];
+          const chromeless = route.location.search === '?chromeless';
+          return chromeless
+            ? <LiveProvider
+                hideSource={true}
+                chromeless={true}
+                scope={selectedExample.scope}
+                source={selectedExample.source}
+              />
+            : <div>
+                <Link to="../">
+                  <IconArrowBack color="currentColor" size="small" />{' '}
+                  {selectedDemo.title}
+                </Link>
+                <ComponentDocExample {...selectedExample} />
+              </div>;
+        }}
+      />
       <Route
         path="/components/:componentId"
         render={route => {


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->

* Add routed page for each demo example
* Make each example title link to its page
* Add a chromeless mode, triggered by adding "?chromeless" to the end of the URL
* Refactor use of react-live components into a standalone LiveProvider component
* Change ComponentDocExample to a stateless functional component from a class
* Remove un-used Anchor styles in ComponentDocExample and other style improvements

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
When developing, it can be a pain to have multiple instances of the component on the screen. You could hack around this by editing the examples index, but this is _way_ nicer. The chromeless mode can be used later for visual diff testing.

### Screenshots or videos, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

http://example-permalink--mineral-ui.netlify.com/components/button

Note the URLs here...

![screen shot 2017-09-29 at 4 22 10 pm](https://user-images.githubusercontent.com/486540/31038372-aa195fd4-a533-11e7-8624-1d014a81f244.png)

![screen shot 2017-09-29 at 4 22 34 pm](https://user-images.githubusercontent.com/486540/31038377-b3e7a69c-a533-11e7-93e9-b94966aceb17.png)

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. Open the site and navigate to a [component page](http://example-permalink--mineral-ui.netlify.com/components/button)
2. Click an example title to navigate to that example’s page
3. Add "?chromeless" to the end of the URL to switch to chromeless mode

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Docs

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Ahhhhhh](https://media.giphy.com/media/3o84sHlCTa6ZvfXukU/giphy.gif)
