### PR TITLE
[Website] component status table

### DIFF
--- a/src/website/app/Label.js
+++ b/src/website/app/Label.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import { createStyledComponent } from '../../utils';
+
+type Props = {
+  children: React$Node,
+  variant?: string
+};
+
+const Root = createStyledComponent('span', ({ theme, variant }) => {
+  const backgroundColor =
+    variant === 'regular'
+      ? theme.color_gray_50
+      : theme[`backgroundColor_${variant}`];
+
+  const color =
+    variant === 'regular' ? theme.color_text : theme[`color_text_on${variant}`];
+
+  return {
+    backgroundColor,
+    borderRadius: theme.borderRadius_1,
+    color,
+    fontSize: theme.fontSize_mouse,
+    lineHeight: theme.lineHeight_prose,
+    padding: `${parseFloat(theme.space_inset_sm) / 2}em
+      ${theme.space_inset_sm}`,
+    textTransform: 'uppercase',
+    verticalAlign: 'text-top',
+    whiteSpace: 'nowrap'
+  };
+});
+
+export default function Label({
+  children,
+  variant = 'regular',
+  ...restProps
+}: Props) {
+  const rootProps = { variant, ...restProps };
+
+  return <Root {...rootProps}>{children}</Root>;
+}

--- a/src/website/app/Markdown.js
+++ b/src/website/app/Markdown.js
@@ -21,6 +21,7 @@ import { createStyledComponent, getNormalizedValue } from '../../utils';
 import Heading from './Heading';
 import Paragraph from './Paragraph';
 import Link from './Link';
+import MarkdownTable from './MarkdownTable';
 import prism from './utils/prism';
 
 type Props = {
@@ -207,6 +208,9 @@ export default function Markdown({ children, scope, ...restProps }: Props) {
       },
       p({ children }) {
         return <Paragraph variant="prose">{children}</Paragraph>;
+      },
+      table({ children }) {
+        return <MarkdownTable>{children}</MarkdownTable>;
       }
     },
     components: {

--- a/src/website/app/MarkdownTable.js
+++ b/src/website/app/MarkdownTable.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import { Table, TableCell, TableHeaderCell, TableRow } from './Table';
+import {
+  isAvailable,
+  isExperimental,
+  isInDevelopment,
+  isNew,
+  isPlanned
+} from './tableCellTransforms';
+
+type TableTreeItem = {
+  props: { children: React$Element<*>[] }
+};
+
+type Props = {
+  children: [Array<TableTreeItem>, Array<TableTreeItem>]
+};
+
+export default function MarkdownTable({ children }: Props) {
+  // we're going to assume there's a table header here
+  // since marked (marksy's parser) requires a header
+  let [head, body] = children;
+
+  // a bunch of the elements returned by marksy are null,
+  // so there's a lot of filtering and finding with the identity
+  const headNode = head.find(element => element);
+  const headRow = headNode && headNode.props.children.find(row => row);
+  const headCells =
+    headRow &&
+    headRow.props.children
+      .filter(cell => cell)
+      .map(cell => (
+        <TableHeaderCell key={cell.key}>{cell.props.children}</TableHeaderCell>
+      ));
+  const bodyNode = body.find(element => element);
+  const bodyRows =
+    bodyNode &&
+    bodyNode.props.children.filter(row => row).map(row => {
+      const bodyCells = row.props.children.filter(cell => cell).map(cell => {
+        let { children: cellReactChildren } = cell.props;
+        if (cellReactChildren == null) {
+          return <TableCell key={cell.key} />;
+        }
+
+        const transforms = [
+          isAvailable,
+          isExperimental,
+          isInDevelopment,
+          isNew,
+          isPlanned
+        ];
+
+        const enhancedChildren = cellReactChildren
+          .filter(child => child)
+          // all the transforms return a (possibly modified) node,
+          // which is passed to the next transform
+          .map(child =>
+            transforms.reduce((node, transform) => transform(node), child)
+          );
+
+        return <TableCell key={cell.key}>{enhancedChildren}</TableCell>;
+      });
+
+      return <TableRow key={row.key}>{bodyCells}</TableRow>;
+    });
+
+  return (
+    <Table>
+      <thead>
+        <TableRow>{headCells}</TableRow>
+      </thead>
+      <tbody>{bodyRows}</tbody>
+    </Table>
+  );
+}

--- a/src/website/app/Nav.js
+++ b/src/website/app/Nav.js
@@ -73,10 +73,8 @@ const styles = {
     padding: theme.space_inset_md,
     backgroundColor: theme.slate_10
   }),
-  subsection: ({ theme }) => ({
-    marginTop: theme.space_stack_sm,
-    listStyle: 'none',
-    paddingLeft: theme.space_inline_sm
+  status: ({ theme }) => ({
+    fontWeight: theme.fontWeight_regular
   })
 };
 
@@ -84,8 +82,8 @@ const Root = createStyledComponent('nav', styles.nav);
 const Heading = createStyledComponent('h2', styles.heading);
 const List = createStyledComponent('ol', styles.list);
 const ListItem = createStyledComponent('li', styles.listItem);
-const SubSection = createStyledComponent('ul', styles.subsection);
 const Logo = createStyledComponent(Link, styles.logo);
+const Status = createStyledComponent(Link, styles.status);
 
 export default function Nav({ demos, ...restProps }: Props) {
   const rootProps = { ...restProps };
@@ -102,22 +100,7 @@ export default function Nav({ demos, ...restProps }: Props) {
   const pageLinks = pages.map((page, i) => {
     return (
       <ListItem key={`page-${i}`}>
-        <Link to={page.path}>{page.title}</Link>
-        {Array.isArray(page.sections) && (
-          <SubSection>
-            {page.sections.map((section, j) => {
-              if (!page.path) return null;
-              const path = section.id
-                ? `${page.path}#${section.id}`
-                : section.path;
-              return (
-                <ListItem key={`section-${j}`}>
-                  <Link to={path}>{section.title}</Link>
-                </ListItem>
-              );
-            })}
-          </SubSection>
-        )}
+        {!page.hiddenInNav && <Link to={page.path}>{page.title}</Link>}
       </ListItem>
     );
   });
@@ -129,7 +112,9 @@ export default function Nav({ demos, ...restProps }: Props) {
         <h1>Mineral UI</h1>
       </Logo>
       <List>{pageLinks}</List>
-      <Heading>Components</Heading>
+      <Heading>
+        Components <Status href="/component-status">[status]</Status>
+      </Heading>
       <List>{demoLinks}</List>
     </Root>
   );

--- a/src/website/app/Router.js
+++ b/src/website/app/Router.js
@@ -31,24 +31,10 @@ type Props = {
 export default function Router({ demos }: Props) {
   const routes = [];
 
-  pages.map((page, i) => {
-    if (page.sections) {
-      page.sections.map((section, j) => {
-        if (section.path) {
-          routes.push(
-            <Route
-              key={`section-${j}`}
-              path={section.path}
-              render={() => <section.component />}
-            />
-          );
-        }
-      });
-    }
-
+  pages.map((page, index) => {
     routes.push(
       <Route
-        key={`page-${i}`}
+        key={`page-${index}`}
         path={page.path}
         render={() => <page.component />}
       />

--- a/src/website/app/pages/ComponentDoc/DocHeader.js
+++ b/src/website/app/pages/ComponentDoc/DocHeader.js
@@ -86,18 +86,26 @@ export default function DocHeader({
   const navElements = []; // only show the tabs menu if there is more than one tab
   if (examples && examples.length > 0) {
     navElements.push(
-      <NavElement href={`#${firstExampleId}`}>Examples</NavElement>
+      <NavElement href={`#${firstExampleId}`} key="examples">
+        Examples
+      </NavElement>
     );
   }
 
   if (props) {
     navElements.push(
-      <NavElement href="#api-and-theme">API & Theme</NavElement>
+      <NavElement href="#api-and-theme" key="api-and-theme">
+        API & Theme
+      </NavElement>
     );
   }
 
   if (whenHowToUse || bestPractices) {
-    navElements.push(<NavElement href="#usage">Usage</NavElement>);
+    navElements.push(
+      <NavElement href="#usage" key="usage">
+        Usage
+      </NavElement>
+    );
   }
 
   return (

--- a/src/website/app/pages/ComponentStatus/Legend.js
+++ b/src/website/app/pages/ComponentStatus/Legend.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import { createStyledComponent, color } from '../../../../utils';
+import IconAssignment from '../../../../Icon/IconAssignment';
+import IconCheck from '../../../../Icon/IconCheck';
+import IconSlowMotionVideo from '../../../../Icon/IconSlowMotionVideo';
+
+const styles = {
+  list: ({ theme }) => ({
+    paddingLeft: 0,
+    marginTop: theme.space_stack_xxl,
+    '& li': {
+      display: 'inline-block',
+      marginRight: theme.space_inline_xl
+    }
+  }),
+  icon: {
+    verticalAlign: 'text-top'
+  }
+};
+
+const Available = createStyledComponent(IconCheck, styles.icon);
+const InDevelopment = createStyledComponent(IconSlowMotionVideo, styles.icon);
+const Planned = createStyledComponent(IconAssignment, styles.icon);
+const List = createStyledComponent('ul', styles.list);
+
+export default function Legend() {
+  return (
+    <List aria-hidden="true">
+      <li>
+        <Available color={color.green_60} size="large" /> Available
+      </li>
+      <li>
+        <InDevelopment color={color.yellow_60} size="large" /> In Development
+      </li>
+      <li>
+        <Planned color={color.blue_60} size="large" /> Planned
+      </li>
+    </List>
+  );
+}

--- a/src/website/app/pages/ComponentStatus/componentStatus.md
+++ b/src/website/app/pages/ComponentStatus/componentStatus.md
@@ -1,0 +1,42 @@
+# Component Status
+
+Check back here anytime to see current component status information.
+If you have a suggestion for a new component not listed here, [create an issue on GitHub](https://github.com/mineral-ui/mineral-ui/issues) to let us know!
+
+See more detailed progress on our [Waffle.io board](https://waffle.io/mineral-ui/mineral-ui).
+
+<Legend />
+
+<!--
+
+Labels:
+~ new
+~ experimental
+
+Statuses:
+[available]
+[planned]
+[in development]
+[deprecated]
+
+-->
+
+| Component | Status |
+|---|---|
+| [Button](/components/button) | [available] |
+| [Card](/components/card) | [available] |
+| DateInput | [planned] |
+| [Dropdown](/components/dropdown) ~ new | [available] |
+| Navigation | [planned] |
+| Grid | [planned] |
+| [Icon](/components/icon) | [available] |
+| [Link](/components/link) | [available] |
+| [Menu](/components/menu) ~ new | [available] |
+| NumericInput | [planned] |
+| [Popover](/components/popover) | [available] |
+| Select | [planned] |
+| TextArea | [planned] |
+| TextInput | [planned] |
+| [ThemeProvider](/components/theme-provider) | [available] |
+| Tooltip | [planned] |
+| [Utils](/components/utils) | [available] |

--- a/src/website/app/pages/ComponentStatus/index.js
+++ b/src/website/app/pages/ComponentStatus/index.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import GuidelinePage from '../../GuidelinePage';
+import Markdown from '../../Markdown';
+import Legend from './Legend';
+import content from './componentStatus.md';
+
+export default function ComponentStatus() {
+  return (
+    <GuidelinePage>
+      <Markdown scope={{ Legend }}>{content}</Markdown>
+    </GuidelinePage>
+  );
+}

--- a/src/website/app/pages/GettingStarted/gettingStarted.md
+++ b/src/website/app/pages/GettingStarted/gettingStarted.md
@@ -45,10 +45,10 @@ render(<App />, document.getElementById('app'));
 ```
 
 <Callout title="Note">
-  <p>Your app must be wrapped in a <code>ThemeProvider</code> at its root
+  <p key="one">Your app must be wrapped in a <code key="two">ThemeProvider</code> at its root
   in order for the styles to apply correctly.</p>
 
-  <p>Also, please see our <a href="https://github.com/mineral-ui/mineral-ui/tree/master/docs/import-syntax.md">import syntax guidelines</a>.</p>
+  <p key="three">Also, please see our <a key="four" href="https://github.com/mineral-ui/mineral-ui/tree/master/docs/import-syntax.md">import syntax guidelines</a>.</p>
 </Callout>
 
 ### Open Sans Font

--- a/src/website/app/pages/index.js
+++ b/src/website/app/pages/index.js
@@ -19,12 +19,13 @@ import GettingStarted from './GettingStarted';
 import Theming from './Theming';
 import Color from './Color';
 import Typography from './Typography';
+import ComponentStatus from './ComponentStatus';
 
 type Page = {
   component: React$ComponentType<*>,
   id?: string,
   path?: string,
-  sections?: Array<Object>,
+  hiddenInNav?: boolean,
   title: string
 };
 
@@ -50,6 +51,12 @@ const pages: Pages = [
     component: Theming,
     path: '/theming',
     title: 'Theming'
+  },
+  {
+    component: ComponentStatus,
+    hiddenInNav: true,
+    path: '/component-status',
+    title: 'Component Status'
   }
 ];
 

--- a/src/website/app/tableCellTransforms.js
+++ b/src/website/app/tableCellTransforms.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import { createStyledComponent, color } from '../../utils';
+import IconCheck from '../../Icon/IconCheck';
+import IconAssignment from '../../Icon/IconAssignment';
+import IconSlowMotionVideo from '../../Icon/IconSlowMotionVideo';
+import IconWarning from '../../Icon/IconWarning';
+import _Label from './Label';
+
+// a tilde surrounded by some spaces and "new"
+const REGEX_LABEL_NEW = /^\s+?~\s+?(new)/;
+// a tilde surrounded by some spaces and "experimental"
+const REGEX_LABEL_EXPERIMENTAL = /^\s+?~\s+?(experimental)/;
+
+const styles = {
+  label: ({ theme }) => ({ marginLeft: theme.space_inline_md }),
+  icon: {
+    '& svg': {
+      verticalAlign: 'text-top'
+    },
+    '& span': {
+      border: 0,
+      height: 1,
+      margin: -1,
+      overflow: 'hidden',
+      padding: 0,
+      position: 'absolute',
+      width: 1
+    }
+  }
+};
+
+const Label = createStyledComponent(_Label, styles.label);
+const Available = createStyledComponent('span', styles.icon);
+const InDevelopment = createStyledComponent('span', styles.icon);
+const Planned = createStyledComponent('span', styles.icon);
+const Deprecated = createStyledComponent('span', styles.icon);
+
+export const isNew = (child: React$Node, index: number) => {
+  if (typeof child !== 'string' || !child.match(REGEX_LABEL_NEW)) {
+    return child;
+  }
+
+  return (
+    <Label key={`label-${index}`} variant="success">
+      {child.replace(REGEX_LABEL_NEW, '$1')}
+    </Label>
+  );
+};
+
+export const isExperimental = (child: React$Node, index: number) => {
+  if (typeof child !== 'string' || !child.match(REGEX_LABEL_EXPERIMENTAL)) {
+    return child;
+  }
+
+  return (
+    <Label key={`label-${index}`} variant="warning">
+      {child.replace(REGEX_LABEL_EXPERIMENTAL, '$1')}
+    </Label>
+  );
+};
+
+export const isAvailable = (child: React$Node, index: number) => {
+  if (typeof child !== 'string' || !child.includes('[available]')) {
+    return child;
+  }
+
+  return (
+    <Available>
+      <IconCheck
+        color={color.green_60}
+        size="large"
+        key={`icon-${index}`}
+        title="available"
+      />
+      <span>available</span>
+    </Available>
+  );
+};
+
+export const isInDevelopment = (child: React$Node, index: number) => {
+  if (typeof child !== 'string' || !child.includes('[in development]')) {
+    return child;
+  }
+
+  return (
+    <InDevelopment>
+      <IconSlowMotionVideo
+        color={color.yellow_60}
+        size="large"
+        key={`icon-${index}`}
+        title="in development"
+      />
+      <span>in development</span>
+    </InDevelopment>
+  );
+};
+
+export const isPlanned = (child: React$Node, index: number) => {
+  if (typeof child !== 'string' || !child.includes('[planned]')) {
+    return child;
+  }
+
+  return (
+    <Planned>
+      <IconAssignment
+        size="large"
+        color={color.blue_60}
+        key={`icon-${index}`}
+        title="in review"
+      />
+      <span>planned</span>
+    </Planned>
+  );
+};
+
+export const isDeprecated = (child: React$Node, index: number) => {
+  if (typeof child !== 'string' || !child.includes('[deprecated]')) {
+    return child;
+  }
+
+  return (
+    <Deprecated>
+      <IconWarning
+        color={color.red_60}
+        size="large"
+        key={`icon-${index}`}
+        title="deprecated"
+      />
+      <span>deprecated</span>
+    </Deprecated>
+  );
+};


### PR DESCRIPTION
### Description
Create a Component Status page with associated table. **In Development** is defined as "things that are actively being worked on by the dev team". **Planned** are components in the "ready" or "ideas" columns on the [waffle board](https://waffle.io/mineral-ui/mineral-ui)

closes #394 

### Motivation and context
We would like to let consumers of Mineral UI, internally and externally, know the current state of the development of our component library. Since we're tracking this in several places currently (Trello, Waffle, Invision) this page will provide at-a-glace information to stakeholders and consumers.

### Screenshots, videos, or demo, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

https://394-component-status--mineral-ui.netlify.com/

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Navigate to Component Status
3. are any links missing? anything misspellt?
4. Go through the pages. You should not see the "missing key" error from any Markdown content.

**Note**: the delineation for an icon is `[status]` while the one for a label is `~ label`. Should I just use the brackets for both?

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![table](https://media.giphy.com/media/Aud9jNop4HpCw/giphy.gif)
