### PR TITLE
[Website] Display complex prop types in Popover

### DIFF
--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -19,7 +19,7 @@ import React from 'react';
 import { createStyledComponent } from '../utils';
 
 type Props = {
-  /** Content of the Card. Can be anything, but see [CardBlock](./card-block), [CardImage](./card-image), and [CardTitle](./card-title). */
+  /** Content of the Card. Can be anything, but see [CardBlock](../card-block), [CardImage](../card-image), and [CardTitle](../card-title). */
   children: React$Node,
   /** Called with the click event */
   onClick?: (event: SyntheticEvent<>) => void

--- a/src/Card/CardImage.js
+++ b/src/Card/CardImage.js
@@ -50,7 +50,7 @@ const Root = createStyledComponent(
 );
 
 /**
- * CardImage renders images full-bleed inside of a [Card](./card).
+ * CardImage renders images full-bleed inside of a [Card](../card).
  * Use CardImage to display static media.
  */
 export default function CardImage(props: Props) {

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -40,8 +40,8 @@ type Props = {
   defaultIsOpen?: boolean,
   /** Disable the Dropdown */
   disabled?: boolean,
-  /** Data from which the [Menu](../menu#data) will be constructed */
-  data: Array<Object>,
+  /** Data from which the [Menu](../menu#data) will be constructed (see [example](#data)) */
+  data: Array<{ items: Array<Item>, title?: React$Node }>,
   /** For use with controlled components, in which the app manages Dropdown state */
   isOpen?: boolean,
   /** Plugins that are used to alter behavior. See [PopperJS docs](https://popper.js.org/popper-documentation.html#modifiers) for options. */

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -40,7 +40,7 @@ type Props = {
   defaultIsOpen?: boolean,
   /** Disable the Dropdown */
   disabled?: boolean,
-  /** Data from which the [Menu](./menu#data) will be constructed */
+  /** Data from which the [Menu](../menu#data) will be constructed */
   data: Array<Object>,
   /** For use with controlled components, in which the app manages Dropdown state */
   isOpen?: boolean,

--- a/src/Dropdown/DropdownContent.js
+++ b/src/Dropdown/DropdownContent.js
@@ -23,7 +23,7 @@ import Menu from '../Menu';
 type Props = {
   /** Function that returns props to be applied to each item */
   getItemProps?: (props: Object, scope: Object) => Object,
-  /** Data used to contruct Menu. See [example](./menu#data) */
+  /** Data used to contruct Menu. See [example](../menu#data) */
   data: Array<Object>,
   /** Plugins that are used to alter behavior. See https://popper.js.org/popper-documentation.html#modifiers */
   modifiers?: Object,

--- a/src/Dropdown/DropdownContent.js
+++ b/src/Dropdown/DropdownContent.js
@@ -23,7 +23,7 @@ import Menu from '../Menu';
 type Props = {
   /** Function that returns props to be applied to each item */
   getItemProps?: (props: Object, scope: Object) => Object,
-  /** Data used to contruct Menu. See [example](../menu#data) */
+  /** Data from which the [Menu](../menu#data) will be constructed */
   data: Array<Object>,
   /** Plugins that are used to alter behavior. See https://popper.js.org/popper-documentation.html#modifiers */
   modifiers?: Object,

--- a/src/Link/Link.js
+++ b/src/Link/Link.js
@@ -21,12 +21,12 @@ import { createStyledComponent } from '../utils';
 type Props = {
   /** Content of the Link */
   children?: React$Node,
-  /** A URL or a URL fragment that the Link points to */
+  /** A URL or URL fragment to which the Link points */
   href?: string,
-  /** Element to be used as the root node - e.g. "a" or { ReactRouterLink } */
-  element?: $FlowFixMe,
+  /** Element to be used as the root node - e.g. "a" or {&nbsp;ReactRouterLink&nbsp;} */
+  element?: $FlowFixMe, // Should allow string | React class
   /** Available variants */
-  variant?: 'regular' | 'danger' | 'success' | 'warning' // Should allow string | React class
+  variant?: 'regular' | 'danger' | 'success' | 'warning'
 };
 
 export const componentTheme = (baseTheme: Object) => ({

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -20,7 +20,7 @@ import { createStyledComponent } from '../utils';
 import { MenuDivider, MenuGroup, MenuItem } from './index';
 
 type Props = {
-  /** [MenuDivider](./menu-divider), [MenuGroup](./menu-group), or [MenuItem](./menu-item) */
+  /** [MenuDivider](../menu-divider), [MenuGroup](../menu-group), or [MenuItem](../menu-item) */
   children?: React$Node,
   /** Data used to contruct Menu. See [example](#data) */
   data?: Array<{ items: Array<Item>, title?: React$Node }>,
@@ -50,7 +50,7 @@ const Root = createStyledComponent(
 );
 
 /**
- * Menus display a list of [MenuItems](./menu-item). The items can have actions or be used for navigation.
+ * Menus display a list of [MenuItems](../menu-item). The items can have actions or be used for navigation.
  */
 export default function Menu({
   children,

--- a/src/Menu/MenuDivider.js
+++ b/src/Menu/MenuDivider.js
@@ -45,7 +45,7 @@ const Root = createStyledComponent(
 );
 
 /**
- * MenuDividers are used to separate [MenuItems](./menu-item) and [MenuGroups](./menu-group).
+ * MenuDividers are used to separate [MenuItems](../menu-item) and [MenuGroups](../menu-group).
  */
 export default function MenuDivider(props: Props) {
   return <Root {...props} role="separator" />;

--- a/src/Menu/MenuGroup.js
+++ b/src/Menu/MenuGroup.js
@@ -20,7 +20,7 @@ import { createStyledComponent } from '../utils';
 import MenuGroupTitle from './MenuGroupTitle';
 
 type Props = {
-  /** [MenuItems](./menu-item) */
+  /** [MenuItems](../menu-item) */
   children?: React$Node,
   /** Title for the group */
   title?: React$Node
@@ -44,7 +44,7 @@ const Root = createStyledComponent(
 );
 
 /**
- * MenuGroups group together [Menu Items](./menu-items) and can display a title.
+ * MenuGroups group together [Menu Items](../menu-items) and can display a title.
  */
 export default function MenuGroup({ children, title, ...restProps }: Props) {
   return (

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -33,7 +33,7 @@ type Props = {
   iconStart?: React$Element<*>,
   /** Display the item in an active style */
   isHighlighted?: boolean,
-  /** Item data (see example below) */
+  /** Item data (see [example](../menu#data)) */
   item?: Item,
   /** Called with the click event */
   onClick?: (event: SyntheticEvent<>) => void,

--- a/src/ThemeProvider/ThemeProvider.js
+++ b/src/ThemeProvider/ThemeProvider.js
@@ -22,7 +22,7 @@ import mineralTheme from '../utils/mineralTheme';
 type Props = {
   /** Components to which the theme will be applied */
   children?: React$Node,
-  /** A shallow object of theme variables and their values */
+  /** A shallow object of [theme variables](/theming/#theming-theme-variables) and their values */
   theme?: Object
 };
 

--- a/src/website/app/demos/Button/examples/iconOnly.js
+++ b/src/website/app/demos/Button/examples/iconOnly.js
@@ -28,7 +28,7 @@ const DemoLayout = createStyledComponent('div', {
 export default {
   id: 'icon-only',
   title: 'Icon-Only Buttons',
-  description: `Buttons that contain only [Icons](./icon) can use either \`iconStart\` or \`iconEnd\` props and must have an \`aria-label\` provided.
+  description: `Buttons that contain only [Icons](../icon) can use either \`iconStart\` or \`iconEnd\` props and must have an \`aria-label\` provided.
 
 Use icon-only Buttons sparingly. The meaning of the Button can be diluted without a visual label.`,
   scope: { Button, IconCloud, DemoLayout },

--- a/src/website/app/demos/Button/examples/icons.js
+++ b/src/website/app/demos/Button/examples/icons.js
@@ -28,7 +28,7 @@ const DemoLayout = createStyledComponent('div', {
 export default {
   id: 'icons',
   title: 'Buttons with Icons',
-  description: `Buttons can contain [Icons](./icon) at their start, end, or both.
+  description: `Buttons can contain [Icons](../icon) at their start, end, or both.
 
 \`small\` Buttons use small Icons; \`medium\` and \`large\` Buttons use medium Icons; \`jumbo\` Buttons use large Icons.`,
   scope: { Button, IconCloud, DemoLayout },

--- a/src/website/app/demos/Button/examples/rtl.js
+++ b/src/website/app/demos/Button/examples/rtl.js
@@ -23,7 +23,7 @@ export default {
   id: 'rtl',
   title: 'RTL Support',
   description: `Buttons with Icons are reversed when the \`rtl\` prop is set.
-A subset of Icons that [convey directionality](./icon#rtl) will be reversed.`,
+A subset of Icons that [convey directionality](../icon#rtl) will be reversed.`,
   scope: { Button, IconBackspace, ThemeProvider },
   source: `
     <div dir="rtl">

--- a/src/website/app/demos/Card/examples/card/card.js
+++ b/src/website/app/demos/Card/examples/card/card.js
@@ -27,7 +27,7 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `Card content should be neither too simple nor too complex.
 Cards are used as a gateway to more detailed content, not merely as a widget container.
-Cards contain one [CardTitle](./card-title), an optional [CardImage](./card-image), and one or more [CardBlocks](./card-block).
+Cards contain one [CardTitle](../card-title), an optional [CardImage](../card-image), and one or more [CardBlocks](../card-block).
 
 <Callout title="Note">
   Cards normally occupy the full available width of their container. The Cards here are width-constrained for illustration purposes.

--- a/src/website/app/demos/Card/examples/card/clickable.js
+++ b/src/website/app/demos/Card/examples/card/clickable.js
@@ -26,7 +26,7 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `If an \`onClick\` callback is provided, the entire Card becomes clickable and keyboard actionable.
 Use this feature when only one action can be taken per Card.
-This simplifies the interface by not requiring an extra [Button](./button).`,
+This simplifies the interface by not requiring an extra [Button](../button).`,
   scope: { Card, CardBlock, CardTitle, DemoLayout },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Card/index.js
+++ b/src/website/app/demos/Card/index.js
@@ -53,9 +53,9 @@ Cards represent a gateway to more detailed information in another app view.`
     slug: 'card-block',
     subcomponent: true,
     title: 'CardBlock',
-    whenHowToUse: `CardBlock is used to help lay out content that's not a [title](./card-title) or an [image](./card-image) in the body of the [Card](./card).
+    whenHowToUse: `CardBlock is used to help lay out content that's not a [title](../card-title) or an [image](../card-image) in the body of the [Card](../card).
 
-Try not to put inline links in your content. Create purposeful calls to action with [Buttons](./button) at the bottom of the Card.`
+Try not to put inline links in your content. Create purposeful calls to action with [Buttons](../button) at the bottom of the Card.`
   },
   {
     bestPractices: bestPractices.cardImage,
@@ -65,7 +65,7 @@ Try not to put inline links in your content. Create purposeful calls to action w
     subcomponent: true,
     title: 'CardImage',
     whenHowToUse: `CardImage is used when you want to reinforce the intent of the Card.
-Images shouldn't be used alone in a Card, but should be paired with a call to action and/or a [CardTitle](./card-title).
+Images shouldn't be used alone in a Card, but should be paired with a call to action and/or a [CardTitle](../card-title).
 
 If you are putting text over top of the CardImage, use a solid color or an image with sufficient contrast to the text.`
   },
@@ -77,7 +77,7 @@ If you are putting text over top of the CardImage, use a solid color or an image
     slug: 'card-title',
     subcomponent: true,
     title: 'CardTitle',
-    whenHowToUse: `Use a CardTitle when you need a consistently styled headings for your [Card](./card).
+    whenHowToUse: `Use a CardTitle when you need a consistently styled headings for your [Card](../card).
 Use a subtitle to provide supporting information for the data displayed in the Card.`
   }
 ];

--- a/src/website/app/demos/Dropdown/examples/data.js
+++ b/src/website/app/demos/Dropdown/examples/data.js
@@ -25,7 +25,7 @@ export default {
   title: 'Data-Driven',
   description: `Dropdown items are defined by an array of data, with the
     structure below. Object properties in the \`items\` array(s) will be passed
-    on to the [MenuItem](./menu-item).`,
+    on to the [MenuItem](../menu-item).`,
   scope: {
     Button,
     CustomRender,

--- a/src/website/app/demos/Icon/index.js
+++ b/src/website/app/demos/Icon/index.js
@@ -33,7 +33,7 @@ Use icons in combination with labels to help users more quickly process your UI.
 
 Don't use too many icons or you run the risk of creating visual clutter.
 
-Icons are usually used inside of a [Button](./button) to reinforce the action.
+Icons are usually used inside of a [Button](../button) to reinforce the action.
 If used alone, Icon placement should be very clear. For example, a play icon ► could be used instead of writing out the word "Play".
 
 Icons should only be used if they aid communication, not merely for decoration.`

--- a/src/website/app/demos/Link/bestPractices.js
+++ b/src/website/app/demos/Link/bestPractices.js
@@ -49,6 +49,6 @@ export default [
     type: 'dont',
     title: 'use a link to perform a page action',
     example: <Link>Scroll to bottom</Link>,
-    description: 'To represent an action, use a [Button](./button).'
+    description: 'To represent an action, use a [Button](../button).'
   }
 ];

--- a/src/website/app/demos/Menu/examples/menu-divider/menuDivider.js
+++ b/src/website/app/demos/Menu/examples/menu-divider/menuDivider.js
@@ -25,7 +25,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description:
-    '[MenuItems](./menu-item) and [MenuGroups](./menu-group) can optionally be separated with a MenuDivider.',
+    '[MenuItems](../menu-item) and [MenuGroups](../menu-group) can optionally be separated with a MenuDivider.',
   scope: { DemoLayout, Menu, MenuDivider, MenuGroup, MenuItem },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Menu/examples/menu-group/menuGroup.js
+++ b/src/website/app/demos/Menu/examples/menu-group/menuGroup.js
@@ -25,7 +25,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description:
-    'To group [MenuItems](./menu-item) together, wrap them in a MenuGroup and optionally provide a title.',
+    'To group [MenuItems](../menu-item) together, wrap them in a MenuGroup and optionally provide a title.',
   scope: { DemoLayout, Menu, MenuGroup, MenuItem },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Menu/examples/menu-item/customRender.js
+++ b/src/website/app/demos/Menu/examples/menu-item/customRender.js
@@ -36,7 +36,7 @@ help match the other MenuItems, you have access to its
 might be a helpful template. Some things to keep in mind:
 
 1. Remember to include \`:focus\`, \`:hover\`, and \`:active\` styles.
-  1. If this is to be used for a [Dropdown](./dropdown), also apply your
+  1. If this is to be used for a [Dropdown](../dropdown), also apply your
      focus/hover styles when \`props.isHighlighted === true\`.
 1. Remember to accommodate the disabled state (\`props.disabled === true\`).
 1. If your app supports RTL languages, you can use \`theme.direction\` to

--- a/src/website/app/demos/Menu/examples/menu-item/icons.js
+++ b/src/website/app/demos/Menu/examples/menu-item/icons.js
@@ -26,7 +26,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description:
-    'MenuItems can contain [Icons](./icon) at their start, end, or both. If both `startIcon` and `variant` props are provided, `startIcon` will be used.',
+    'MenuItems can contain [Icons](../icon) at their start, end, or both. If both `startIcon` and `variant` props are provided, `startIcon` will be used.',
   scope: { DemoLayout, IconCloud, Menu, MenuItem },
   source: `
     () => {

--- a/src/website/app/demos/Menu/examples/menu/data.js
+++ b/src/website/app/demos/Menu/examples/menu/data.js
@@ -28,7 +28,7 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `Menu content can also be defined by an array of data, with the
     structure below. Object properties in the \`items\` array(s) will be passed
-    on to the [MenuItem](./menu-item).`,
+    on to the [MenuItem](../menu-item).`,
   scope: { CustomRender, DemoLayout, IconCloud, Menu },
   source: `
     () => {

--- a/src/website/app/demos/Menu/examples/menu/menu.js
+++ b/src/website/app/demos/Menu/examples/menu/menu.js
@@ -26,7 +26,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description:
-    'Menus are composed of [MenuDivider](./menu-divider), [MenuGroup](./menu-group), and [MenuItem](./menu-item).',
+    'Menus are composed of [MenuDivider](../menu-divider), [MenuGroup](../menu-group), and [MenuItem](../menu-item).',
   scope: { DemoLayout, IconCloud, Menu, MenuDivider, MenuGroup, MenuItem },
   source: `
     <DemoLayout>


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
- Arrays, functions, objects, and unions that are sufficiently complex are displayed as a Button with text content of the type (e.g. “Array”) that opens a Popover displaying the full type information in a more readable manner.
- Fix broken component-to-component links caused by #371
- Improve prop descriptions for various components

#### Notes and open questions
- I first tried to put the Popover content in a codeblock with syntax highlighting that matched the others on the site, but it looked terrible inside the Popover.
- The logic to determine whether a type is displayed in a Popover is somewhat arbitrary.
    - For most, it’s a simple character count determined by what looks OK in our table at a variety of screen widths. However, this means that our most common Function type, `(event: SyntheticEvent<>) => void`, is always obscured. Is that the right choice?
    - If we can’t find good heuristics for this determination, we can change it later to simply always display certain types in a Popover.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Displaying the full info for complex types is ugly and hard to read.

### Screenshots or videos, if appropriate
<!-- To record and share a video: http://recordit.co/ -->
http://prop-type-popover--mineral-ui.netlify.com/components/menu-item/#api-and-theme

![screen shot 2017-10-03 at 1 43 45 pm](https://user-images.githubusercontent.com/486540/31145411-e923e518-a840-11e7-8bed-b1234dd5a8f9.png)

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Navigate to a [component’s prop table](http://prop-type-popover--mineral-ui.netlify.com/components/menu-item/#api-and-theme)
3. Confirm that complex types are displayed in Popovers and that the Popover content is correct and readable

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Docs

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->
