### PR TITLE
fix(utils): Remove immutability-helper from createThemedComponent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
     "no-console": ["error", {
       "allow": ["warn", "error"]
     }],
+    "no-unused-vars": ["error", {"vars": "all", "varsIgnorePattern": "[Ii]gnore"}],
     "prettier/prettier": ["error", {
       "bracketSpacing": true,
       "jsxBracketSameLine": true,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "glob": "7.1.2",
     "html-webpack-plugin": "2.30.1",
     "husky": "0.14.3",
-    "immutability-helper": "2.4.0",
     "inquirer": "3.3.0",
     "jest": "21.2.1",
     "jest-glamor-react": "3.1.1",

--- a/src/utils/createThemedComponent.js
+++ b/src/utils/createThemedComponent.js
@@ -17,7 +17,6 @@
 /* @flow */
 import React from 'react';
 import { withTheme } from 'glamorous';
-import update from 'immutability-helper';
 import ThemeProvider from '../ThemeProvider';
 
 function getComponentDisplayName(Component: React$ComponentType<*>): string {
@@ -33,7 +32,7 @@ export default function createThemedComponent(
   const ThemedComponent = (props, context) => {
     const outTheme =
       typeof theme === 'function' ? theme(props, context) : theme;
-    const outProps = update(props, { $unset: ['theme'] });
+    const { theme: ignore, ...outProps } = props;
 
     return (
       <ThemeProvider theme={outTheme}>


### PR DESCRIPTION
### Description

Get rid of `immutability-helper`

### Motivation and context

Was causing an error in sample consumer app.

I like the idea of avoiding mutation, but this is the only place where the helper was being used and it feels like overkill to add a dependency just for that.  Alternatively, we could have moved it to runtime dependencies.

We'll need to publish a new release following merge...

### Screenshots, videos, or demo, if appropriate

![screen shot 2017-10-13 at 12 49 25 pm](https://user-images.githubusercontent.com/202773/31561963-e8bd71f6-b016-11e7-8692-c1c9c329e56b.png)

https://fix-dependency--mineral-ui.netlify.com/

### How to test

1. Try to import `createThemedComponent` in a consumer app and see if you get the error.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
