### PR TITLE
docs(changelog): Fix duplicate entries in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 ### Features
 
 * **dropdown,popover:** Dropdown and Popover updates ([23b96ff](https://github.com/mineral-ui/mineral-ui/commit/23b96ff))
-* **site:** add Color page ([2e5ff5e](https://github.com/mineral-ui/mineral-ui/commit/2e5ff5e))
-* **site:** Typography page with some demos and tokens ([a2ce02b](https://github.com/mineral-ui/mineral-ui/commit/a2ce02b))
-* **website:** Add a meta description tag to the index page and update the README.md to match ([bb995bd](https://github.com/mineral-ui/mineral-ui/commit/bb995bd))
-
 
 ### BREAKING CHANGES
 
@@ -20,18 +16,10 @@
 # [0.5.0](https://github.com/mineral-ui/mineral-ui/compare/v0.4.0...v0.5.0) (2017-09-29)
 
 
-### Bug Fixes
-
-* **site:** make the propDoc optional in DocProps component ([ed22069](https://github.com/mineral-ui/mineral-ui/commit/ed22069))
-
-
 ### Features
 
 * **dropdown:** Add new component ([5ee58ba](https://github.com/mineral-ui/mineral-ui/commit/5ee58ba))
 * **menu:** Add new component ([7fbd662](https://github.com/mineral-ui/mineral-ui/commit/7fbd662))
-* **site:** add styled typographic elements ([a5fbeb7](https://github.com/mineral-ui/mineral-ui/commit/a5fbeb7))
-* **website:** normalize guidelines pages layout ([1f5e40b](https://github.com/mineral-ui/mineral-ui/commit/1f5e40b))
-
 
 
 <a name="0.4.0"></a>
@@ -81,6 +69,3 @@
 ### Bug Fixes
 
 * **Link:** closes [#317](https://github.com/mineral-ui/mineral-ui/issues/317), closes [#255](https://github.com/mineral-ui/mineral-ui/issues/255) ([825ba31](https://github.com/mineral-ui/mineral-ui/commit/825ba31))
-
-
-

--- a/utils/changelogConfig.js
+++ b/utils/changelogConfig.js
@@ -16,7 +16,15 @@
 
 /* @flow */
 module.exports = {
-  gitRawCommitsOpts: {
-    from: 'e293ace5ce534fe5a57306eb737db57943aa99e4' // Since mineral-ui package created
-  }
+  /**
+   * When enabled, the following configuration setting will generate all
+   * changelog entries starting from the creation of the mineral-ui package and
+   * prepend them to the changelog. This should only be run against a new/blank
+   * changelog.
+   *
+   * When disabled, only new entries will be prepended to the changelog.
+   */
+  // gitRawCommitsOpts: {
+  //   from: 'e293ace5ce534fe5a57306eb737db57943aa99e4' // mineral-ui package created
+  // }
 };


### PR DESCRIPTION
### Description

Fix duplicate entries in changelog

* Ensure only new entries will be prepended to the changelog
* Manually update changelog to remove site/website commits

I left the configuration setting in the code in case we need to generate the changelog again from scratch.  Not sure that is entirely necessary, but that configuration setting is really obscure.

### Motivation and context

Fixes a bug where changelog entries were being duplicated on each release.  Also, this update should allow us to manually edit a changelog and have those changes persisted - e.g. we could provide more detailed upgrade guidelines in the case of a breaking change, etc.

closes #401 

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. checkout the `fix-changelog` branch locally
2. open `scripts/release.js` and add a `process.exit(0)` right before the line that says `// Check if a changelog has been generated`
3. `npm run release:dist`
4. Verify that a single new entry has been prepended to the changelog

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

Fixes a bug in our changelog generation.  Also manually updates the changelog.

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**

