### PR TITLE
[Website] Component status page design tweaks

### DIFF
--- a/src/website/app/GuidelinePage.js
+++ b/src/website/app/GuidelinePage.js
@@ -30,12 +30,13 @@ const Root = createStyledComponent('div', ({ theme }) => ({
   // There might be more than one paragraph element in the Intro section.
   // marksy generates a flat-ish tree of elements, so body copy Ps are on the same level
   // as the intro paragraph.
-  '& > div > h2 ~ p': {
+  '& > div > h2 ~ p, & > div > ul ~ p': {
     fontSize: theme.fontSize_prose,
     margin: `0 0 ${theme.lineHeight * 1.5}em`
   }
 }));
 
-export default function GuidelinePage({ children }: Props) {
-  return <Root>{children}</Root>;
+export default function GuidelinePage({ children, ...restProps }: Props) {
+  const rootProps = { ...restProps };
+  return <Root {...rootProps}>{children}</Root>;
 }

--- a/src/website/app/Label.js
+++ b/src/website/app/Label.js
@@ -41,7 +41,7 @@ const Root = createStyledComponent('span', ({ theme, variant }) => {
     padding: `${parseFloat(theme.space_inset_sm) / 2}em
       ${theme.space_inset_sm}`,
     textTransform: 'uppercase',
-    verticalAlign: 'text-top',
+    verticalAlign: 'middle',
     whiteSpace: 'nowrap'
   };
 });

--- a/src/website/app/MarkdownTable.js
+++ b/src/website/app/MarkdownTable.js
@@ -46,14 +46,14 @@ export default function MarkdownTable({ children }: Props) {
     headRow &&
     headRow.props.children
       .filter(cell => cell)
-      .map(cell => (
-        <TableHeaderCell key={cell.key}>{cell.props.children}</TableHeaderCell>
+      .map((cell, index) => (
+        <TableHeaderCell key={index}>{cell.props.children}</TableHeaderCell>
       ));
   const bodyNode = body.find(element => element);
   const bodyRows =
     bodyNode &&
     bodyNode.props.children.filter(row => row).map(row => {
-      const bodyCells = row.props.children.filter(cell => cell).map(cell => {
+      const rowCells = row.props.children.filter(cell => cell).map(cell => {
         let { children: cellReactChildren } = cell.props;
         if (cellReactChildren == null) {
           return <TableCell key={cell.key} />;
@@ -78,7 +78,14 @@ export default function MarkdownTable({ children }: Props) {
         return <TableCell key={cell.key}>{enhancedChildren}</TableCell>;
       });
 
-      return <TableRow key={row.key}>{bodyCells}</TableRow>;
+      // Sometimes marksy returns null if the cell actually contains empty string.
+      // Pad out the length of the rowCells array so there are at least as many
+      // columns as defined in the header
+      while (headCells && rowCells.length < headCells.length) {
+        rowCells.push(<TableCell key={`emptyCell_${rowCells.length}`} />);
+      }
+
+      return <TableRow key={row.key}>{rowCells}</TableRow>;
     });
 
   return (

--- a/src/website/app/Nav.js
+++ b/src/website/app/Nav.js
@@ -18,7 +18,7 @@
 import React from 'react';
 import { createStyledComponent } from '../../utils';
 import Link from './Link';
-import pages from './pages';
+import sections from './pages';
 
 type Props = {
   demos: Object
@@ -72,9 +72,6 @@ const styles = {
   nav: ({ theme }) => ({
     padding: theme.space_inset_md,
     backgroundColor: theme.slate_10
-  }),
-  status: ({ theme }) => ({
-    fontWeight: theme.fontWeight_regular
   })
 };
 
@@ -83,7 +80,6 @@ const Heading = createStyledComponent('h2', styles.heading);
 const List = createStyledComponent('ol', styles.list);
 const ListItem = createStyledComponent('li', styles.listItem);
 const Logo = createStyledComponent(Link, styles.logo);
-const Status = createStyledComponent(Link, styles.status);
 
 export default function Nav({ demos, ...restProps }: Props) {
   const rootProps = { ...restProps };
@@ -97,11 +93,22 @@ export default function Nav({ demos, ...restProps }: Props) {
     );
   });
 
-  const pageLinks = pages.map((page, i) => {
+  const nav = sections.map((section, index) => {
     return (
-      <ListItem key={`page-${i}`}>
-        {!page.hiddenInNav && <Link to={page.path}>{page.title}</Link>}
-      </ListItem>
+      <div key={index}>
+        <Heading>{section.heading}</Heading>
+        <List>
+          {section.pages.map(page => {
+            return (
+              !page.hiddenInNav && (
+                <ListItem key={page.title}>
+                  <Link to={page.path}>{page.title}</Link>
+                </ListItem>
+              )
+            );
+          })}
+        </List>
+      </div>
     );
   });
 
@@ -111,10 +118,8 @@ export default function Nav({ demos, ...restProps }: Props) {
         <span>M</span>
         <h1>Mineral UI</h1>
       </Logo>
-      <List>{pageLinks}</List>
-      <Heading>
-        Components <Status href="/component-status">[status]</Status>
-      </Heading>
+      {nav}
+      <Heading>Components</Heading>
       <List>{demoLinks}</List>
     </Root>
   );

--- a/src/website/app/Router.js
+++ b/src/website/app/Router.js
@@ -22,24 +22,28 @@ import ComponentDoc from './pages/ComponentDoc';
 import ComponentDocExample from './ComponentDocExample';
 import Link from './Link';
 import LiveProvider from './LiveProvider';
-import pages from './pages';
+import sections from './pages';
 
 type Props = {
   demos: Object
 };
 
 export default function Router({ demos }: Props) {
-  const routes = [];
-
-  pages.map((page, index) => {
-    routes.push(
-      <Route
-        key={`page-${index}`}
-        path={page.path}
-        render={() => <page.component />}
-      />
-    );
-  });
+  const routes = sections
+    .map(section => section.pages)
+    // flatten array of pages arrays
+    .reduce((acc, pages) => {
+      return [...acc, ...pages];
+    }, [])
+    .map((page, index) => {
+      return (
+        <Route
+          key={`page-${index}`}
+          path={page.path}
+          render={() => <page.component />}
+        />
+      );
+    });
 
   return (
     <Switch>

--- a/src/website/app/pages/ComponentStatus/Legend.js
+++ b/src/website/app/pages/ComponentStatus/Legend.js
@@ -24,10 +24,13 @@ import IconSlowMotionVideo from '../../../../Icon/IconSlowMotionVideo';
 const styles = {
   list: ({ theme }) => ({
     paddingLeft: 0,
-    marginTop: theme.space_stack_xxl,
+    margin: `0 0 ${theme.space_stack_xl}`,
     '& li': {
       display: 'inline-block',
-      marginRight: theme.space_inline_xl
+      marginRight: theme.space_inline_xl,
+      '@media(max-width: 45em)': {
+        display: 'block'
+      }
     }
   }),
   icon: {

--- a/src/website/app/pages/ComponentStatus/componentStatus.md
+++ b/src/website/app/pages/ComponentStatus/componentStatus.md
@@ -25,18 +25,19 @@ Statuses:
 |---|---|
 | [Button](/components/button) | [available] |
 | [Card](/components/card) | [available] |
-| DateInput | [planned] |
 | [Dropdown](/components/dropdown) ~ new | [available] |
-| Navigation | [planned] |
-| Grid | [planned] |
 | [Icon](/components/icon) | [available] |
 | [Link](/components/link) | [available] |
 | [Menu](/components/menu) ~ new | [available] |
-| NumericInput | [planned] |
 | [Popover](/components/popover) | [available] |
+| [ThemeProvider](/components/theme-provider) | [available] |
+| [Utils](/components/utils) | [available] |
+| NumericInput | [planned] |
 | Select | [planned] |
 | TextArea | [planned] |
 | TextInput | [planned] |
-| [ThemeProvider](/components/theme-provider) | [available] |
 | Tooltip | [planned] |
-| [Utils](/components/utils) | [available] |
+| DataTable | |
+| DateInput | |
+| Grid | |
+| Navigation | |

--- a/src/website/app/pages/ComponentStatus/index.js
+++ b/src/website/app/pages/ComponentStatus/index.js
@@ -16,15 +16,34 @@
 
 /* @flow */
 import React from 'react';
+import { createStyledComponent } from '../../../../utils';
 import GuidelinePage from '../../GuidelinePage';
 import Markdown from '../../Markdown';
 import Legend from './Legend';
 import content from './componentStatus.md';
 
+const Layout = createStyledComponent(GuidelinePage, ({ theme }) => ({
+  '& table': {
+    maxWidth: '40em'
+  },
+  '& th:last-child, & td:last-child': {
+    textAlign: 'center',
+    width: '6em'
+  },
+  // This will have to be updated if there are more intro paragraphs
+  // in the markdown for this page
+  '& p:nth-of-type(2)': {
+    marginBottom: theme.space_stack_xxl,
+    '@media(max-width: 45em)': {
+      marginBottom: theme.space_stack_lg
+    }
+  }
+}));
+
 export default function ComponentStatus() {
   return (
-    <GuidelinePage>
+    <Layout>
       <Markdown scope={{ Legend }}>{content}</Markdown>
-    </GuidelinePage>
+    </Layout>
   );
 }

--- a/src/website/app/pages/index.js
+++ b/src/website/app/pages/index.js
@@ -24,40 +24,54 @@ import ComponentStatus from './ComponentStatus';
 type Page = {
   component: React$ComponentType<*>,
   id?: string,
-  path?: string,
+  path: string,
   hiddenInNav?: boolean,
   title: string
 };
 
 type Pages = Array<Page>;
 
-const pages: Pages = [
+type Section = {
+  heading: string,
+  pages: Pages
+};
+
+const sections: Array<Section> = [
   {
-    component: GettingStarted,
-    path: '/getting-started',
-    title: 'Getting Started'
+    heading: 'Guidelines',
+    pages: [
+      {
+        component: GettingStarted,
+        path: '/getting-started',
+        title: 'Getting Started'
+      },
+      {
+        component: Color,
+        path: '/color',
+        title: 'Color'
+      },
+      {
+        component: Typography,
+        path: '/typography',
+        title: 'Typography'
+      },
+      {
+        component: Theming,
+        path: '/theming',
+        title: 'Theming'
+      }
+    ]
   },
   {
-    component: Color,
-    path: '/color',
-    title: 'Color'
-  },
-  {
-    component: Typography,
-    path: '/typography',
-    title: 'Typography'
-  },
-  {
-    component: Theming,
-    path: '/theming',
-    title: 'Theming'
-  },
-  {
-    component: ComponentStatus,
-    hiddenInNav: true,
-    path: '/component-status',
-    title: 'Component Status'
+    heading: 'What’s New',
+    pages: [
+      {
+        component: ComponentStatus,
+        path: '/component-status',
+        title: 'Component Status'
+      }
+    ]
   }
 ];
 
-export default pages;
+export default sections;

--- a/src/website/app/tableCellTransforms.js
+++ b/src/website/app/tableCellTransforms.js
@@ -82,13 +82,8 @@ export const isAvailable = (child: React$Node, index: number) => {
   }
 
   return (
-    <Available>
-      <IconCheck
-        color={color.green_60}
-        size="large"
-        key={`icon-${index}`}
-        title="available"
-      />
+    <Available key={`icon-${index}`}>
+      <IconCheck color={color.green_60} size="large" title="available" />
       <span>available</span>
     </Available>
   );
@@ -100,11 +95,10 @@ export const isInDevelopment = (child: React$Node, index: number) => {
   }
 
   return (
-    <InDevelopment>
+    <InDevelopment key={`icon-${index}`}>
       <IconSlowMotionVideo
         color={color.yellow_60}
         size="large"
-        key={`icon-${index}`}
         title="in development"
       />
       <span>in development</span>
@@ -118,13 +112,8 @@ export const isPlanned = (child: React$Node, index: number) => {
   }
 
   return (
-    <Planned>
-      <IconAssignment
-        size="large"
-        color={color.blue_60}
-        key={`icon-${index}`}
-        title="in review"
-      />
+    <Planned key={`icon-${index}`}>
+      <IconAssignment size="large" color={color.blue_60} title="in review" />
       <span>planned</span>
     </Planned>
   );
@@ -136,13 +125,8 @@ export const isDeprecated = (child: React$Node, index: number) => {
   }
 
   return (
-    <Deprecated>
-      <IconWarning
-        color={color.red_60}
-        size="large"
-        key={`icon-${index}`}
-        title="deprecated"
-      />
+    <Deprecated key={`icon-${index}`}>
+      <IconWarning color={color.red_60} size="large" title="deprecated" />
       <span>deprecated</span>
     </Deprecated>
   );


### PR DESCRIPTION
### Description
- add hierarchy to pages array (and thus the navigation)
- cleanup design on Component Status page
- move some keys around to fix another markdown error

### Motivation and context
The Component Status page isn't really a Guideline page, and making the Components header a link isn't super discoverable. This PR adds a couple top-level nav headers to organize things a bit more.

Also some design tweaks so the table (with its icon-only column) doesn't look insane on larger monitors. Deprecate `margin-top` in favor of better css.

https://status-page-tweaks--mineral-ui.netlify.com/

### How to test

1. `cd mineral-ui && npm start`
2. Navigate to `/component-status`
3. Check everything out. The table should feel a bit tighter.

### Types of changes
- design cleanup

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
![graphic design](https://media.giphy.com/media/MvovQGsMBY9H2/giphy.gif)
