### PR TITLE
chore(website): Fix code example error display

### DIFF
--- a/src/website/app/LiveProvider.js
+++ b/src/website/app/LiveProvider.js
@@ -52,6 +52,24 @@ const styles = {
       theme.fontSize_ui
     ),
     overflow: 'auto'
+  }),
+  liveError: ({ theme }) => ({
+    backgroundColor: '#fce3e3', // color.red_10
+    color: theme.color_text_danger,
+    fontFamily: theme.fontFamily_monospace,
+    fontSize: theme.fontSize_mouse,
+    lineHeight: theme.lineHeight_prose,
+    overflow: 'auto',
+    padding: '0 0.5rem', // Match value of the live-editor from .prism-code
+    whiteSpace: 'pre',
+
+    '&:first-line': {
+      fontFamily: theme.fontFamily,
+      fontWeight: theme.fontWeight_semiBold,
+      // Can't use margin/padding here, so this is to space off the heading
+      // from the code
+      lineHeight: 2 * theme.lineHeight_prose
+    }
   })
 };
 
@@ -59,6 +77,7 @@ const MyLivePreview = createStyledComponent(LivePreview, styles.livePreview, {
   rootEl: 'div'
 });
 const MyLiveEditor = createStyledComponent(LiveEditor, styles.liveEditor);
+const MyLiveError = createStyledComponent(LiveError, styles.liveError);
 
 export default function LiveProvider({
   backgroundColor,
@@ -76,7 +95,7 @@ export default function LiveProvider({
         backgroundColor={backgroundColor}
         chromeless={chromeless}
       />
-      {!hideSource && [<MyLiveEditor key={0} />, <LiveError key={1} />]}
+      {!hideSource && [<MyLiveEditor key={0} />, <MyLiveError key={1} />]}
     </ReactLiveProvider>
   );
 }


### PR DESCRIPTION
### Description

Fix regression in website code example error display

### Motivation and context

closes #418 

### Screenshots, videos, or demo, if appropriate

https://418-live-error-styles--mineral-ui.netlify.com/

<img width="563" alt="screen shot 2017-10-17 at 2 34 18 pm" src="https://user-images.githubusercontent.com/202773/31688047-4da966b8-b348-11e7-9aaf-90b011df6e76.png">

### How to test

1. Go to any code example in the website
1. Add a semicolon in the middle of a tag - in order to throw a syntax error
1. The error message should be nicely formatted and readable underneath the code example, simlar to that shown in the screenshot above

### Types of changes

- Other (provide details below)

bug fix to the website, so... chore

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**

