### PR TITLE
[Popover][Dropdown]: Improve a11y

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -18,7 +18,7 @@
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { generateId } from '../utils';
-import Root, { PopoverTrigger as DropdownTrigger } from '../Popover';
+import Root from '../Popover';
 import DropdownContent from './DropdownContent';
 
 type Item = {
@@ -119,20 +119,9 @@ export default class Dropdown extends Component<Props, State> {
           : `${this.id}-menuItem-${this.state.highlightedIndex}`;
     }
 
-    const contentId = `${this.id}-dropdownContent`;
-
-    const dropdownTriggerProps = {
-      'aria-activedescendant': this.selectedItemId,
-      'aria-haspopup': true,
-      children,
-      contentId,
-      isOpen,
-      onKeyDown: this.onTriggerKeyDown
-    };
-
     const dropdownContentProps = {
       data,
-      id: contentId,
+      id: `${this.id}-dropdownContent`,
       getItemProps: this.getItemProps,
       modifiers,
       placement,
@@ -142,13 +131,12 @@ export default class Dropdown extends Component<Props, State> {
     const rootProps = {
       id: this.id,
       ...restProps,
-      autoFocus: false,
       content: <DropdownContent {...dropdownContentProps} />,
+      getTriggerProps: this.getTriggerProps,
       isOpen,
       onClose: this.close,
       onOpen: this.open,
-      trigger: <DropdownTrigger {...dropdownTriggerProps} />,
-      triggerRef: node => {
+      triggerRef: (node: ?React$Component<*, *>) => {
         this.dropdownTrigger = node;
       },
       wrapContent: false
@@ -156,6 +144,21 @@ export default class Dropdown extends Component<Props, State> {
 
     return <Root {...rootProps}>{children}</Root>;
   }
+
+  getTriggerProps = (props: Object) => {
+    const contentId = `${this.id}-dropdownContent`;
+    const { isOpen } = props;
+
+    return {
+      ...props,
+      'aria-activedescendant': isOpen
+        ? this.selectedItemId || `${contentId}-menu`
+        : undefined,
+      'aria-haspopup': true,
+      contentId,
+      onKeyDown: this.onTriggerKeyDown
+    };
+  };
 
   getItems = () => {
     return this.props.data.reduce((acc, group) => {
@@ -246,11 +249,12 @@ export default class Dropdown extends Component<Props, State> {
 
     return {
       ...props,
+      'aria-disabled': props.disabled,
       id: `${this.id}-menuItem-${index}`,
       isHighlighted: this.state.highlightedIndex === index,
       onClick: this.itemOnClick.bind(null, item),
       role: 'menuitem',
-      tabIndex: null
+      tabIndex: null // Unset tabIndex because we use arrow keys to navigate instead
     };
   };
 

--- a/src/Dropdown/DropdownContent.js
+++ b/src/Dropdown/DropdownContent.js
@@ -25,6 +25,8 @@ type Props = {
   getItemProps?: (props: Object, scope: Object) => Object,
   /** Data from which the [Menu](../menu#data) will be constructed */
   data: Array<Object>,
+  /** Id of the Dropdown content */
+  id: string,
   /** Plugins that are used to alter behavior. See https://popper.js.org/popper-documentation.html#modifiers */
   modifiers?: Object,
   /** Placement of the dropdown */
@@ -98,15 +100,24 @@ export default class DropdownContent extends Component<Props> {
   props: Props;
 
   render() {
-    const { data, getItemProps, placement, wide, ...restProps } = this.props;
+    const {
+      data,
+      getItemProps,
+      id,
+      placement,
+      wide,
+      ...restProps
+    } = this.props;
 
     const rootProps = {
+      id,
       placement,
       wide,
       ...restProps
     };
 
     const menuProps = {
+      id: `${id}-menu`,
       data,
       getItemProps,
       role: 'menu'

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -359,7 +359,6 @@ exports[`Dropdown demo examples basic 1`] = `
               placement="bottom-start"
             >
               <Popover
-                autoFocus={false}
                 content={
                   <DropdownContent
                     data={
@@ -389,50 +388,35 @@ exports[`Dropdown demo examples basic 1`] = `
                     wide={undefined}
                   />
                 }
+                getTriggerProps={[Function]}
                 hasArrow={true}
                 id="dropdown-42"
                 isOpen={false}
                 onClose={[Function]}
                 onOpen={[Function]}
                 placement="bottom"
-                trigger={
-                  <PopoverTrigger
-                    aria-activedescendant={undefined}
-                    aria-haspopup={true}
-                    contentId="dropdown-42-dropdownContent"
-                    isOpen={false}
-                    onKeyDown={[Function]}
-                  >
-                    <Button>
-                      Menu
-                    </Button>
-                  </PopoverTrigger>
-                }
                 triggerRef={[Function]}
                 wrapContent={false}
               >
                 <Popover
-                  autoFocus={false}
                   id="dropdown-42"
                   isOpen={false}
                   onClose={[Function]}
                   onOpen={[Function]}
                 >
                   <Manager
-                    autoFocus={false}
                     className="glamor-5"
                     id="dropdown-42"
                     tag="div"
                   >
                     <div
-                      autoFocus={false}
                       className="glamor-5"
                       id="dropdown-42"
                     >
                       <PopoverTrigger
                         aria-activedescendant={undefined}
                         aria-haspopup={true}
-                        contentId="popover-43-popoverContent"
+                        contentId="dropdown-42-dropdownContent"
                         disabled={undefined}
                         isOpen={false}
                         onClick={[Function]}
@@ -447,10 +431,11 @@ exports[`Dropdown demo examples basic 1`] = `
                             >
                               <Button
                                 aria-activedescendant={undefined}
-                                aria-describedby="popover-43-popoverContent"
+                                aria-describedby="dropdown-42-dropdownContent"
                                 aria-disabled={undefined}
                                 aria-expanded={false}
                                 aria-haspopup={true}
+                                aria-owns="dropdown-42-dropdownContent"
                                 disabled={undefined}
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
@@ -458,10 +443,11 @@ exports[`Dropdown demo examples basic 1`] = `
                               >
                                 <glamorous(button)
                                   aria-activedescendant={undefined}
-                                  aria-describedby="popover-43-popoverContent"
+                                  aria-describedby="dropdown-42-dropdownContent"
                                   aria-disabled={undefined}
                                   aria-expanded={false}
                                   aria-haspopup={true}
+                                  aria-owns="dropdown-42-dropdownContent"
                                   disabled={undefined}
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
@@ -473,10 +459,11 @@ exports[`Dropdown demo examples basic 1`] = `
                                 >
                                   <button
                                     aria-activedescendant={undefined}
-                                    aria-describedby="popover-43-popoverContent"
+                                    aria-describedby="dropdown-42-dropdownContent"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup={true}
+                                    aria-owns="dropdown-42-dropdownContent"
                                     className="glamor-2"
                                     disabled={undefined}
                                     onClick={[Function]}
@@ -961,7 +948,6 @@ exports[`Dropdown demo examples controlled 1`] = `
                     placement="bottom-start"
                   >
                     <Popover
-                      autoFocus={false}
                       content={
                         <DropdownContent
                           data={
@@ -991,50 +977,35 @@ exports[`Dropdown demo examples controlled 1`] = `
                           wide={undefined}
                         />
                       }
+                      getTriggerProps={[Function]}
                       hasArrow={true}
                       id="dropdown-56"
                       isOpen={false}
                       onClose={[Function]}
                       onOpen={[Function]}
                       placement="bottom"
-                      trigger={
-                        <PopoverTrigger
-                          aria-activedescendant={undefined}
-                          aria-haspopup={true}
-                          contentId="dropdown-56-dropdownContent"
-                          isOpen={false}
-                          onKeyDown={[Function]}
-                        >
-                          <Button>
-                            Open Dropdown
-                          </Button>
-                        </PopoverTrigger>
-                      }
                       triggerRef={[Function]}
                       wrapContent={false}
                     >
                       <Popover
-                        autoFocus={false}
                         id="dropdown-56"
                         isOpen={false}
                         onClose={[Function]}
                         onOpen={[Function]}
                       >
                         <Manager
-                          autoFocus={false}
                           className="glamor-5"
                           id="dropdown-56"
                           tag="div"
                         >
                           <div
-                            autoFocus={false}
                             className="glamor-5"
                             id="dropdown-56"
                           >
                             <PopoverTrigger
                               aria-activedescendant={undefined}
                               aria-haspopup={true}
-                              contentId="popover-57-popoverContent"
+                              contentId="dropdown-56-dropdownContent"
                               disabled={undefined}
                               isOpen={false}
                               onClick={[Function]}
@@ -1049,10 +1020,11 @@ exports[`Dropdown demo examples controlled 1`] = `
                                   >
                                     <Button
                                       aria-activedescendant={undefined}
-                                      aria-describedby="popover-57-popoverContent"
+                                      aria-describedby="dropdown-56-dropdownContent"
                                       aria-disabled={undefined}
                                       aria-expanded={false}
                                       aria-haspopup={true}
+                                      aria-owns="dropdown-56-dropdownContent"
                                       disabled={undefined}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
@@ -1060,10 +1032,11 @@ exports[`Dropdown demo examples controlled 1`] = `
                                     >
                                       <glamorous(button)
                                         aria-activedescendant={undefined}
-                                        aria-describedby="popover-57-popoverContent"
+                                        aria-describedby="dropdown-56-dropdownContent"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup={true}
+                                        aria-owns="dropdown-56-dropdownContent"
                                         disabled={undefined}
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
@@ -1075,10 +1048,11 @@ exports[`Dropdown demo examples controlled 1`] = `
                                       >
                                         <button
                                           aria-activedescendant={undefined}
-                                          aria-describedby="popover-57-popoverContent"
+                                          aria-describedby="dropdown-56-dropdownContent"
                                           aria-disabled={undefined}
                                           aria-expanded={false}
                                           aria-haspopup={true}
+                                          aria-owns="dropdown-56-dropdownContent"
                                           className="glamor-2"
                                           disabled={undefined}
                                           onClick={[Function]}
@@ -1562,7 +1536,6 @@ exports[`Dropdown demo examples data 1`] = `
                 placement="bottom-start"
               >
                 <Popover
-                  autoFocus={false}
                   content={
                     <DropdownContent
                       data={
@@ -1619,50 +1592,35 @@ exports[`Dropdown demo examples data 1`] = `
                       wide={undefined}
                     />
                   }
+                  getTriggerProps={[Function]}
                   hasArrow={true}
                   id="dropdown-44"
                   isOpen={false}
                   onClose={[Function]}
                   onOpen={[Function]}
                   placement="bottom"
-                  trigger={
-                    <PopoverTrigger
-                      aria-activedescendant={undefined}
-                      aria-haspopup={true}
-                      contentId="dropdown-44-dropdownContent"
-                      isOpen={false}
-                      onKeyDown={[Function]}
-                    >
-                      <Button>
-                        Menu
-                      </Button>
-                    </PopoverTrigger>
-                  }
                   triggerRef={[Function]}
                   wrapContent={false}
                 >
                   <Popover
-                    autoFocus={false}
                     id="dropdown-44"
                     isOpen={false}
                     onClose={[Function]}
                     onOpen={[Function]}
                   >
                     <Manager
-                      autoFocus={false}
                       className="glamor-5"
                       id="dropdown-44"
                       tag="div"
                     >
                       <div
-                        autoFocus={false}
                         className="glamor-5"
                         id="dropdown-44"
                       >
                         <PopoverTrigger
                           aria-activedescendant={undefined}
                           aria-haspopup={true}
-                          contentId="popover-45-popoverContent"
+                          contentId="dropdown-44-dropdownContent"
                           disabled={undefined}
                           isOpen={false}
                           onClick={[Function]}
@@ -1677,10 +1635,11 @@ exports[`Dropdown demo examples data 1`] = `
                               >
                                 <Button
                                   aria-activedescendant={undefined}
-                                  aria-describedby="popover-45-popoverContent"
+                                  aria-describedby="dropdown-44-dropdownContent"
                                   aria-disabled={undefined}
                                   aria-expanded={false}
                                   aria-haspopup={true}
+                                  aria-owns="dropdown-44-dropdownContent"
                                   disabled={undefined}
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
@@ -1688,10 +1647,11 @@ exports[`Dropdown demo examples data 1`] = `
                                 >
                                   <glamorous(button)
                                     aria-activedescendant={undefined}
-                                    aria-describedby="popover-45-popoverContent"
+                                    aria-describedby="dropdown-44-dropdownContent"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup={true}
+                                    aria-owns="dropdown-44-dropdownContent"
                                     disabled={undefined}
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
@@ -1703,10 +1663,11 @@ exports[`Dropdown demo examples data 1`] = `
                                   >
                                     <button
                                       aria-activedescendant={undefined}
-                                      aria-describedby="popover-45-popoverContent"
+                                      aria-describedby="dropdown-44-dropdownContent"
                                       aria-disabled={undefined}
                                       aria-expanded={false}
                                       aria-haspopup={true}
+                                      aria-owns="dropdown-44-dropdownContent"
                                       className="glamor-2"
                                       disabled={undefined}
                                       onClick={[Function]}
@@ -2096,7 +2057,6 @@ exports[`Dropdown demo examples disabled 1`] = `
               placement="bottom-start"
             >
               <Popover
-                autoFocus={false}
                 content={
                   <DropdownContent
                     data={
@@ -2127,50 +2087,35 @@ exports[`Dropdown demo examples disabled 1`] = `
                   />
                 }
                 disabled={true}
+                getTriggerProps={[Function]}
                 hasArrow={true}
                 id="dropdown-54"
                 isOpen={false}
                 onClose={[Function]}
                 onOpen={[Function]}
                 placement="bottom"
-                trigger={
-                  <PopoverTrigger
-                    aria-activedescendant={undefined}
-                    aria-haspopup={true}
-                    contentId="dropdown-54-dropdownContent"
-                    isOpen={false}
-                    onKeyDown={[Function]}
-                  >
-                    <Button>
-                      Menu
-                    </Button>
-                  </PopoverTrigger>
-                }
                 triggerRef={[Function]}
                 wrapContent={false}
               >
                 <Popover
-                  autoFocus={false}
                   id="dropdown-54"
                   isOpen={false}
                   onClose={[Function]}
                   onOpen={[Function]}
                 >
                   <Manager
-                    autoFocus={false}
                     className="glamor-5"
                     id="dropdown-54"
                     tag="div"
                   >
                     <div
-                      autoFocus={false}
                       className="glamor-5"
                       id="dropdown-54"
                     >
                       <PopoverTrigger
                         aria-activedescendant={undefined}
                         aria-haspopup={true}
-                        contentId="popover-55-popoverContent"
+                        contentId="dropdown-54-dropdownContent"
                         disabled={true}
                         isOpen={false}
                         onClick={undefined}
@@ -2185,10 +2130,11 @@ exports[`Dropdown demo examples disabled 1`] = `
                             >
                               <Button
                                 aria-activedescendant={undefined}
-                                aria-describedby="popover-55-popoverContent"
+                                aria-describedby="dropdown-54-dropdownContent"
                                 aria-disabled={true}
                                 aria-expanded={false}
                                 aria-haspopup={true}
+                                aria-owns="dropdown-54-dropdownContent"
                                 disabled={true}
                                 onClick={undefined}
                                 onKeyDown={[Function]}
@@ -2196,10 +2142,11 @@ exports[`Dropdown demo examples disabled 1`] = `
                               >
                                 <glamorous(button)
                                   aria-activedescendant={undefined}
-                                  aria-describedby="popover-55-popoverContent"
+                                  aria-describedby="dropdown-54-dropdownContent"
                                   aria-disabled={true}
                                   aria-expanded={false}
                                   aria-haspopup={true}
+                                  aria-owns="dropdown-54-dropdownContent"
                                   disabled={true}
                                   onClick={undefined}
                                   onKeyDown={[Function]}
@@ -2211,10 +2158,11 @@ exports[`Dropdown demo examples disabled 1`] = `
                                 >
                                   <button
                                     aria-activedescendant={undefined}
-                                    aria-describedby="popover-55-popoverContent"
+                                    aria-describedby="dropdown-54-dropdownContent"
                                     aria-disabled={true}
                                     aria-expanded={false}
                                     aria-haspopup={true}
+                                    aria-owns="dropdown-54-dropdownContent"
                                     className="glamor-2"
                                     disabled={true}
                                     onClick={undefined}
@@ -2631,7 +2579,6 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                 placement="bottom-start"
               >
                 <Popover
-                  autoFocus={false}
                   content={
                     <DropdownContent
                       data={
@@ -2661,50 +2608,35 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                       wide={undefined}
                     />
                   }
+                  getTriggerProps={[Function]}
                   hasArrow={true}
                   id="dropdown-52"
                   isOpen={false}
                   onClose={[Function]}
                   onOpen={[Function]}
                   placement="bottom"
-                  trigger={
-                    <PopoverTrigger
-                      aria-activedescendant={undefined}
-                      aria-haspopup={true}
-                      contentId="dropdown-52-dropdownContent"
-                      isOpen={false}
-                      onKeyDown={[Function]}
-                    >
-                      <Button>
-                        Menu
-                      </Button>
-                    </PopoverTrigger>
-                  }
                   triggerRef={[Function]}
                   wrapContent={false}
                 >
                   <Popover
-                    autoFocus={false}
                     id="dropdown-52"
                     isOpen={false}
                     onClose={[Function]}
                     onOpen={[Function]}
                   >
                     <Manager
-                      autoFocus={false}
                       className="glamor-5"
                       id="dropdown-52"
                       tag="div"
                     >
                       <div
-                        autoFocus={false}
                         className="glamor-5"
                         id="dropdown-52"
                       >
                         <PopoverTrigger
                           aria-activedescendant={undefined}
                           aria-haspopup={true}
-                          contentId="popover-53-popoverContent"
+                          contentId="dropdown-52-dropdownContent"
                           disabled={undefined}
                           isOpen={false}
                           onClick={[Function]}
@@ -2719,10 +2651,11 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                               >
                                 <Button
                                   aria-activedescendant={undefined}
-                                  aria-describedby="popover-53-popoverContent"
+                                  aria-describedby="dropdown-52-dropdownContent"
                                   aria-disabled={undefined}
                                   aria-expanded={false}
                                   aria-haspopup={true}
+                                  aria-owns="dropdown-52-dropdownContent"
                                   disabled={undefined}
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
@@ -2730,10 +2663,11 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                                 >
                                   <glamorous(button)
                                     aria-activedescendant={undefined}
-                                    aria-describedby="popover-53-popoverContent"
+                                    aria-describedby="dropdown-52-dropdownContent"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup={true}
+                                    aria-owns="dropdown-52-dropdownContent"
                                     disabled={undefined}
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
@@ -2745,10 +2679,11 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                                   >
                                     <button
                                       aria-activedescendant={undefined}
-                                      aria-describedby="popover-53-popoverContent"
+                                      aria-describedby="dropdown-52-dropdownContent"
                                       aria-disabled={undefined}
                                       aria-expanded={false}
                                       aria-haspopup={true}
+                                      aria-owns="dropdown-52-dropdownContent"
                                       className="glamor-2"
                                       disabled={undefined}
                                       onClick={[Function]}
@@ -2963,29 +2898,6 @@ exports[`Dropdown demo examples placement 1`] = `
   word-break: break-word;
 }
 
-.glamor-1,
-[data-glamor-1] {
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -moz-inline-box;
-  display: -ms-inline-flexbox;
-  display: -webkit-inline-flex;
-  display: inline-flex;
-  justify-content: center;
-  max-height: 100%;
-  width: 100%;
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-}
-
-.glamor-31,
-[data-glamor-31] {
-  height: 400px;
-  position: relative;
-}
-
 .glamor-2,
 [data-glamor-2] {
   box-sizing: border-box;
@@ -3001,8 +2913,8 @@ exports[`Dropdown demo examples placement 1`] = `
   border-width: 1px;
   cursor: pointer;
   font-weight: 600;
-  height: 3.25em;
-  min-width: 3.25em;
+  height: 2.5em;
+  min-width: 2.5em;
   padding: 0 0.5em;
   vertical-align: middle;
 }
@@ -3068,6 +2980,23 @@ exports[`Dropdown demo examples placement 1`] = `
   margin: 0;
 }
 
+.glamor-1,
+[data-glamor-1] {
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  justify-content: center;
+  max-height: 100%;
+  width: 100%;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+}
+
 .glamor-0,
 [data-glamor-0] {
   display: block;
@@ -3077,7 +3006,7 @@ exports[`Dropdown demo examples placement 1`] = `
   white-space: nowrap;
   word-wrap: normal;
   font-size: 0.875em;
-  line-height: 3.7142857142857144em;
+  line-height: 2.857142857142857em;
 }
 
 .glamor-0:first-child,
@@ -3092,6 +3021,12 @@ exports[`Dropdown demo examples placement 1`] = `
 .glamor-0[data-simulate-lastchild],
 [data-glamor-0][data-simulate-lastchild] {
   padding-right: 0.5714285714285714em;
+}
+
+.glamor-31,
+[data-glamor-31] {
+  height: 400px;
+  position: relative;
 }
 
 <ThemeProvider>
@@ -3238,8 +3173,11 @@ exports[`Dropdown demo examples placement 1`] = `
     <LiveProvider
       code="
     <DemoLayout>
-      <Dropdown placement=\\"bottom-start\\" data={data} isOpen={true}>
-        <Button size=\\"jumbo\\" disabled>Menu</Button>
+      <Dropdown
+        placement=\\"bottom-start\\"
+        data={data}
+        isOpen>
+        <Button>Menu</Button>
       </Dropdown>
     </DemoLayout>"
       mountStylesheet={false}
@@ -3331,7 +3269,6 @@ exports[`Dropdown demo examples placement 1`] = `
                   placement="bottom-start"
                 >
                   <Popover
-                    autoFocus={false}
                     content={
                       <DropdownContent
                         data={
@@ -3361,53 +3298,35 @@ exports[`Dropdown demo examples placement 1`] = `
                         wide={undefined}
                       />
                     }
+                    getTriggerProps={[Function]}
                     hasArrow={true}
                     id="dropdown-48"
                     isOpen={true}
                     onClose={[Function]}
                     onOpen={[Function]}
                     placement="bottom"
-                    trigger={
-                      <PopoverTrigger
-                        aria-activedescendant={undefined}
-                        aria-haspopup={true}
-                        contentId="dropdown-48-dropdownContent"
-                        isOpen={true}
-                        onKeyDown={[Function]}
-                      >
-                        <Button
-                          disabled={true}
-                          size="jumbo"
-                        >
-                          Menu
-                        </Button>
-                      </PopoverTrigger>
-                    }
                     triggerRef={[Function]}
                     wrapContent={false}
                   >
                     <Popover
-                      autoFocus={false}
                       id="dropdown-48"
                       isOpen={true}
                       onClose={[Function]}
                       onOpen={[Function]}
                     >
                       <Manager
-                        autoFocus={false}
                         className="glamor-29"
                         id="dropdown-48"
                         tag="div"
                       >
                         <div
-                          autoFocus={false}
                           className="glamor-29"
                           id="dropdown-48"
                         >
                           <PopoverTrigger
-                            aria-activedescendant={undefined}
+                            aria-activedescendant="dropdown-48-dropdownContent-menu"
                             aria-haspopup={true}
-                            contentId="popover-49-popoverContent"
+                            contentId="dropdown-48-dropdownContent"
                             disabled={undefined}
                             isOpen={true}
                             onClick={[Function]}
@@ -3421,38 +3340,40 @@ exports[`Dropdown demo examples placement 1`] = `
                                   className="glamor-3"
                                 >
                                   <Button
-                                    aria-activedescendant={undefined}
-                                    aria-describedby="popover-49-popoverContent"
+                                    aria-activedescendant="dropdown-48-dropdownContent-menu"
+                                    aria-describedby="dropdown-48-dropdownContent"
                                     aria-disabled={undefined}
                                     aria-expanded={true}
                                     aria-haspopup={true}
+                                    aria-owns="dropdown-48-dropdownContent"
                                     disabled={undefined}
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="button"
-                                    size="jumbo"
                                   >
                                     <glamorous(button)
-                                      aria-activedescendant={undefined}
-                                      aria-describedby="popover-49-popoverContent"
+                                      aria-activedescendant="dropdown-48-dropdownContent-menu"
+                                      aria-describedby="dropdown-48-dropdownContent"
                                       aria-disabled={undefined}
                                       aria-expanded={true}
                                       aria-haspopup={true}
+                                      aria-owns="dropdown-48-dropdownContent"
                                       disabled={undefined}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       role="button"
-                                      size="jumbo"
+                                      size="large"
                                       text="Menu"
                                       type="button"
                                       variant="regular"
                                     >
                                       <button
-                                        aria-activedescendant={undefined}
-                                        aria-describedby="popover-49-popoverContent"
+                                        aria-activedescendant="dropdown-48-dropdownContent-menu"
+                                        aria-describedby="dropdown-48-dropdownContent"
                                         aria-disabled={undefined}
                                         aria-expanded={true}
                                         aria-haspopup={true}
+                                        aria-owns="dropdown-48-dropdownContent"
                                         className="glamor-2"
                                         disabled={undefined}
                                         onClick={[Function]}
@@ -3465,7 +3386,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                             className="glamor-1"
                                           >
                                             <glamorous(span)
-                                              size="jumbo"
+                                              size="large"
                                             >
                                               <span
                                                 className="glamor-0"
@@ -3558,13 +3479,16 @@ exports[`Dropdown demo examples placement 1`] = `
                                       ]
                                     }
                                     getItemProps={[Function]}
+                                    id="dropdown-48-dropdownContent-menu"
                                     role="menu"
                                   >
                                     <Menu
+                                      id="dropdown-48-dropdownContent-menu"
                                       role="menu"
                                     >
                                       <div
                                         className="glamor-26"
+                                        id="dropdown-48-dropdownContent-menu"
                                         role="menu"
                                       >
                                         <MenuGroup
@@ -3576,6 +3500,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                               className="glamor-25"
                                             >
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-48-menuItem-0"
                                                 isHighlighted={false}
                                                 item={
@@ -3589,6 +3514,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-48-menuItem-0"
                                                   isHighlighted={false}
@@ -3604,6 +3530,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-48-menuItem-0"
                                                     onClick={[Function]}
@@ -3639,6 +3566,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 </MenuItem>
                                               </MenuItem>
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-48-menuItem-1"
                                                 isHighlighted={false}
                                                 item={
@@ -3652,6 +3580,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-48-menuItem-1"
                                                   isHighlighted={false}
@@ -3667,6 +3596,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-48-menuItem-1"
                                                     onClick={[Function]}
@@ -3702,6 +3632,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 </MenuItem>
                                               </MenuItem>
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-48-menuItem-2"
                                                 isHighlighted={false}
                                                 item={
@@ -3715,6 +3646,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-48-menuItem-2"
                                                   isHighlighted={false}
@@ -3730,6 +3662,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-48-menuItem-2"
                                                     onClick={[Function]}
@@ -3765,6 +3698,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 </MenuItem>
                                               </MenuItem>
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-48-menuItem-3"
                                                 isHighlighted={false}
                                                 item={
@@ -3778,6 +3712,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-48-menuItem-3"
                                                   isHighlighted={false}
@@ -3793,6 +3728,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-48-menuItem-3"
                                                     onClick={[Function]}
@@ -3837,6 +3773,24 @@ exports[`Dropdown demo examples placement 1`] = `
                               </Popper>
                             </DropdownContent>
                           </DropdownContent>
+                          <EventListener
+                            listeners={
+                              Array [
+                                Object {
+                                  "event": "click",
+                                  "handler": [Function],
+                                  "options": true,
+                                  "target": "document",
+                                },
+                                Object {
+                                  "event": "keydown",
+                                  "handler": [Function],
+                                  "options": true,
+                                  "target": "document",
+                                },
+                              ]
+                            }
+                          />
                         </div>
                       </Manager>
                     </Popover>
@@ -4416,8 +4370,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
       <Dropdown
         data={data}
         isOpen
-        placement=\\"bottom-start\\"
-        restoreFocus={false}>
+        placement=\\"bottom-start\\">
         <Button>Menu</Button>
       </Dropdown>
     </ScrollParent>
@@ -4525,10 +4478,8 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                             }
                             isOpen={true}
                             placement="bottom-start"
-                            restoreFocus={false}
                           >
                             <Popover
-                              autoFocus={false}
                               content={
                                 <DropdownContent
                                   data={
@@ -4558,52 +4509,35 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                   wide={undefined}
                                 />
                               }
+                              getTriggerProps={[Function]}
                               hasArrow={true}
                               id="dropdown-50"
                               isOpen={true}
                               onClose={[Function]}
                               onOpen={[Function]}
                               placement="bottom"
-                              restoreFocus={false}
-                              trigger={
-                                <PopoverTrigger
-                                  aria-activedescendant={undefined}
-                                  aria-haspopup={true}
-                                  contentId="dropdown-50-dropdownContent"
-                                  isOpen={true}
-                                  onKeyDown={[Function]}
-                                >
-                                  <Button>
-                                    Menu
-                                  </Button>
-                                </PopoverTrigger>
-                              }
                               triggerRef={[Function]}
                               wrapContent={false}
                             >
                               <Popover
-                                autoFocus={false}
                                 id="dropdown-50"
                                 isOpen={true}
                                 onClose={[Function]}
                                 onOpen={[Function]}
-                                restoreFocus={false}
                               >
                                 <Manager
-                                  autoFocus={false}
                                   className="glamor-29"
                                   id="dropdown-50"
                                   tag="div"
                                 >
                                   <div
-                                    autoFocus={false}
                                     className="glamor-29"
                                     id="dropdown-50"
                                   >
                                     <PopoverTrigger
-                                      aria-activedescendant={undefined}
+                                      aria-activedescendant="dropdown-50-dropdownContent-menu"
                                       aria-haspopup={true}
-                                      contentId="popover-51-popoverContent"
+                                      contentId="dropdown-50-dropdownContent"
                                       disabled={undefined}
                                       isOpen={true}
                                       onClick={[Function]}
@@ -4617,22 +4551,24 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                             className="glamor-3"
                                           >
                                             <Button
-                                              aria-activedescendant={undefined}
-                                              aria-describedby="popover-51-popoverContent"
+                                              aria-activedescendant="dropdown-50-dropdownContent-menu"
+                                              aria-describedby="dropdown-50-dropdownContent"
                                               aria-disabled={undefined}
                                               aria-expanded={true}
                                               aria-haspopup={true}
+                                              aria-owns="dropdown-50-dropdownContent"
                                               disabled={undefined}
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
                                               role="button"
                                             >
                                               <glamorous(button)
-                                                aria-activedescendant={undefined}
-                                                aria-describedby="popover-51-popoverContent"
+                                                aria-activedescendant="dropdown-50-dropdownContent-menu"
+                                                aria-describedby="dropdown-50-dropdownContent"
                                                 aria-disabled={undefined}
                                                 aria-expanded={true}
                                                 aria-haspopup={true}
+                                                aria-owns="dropdown-50-dropdownContent"
                                                 disabled={undefined}
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -4643,11 +4579,12 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                 variant="regular"
                                               >
                                                 <button
-                                                  aria-activedescendant={undefined}
-                                                  aria-describedby="popover-51-popoverContent"
+                                                  aria-activedescendant="dropdown-50-dropdownContent-menu"
+                                                  aria-describedby="dropdown-50-dropdownContent"
                                                   aria-disabled={undefined}
                                                   aria-expanded={true}
                                                   aria-haspopup={true}
+                                                  aria-owns="dropdown-50-dropdownContent"
                                                   className="glamor-2"
                                                   disabled={undefined}
                                                   onClick={[Function]}
@@ -4753,13 +4690,16 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                 ]
                                               }
                                               getItemProps={[Function]}
+                                              id="dropdown-50-dropdownContent-menu"
                                               role="menu"
                                             >
                                               <Menu
+                                                id="dropdown-50-dropdownContent-menu"
                                                 role="menu"
                                               >
                                                 <div
                                                   className="glamor-26"
+                                                  id="dropdown-50-dropdownContent-menu"
                                                   role="menu"
                                                 >
                                                   <MenuGroup
@@ -4771,6 +4711,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                         className="glamor-25"
                                                       >
                                                         <MenuItem
+                                                          aria-disabled={undefined}
                                                           id="dropdown-50-menuItem-0"
                                                           isHighlighted={false}
                                                           item={
@@ -4784,6 +4725,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           tabIndex={null}
                                                         >
                                                           <MenuItem
+                                                            aria-disabled={undefined}
                                                             disabled={undefined}
                                                             id="dropdown-50-menuItem-0"
                                                             isHighlighted={false}
@@ -4799,6 +4741,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                             variant="regular"
                                                           >
                                                             <div
+                                                              aria-disabled={undefined}
                                                               className="glamor-9"
                                                               id="dropdown-50-menuItem-0"
                                                               onClick={[Function]}
@@ -4834,6 +4777,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           </MenuItem>
                                                         </MenuItem>
                                                         <MenuItem
+                                                          aria-disabled={undefined}
                                                           id="dropdown-50-menuItem-1"
                                                           isHighlighted={false}
                                                           item={
@@ -4847,6 +4791,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           tabIndex={null}
                                                         >
                                                           <MenuItem
+                                                            aria-disabled={undefined}
                                                             disabled={undefined}
                                                             id="dropdown-50-menuItem-1"
                                                             isHighlighted={false}
@@ -4862,6 +4807,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                             variant="regular"
                                                           >
                                                             <div
+                                                              aria-disabled={undefined}
                                                               className="glamor-9"
                                                               id="dropdown-50-menuItem-1"
                                                               onClick={[Function]}
@@ -4897,6 +4843,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           </MenuItem>
                                                         </MenuItem>
                                                         <MenuItem
+                                                          aria-disabled={undefined}
                                                           id="dropdown-50-menuItem-2"
                                                           isHighlighted={false}
                                                           item={
@@ -4910,6 +4857,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           tabIndex={null}
                                                         >
                                                           <MenuItem
+                                                            aria-disabled={undefined}
                                                             disabled={undefined}
                                                             id="dropdown-50-menuItem-2"
                                                             isHighlighted={false}
@@ -4925,6 +4873,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                             variant="regular"
                                                           >
                                                             <div
+                                                              aria-disabled={undefined}
                                                               className="glamor-9"
                                                               id="dropdown-50-menuItem-2"
                                                               onClick={[Function]}
@@ -4960,6 +4909,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           </MenuItem>
                                                         </MenuItem>
                                                         <MenuItem
+                                                          aria-disabled={undefined}
                                                           id="dropdown-50-menuItem-3"
                                                           isHighlighted={false}
                                                           item={
@@ -4973,6 +4923,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                           tabIndex={null}
                                                         >
                                                           <MenuItem
+                                                            aria-disabled={undefined}
                                                             disabled={undefined}
                                                             id="dropdown-50-menuItem-3"
                                                             isHighlighted={false}
@@ -4988,6 +4939,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                             variant="regular"
                                                           >
                                                             <div
+                                                              aria-disabled={undefined}
                                                               className="glamor-9"
                                                               id="dropdown-50-menuItem-3"
                                                               onClick={[Function]}
@@ -5032,6 +4984,24 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                         </Popper>
                                       </DropdownContent>
                                     </DropdownContent>
+                                    <EventListener
+                                      listeners={
+                                        Array [
+                                          Object {
+                                            "event": "click",
+                                            "handler": [Function],
+                                            "options": true,
+                                            "target": "document",
+                                          },
+                                          Object {
+                                            "event": "keydown",
+                                            "handler": [Function],
+                                            "options": true,
+                                            "target": "document",
+                                          },
+                                        ]
+                                      }
+                                    />
                                   </div>
                                 </Manager>
                               </Popover>
@@ -5541,8 +5511,8 @@ exports[`Dropdown demo examples wide 1`] = `
     <LiveProvider
       code="
     <DemoLayout>
-      <Dropdown wide data={data} isOpen={true}>
-        <Button disabled>Menu</Button>
+      <Dropdown wide isOpen data={data}>
+        <Button>Menu</Button>
       </Dropdown>
     </DemoLayout>"
       mountStylesheet={false}
@@ -5635,7 +5605,6 @@ exports[`Dropdown demo examples wide 1`] = `
                   wide={true}
                 >
                   <Popover
-                    autoFocus={false}
                     content={
                       <DropdownContent
                         data={
@@ -5665,52 +5634,35 @@ exports[`Dropdown demo examples wide 1`] = `
                         wide={true}
                       />
                     }
+                    getTriggerProps={[Function]}
                     hasArrow={true}
                     id="dropdown-46"
                     isOpen={true}
                     onClose={[Function]}
                     onOpen={[Function]}
                     placement="bottom"
-                    trigger={
-                      <PopoverTrigger
-                        aria-activedescendant={undefined}
-                        aria-haspopup={true}
-                        contentId="dropdown-46-dropdownContent"
-                        isOpen={true}
-                        onKeyDown={[Function]}
-                      >
-                        <Button
-                          disabled={true}
-                        >
-                          Menu
-                        </Button>
-                      </PopoverTrigger>
-                    }
                     triggerRef={[Function]}
                     wrapContent={false}
                   >
                     <Popover
-                      autoFocus={false}
                       id="dropdown-46"
                       isOpen={true}
                       onClose={[Function]}
                       onOpen={[Function]}
                     >
                       <Manager
-                        autoFocus={false}
                         className="glamor-29"
                         id="dropdown-46"
                         tag="div"
                       >
                         <div
-                          autoFocus={false}
                           className="glamor-29"
                           id="dropdown-46"
                         >
                           <PopoverTrigger
-                            aria-activedescendant={undefined}
+                            aria-activedescendant="dropdown-46-dropdownContent-menu"
                             aria-haspopup={true}
-                            contentId="popover-47-popoverContent"
+                            contentId="dropdown-46-dropdownContent"
                             disabled={undefined}
                             isOpen={true}
                             onClick={[Function]}
@@ -5724,22 +5676,24 @@ exports[`Dropdown demo examples wide 1`] = `
                                   className="glamor-3"
                                 >
                                   <Button
-                                    aria-activedescendant={undefined}
-                                    aria-describedby="popover-47-popoverContent"
+                                    aria-activedescendant="dropdown-46-dropdownContent-menu"
+                                    aria-describedby="dropdown-46-dropdownContent"
                                     aria-disabled={undefined}
                                     aria-expanded={true}
                                     aria-haspopup={true}
+                                    aria-owns="dropdown-46-dropdownContent"
                                     disabled={undefined}
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="button"
                                   >
                                     <glamorous(button)
-                                      aria-activedescendant={undefined}
-                                      aria-describedby="popover-47-popoverContent"
+                                      aria-activedescendant="dropdown-46-dropdownContent-menu"
+                                      aria-describedby="dropdown-46-dropdownContent"
                                       aria-disabled={undefined}
                                       aria-expanded={true}
                                       aria-haspopup={true}
+                                      aria-owns="dropdown-46-dropdownContent"
                                       disabled={undefined}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
@@ -5750,11 +5704,12 @@ exports[`Dropdown demo examples wide 1`] = `
                                       variant="regular"
                                     >
                                       <button
-                                        aria-activedescendant={undefined}
-                                        aria-describedby="popover-47-popoverContent"
+                                        aria-activedescendant="dropdown-46-dropdownContent-menu"
+                                        aria-describedby="dropdown-46-dropdownContent"
                                         aria-disabled={undefined}
                                         aria-expanded={true}
                                         aria-haspopup={true}
+                                        aria-owns="dropdown-46-dropdownContent"
                                         className="glamor-2"
                                         disabled={undefined}
                                         onClick={[Function]}
@@ -5860,13 +5815,16 @@ exports[`Dropdown demo examples wide 1`] = `
                                       ]
                                     }
                                     getItemProps={[Function]}
+                                    id="dropdown-46-dropdownContent-menu"
                                     role="menu"
                                   >
                                     <Menu
+                                      id="dropdown-46-dropdownContent-menu"
                                       role="menu"
                                     >
                                       <div
                                         className="glamor-26"
+                                        id="dropdown-46-dropdownContent-menu"
                                         role="menu"
                                       >
                                         <MenuGroup
@@ -5878,6 +5836,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                               className="glamor-25"
                                             >
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-46-menuItem-0"
                                                 isHighlighted={false}
                                                 item={
@@ -5891,6 +5850,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-46-menuItem-0"
                                                   isHighlighted={false}
@@ -5906,6 +5866,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-46-menuItem-0"
                                                     onClick={[Function]}
@@ -5941,6 +5902,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 </MenuItem>
                                               </MenuItem>
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-46-menuItem-1"
                                                 isHighlighted={false}
                                                 item={
@@ -5954,6 +5916,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-46-menuItem-1"
                                                   isHighlighted={false}
@@ -5969,6 +5932,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-46-menuItem-1"
                                                     onClick={[Function]}
@@ -6004,6 +5968,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 </MenuItem>
                                               </MenuItem>
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-46-menuItem-2"
                                                 isHighlighted={false}
                                                 item={
@@ -6017,6 +5982,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-46-menuItem-2"
                                                   isHighlighted={false}
@@ -6032,6 +5998,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-46-menuItem-2"
                                                     onClick={[Function]}
@@ -6067,6 +6034,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 </MenuItem>
                                               </MenuItem>
                                               <MenuItem
+                                                aria-disabled={undefined}
                                                 id="dropdown-46-menuItem-3"
                                                 isHighlighted={false}
                                                 item={
@@ -6080,6 +6048,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                 tabIndex={null}
                                               >
                                                 <MenuItem
+                                                  aria-disabled={undefined}
                                                   disabled={undefined}
                                                   id="dropdown-46-menuItem-3"
                                                   isHighlighted={false}
@@ -6095,6 +6064,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                                   variant="regular"
                                                 >
                                                   <div
+                                                    aria-disabled={undefined}
                                                     className="glamor-9"
                                                     id="dropdown-46-menuItem-3"
                                                     onClick={[Function]}
@@ -6139,6 +6109,24 @@ exports[`Dropdown demo examples wide 1`] = `
                               </Popper>
                             </DropdownContent>
                           </DropdownContent>
+                          <EventListener
+                            listeners={
+                              Array [
+                                Object {
+                                  "event": "click",
+                                  "handler": [Function],
+                                  "options": true,
+                                  "target": "document",
+                                },
+                                Object {
+                                  "event": "keydown",
+                                  "handler": [Function],
+                                  "options": true,
+                                  "target": "document",
+                                },
+                              ]
+                            }
+                          />
                         </div>
                       </Manager>
                     </Popover>

--- a/src/EventListener/EventListener.js
+++ b/src/EventListener/EventListener.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import { Component } from 'react';
+import { canUseDOM, canUseEventListeners } from 'exenv';
+
+type Listener = {
+  /** Target on which to add event listener. Can be a global such as `window` or `document` or any CSS selector */
+  target: string,
+  /** Type of event to listen for, e.g. click */
+  event: string,
+  /** Function called when the event is triggered */
+  handler: Function,
+  /** Options passed to addEventListener/removeEventListener */
+  options?: boolean | Object
+};
+
+type Listeners = Array<Listener>;
+
+type Props = {
+  listeners: Listeners
+};
+
+/** Declarative event listener component */
+export default class EventListener extends Component<Props> {
+  props: Props;
+
+  componentDidMount() {
+    this.addEventListeners();
+  }
+
+  componentWillUpdate() {
+    this.removeEventListeners();
+  }
+
+  componentDidUpdate() {
+    this.addEventListeners();
+  }
+
+  componentWillUnmount() {
+    this.removeEventListeners();
+  }
+
+  render() {
+    return null;
+  }
+
+  getTargetNode(target: string) {
+    if (canUseDOM) {
+      return global[target] || global.document.querySelector(target);
+    }
+  }
+
+  addEventListeners() {
+    if (canUseEventListeners) {
+      this.props.listeners.forEach(
+        ({ target, event, handler, options }: Listener) => {
+          const node = this.getTargetNode(target);
+          node && node.addEventListener(event, handler, options);
+        }
+      );
+    }
+  }
+
+  removeEventListeners() {
+    if (canUseEventListeners) {
+      this.props.listeners.forEach(
+        ({ target, event, handler, options }: Listener) => {
+          const node = this.getTargetNode(target);
+          node && node.removeEventListener(event, handler, options);
+        }
+      );
+    }
+  }
+}

--- a/src/EventListener/__tests__/EventListener.spec.js
+++ b/src/EventListener/__tests__/EventListener.spec.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React from 'react';
+import { shallow } from 'enzyme';
+import EventListener from '../EventListener';
+
+function shallowEventListener(props = {}) {
+  const eventListenerProps = {
+    listeners: [],
+    ...props
+  };
+  return shallow(<EventListener {...eventListenerProps} />, {
+    lifecycleExperimental: true
+  });
+}
+
+function runTargetAssertions(target: string) {
+  let eventListener, onClick, onMouseDown, targetNode;
+
+  beforeEach(() => {
+    onClick = jest.fn();
+    eventListener = shallowEventListener({
+      listeners: [{ target, event: 'click', handler: onClick }]
+    });
+    targetNode = global[target] || global.document.querySelector(target);
+  });
+
+  it('adds listeners to target', () => {
+    const event = new MouseEvent('click');
+    targetNode.dispatchEvent(event);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  describe('when unmounted', () => {
+    it('removes listeners from target', () => {
+      eventListener.unmount();
+
+      const event = new MouseEvent('click');
+      targetNode.dispatchEvent(event);
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when updated', () => {
+    beforeEach(() => {
+      onMouseDown = jest.fn();
+      eventListener = eventListener.setProps({
+        listeners: [{ target, event: 'mousedown', handler: onMouseDown }]
+      });
+    });
+
+    it('removes old listeners from target', () => {
+      const event = new MouseEvent('click');
+      targetNode.dispatchEvent(event);
+
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('adds new listeners to target', () => {
+      const event = new MouseEvent('mousedown');
+      targetNode.dispatchEvent(event);
+
+      expect(onMouseDown).toHaveBeenCalled();
+    });
+  });
+}
+
+describe('EventListener', () => {
+  it('renders', () => {
+    const eventListener = shallowEventListener();
+
+    expect(eventListener.exists()).toEqual(true);
+  });
+
+  describe('when target is a global', () => {
+    runTargetAssertions('document');
+  });
+
+  describe('when target is a CSS selector', () => {
+    runTargetAssertions('body');
+  });
+});

--- a/src/EventListener/index.js
+++ b/src/EventListener/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+export { default } from './EventListener';

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -15,7 +15,7 @@
  */
 
 /* @flow */
-import React, { cloneElement, Component } from 'react';
+import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { canUseEventListeners } from 'exenv';
 import { Manager } from 'react-popper';
@@ -42,6 +42,8 @@ type Props = {
   onOpen?: (event: SyntheticEvent<>) => void,
   /** Open the Popover immediately upon initialization */
   defaultIsOpen?: boolean,
+  /** Function that returns props to be applied to the trigger */
+  getTriggerProps?: (props: Object, scope?: Object) => Object,
   /** Placement of the Popover */
   placement?:
     | 'auto'
@@ -63,10 +65,8 @@ type Props = {
   subtitle?: React$Node,
   /** Title of the Popover */
   title?: React$Node,
-  /** @Private Custom trigger component */
-  trigger?: React$Element<*>,
-  /** @Private Ref for the Popover trigger */
-  triggerRef?: Function,
+  /** @Private ref for the Popover trigger */
+  triggerRef?: (node: ?React$Component<*, *>) => void,
   /** Display the content with default styles */
   wrapContent?: boolean
 };
@@ -120,12 +120,12 @@ export default class Popover extends Component<Props, State> {
       children,
       content,
       disabled,
+      getTriggerProps,
       hasArrow,
       modifiers,
       placement,
       subtitle,
       title,
-      trigger,
       triggerRef,
       wrapContent,
       ...restProps
@@ -142,7 +142,8 @@ export default class Popover extends Component<Props, State> {
       ...restProps
     };
     const contentId = `${this.id}-popoverContent`;
-    const popoverTriggerProps = {
+
+    let popoverTriggerProps = {
       contentId,
       children,
       disabled,
@@ -154,33 +155,34 @@ export default class Popover extends Component<Props, State> {
       }
     };
 
-    const popoverTrigger = trigger ? (
-      cloneElement(trigger, popoverTriggerProps)
-    ) : (
-      <PopoverTrigger {...popoverTriggerProps} />
-    );
+    popoverTriggerProps = {
+      ...popoverTriggerProps,
+      ...(getTriggerProps && getTriggerProps(popoverTriggerProps))
+    };
 
     let popoverContent;
-    if (wrapContent) {
-      const popoverContentProps = {
-        hasArrow,
-        id: contentId,
-        modifiers,
-        placement,
-        subtitle,
-        title
-      };
+    if (isOpen) {
+      if (wrapContent) {
+        const popoverContentProps = {
+          hasArrow,
+          id: contentId,
+          modifiers,
+          placement,
+          subtitle,
+          title
+        };
 
-      popoverContent = (
-        <PopoverContent {...popoverContentProps}>{content}</PopoverContent>
-      );
-    } else {
-      popoverContent = content;
+        popoverContent = (
+          <PopoverContent {...popoverContentProps}>{content}</PopoverContent>
+        );
+      } else {
+        popoverContent = content;
+      }
     }
 
     return (
       <Root {...rootProps}>
-        {popoverTrigger}
+        <PopoverTrigger {...popoverTriggerProps} />
         {isOpen && popoverContent}
       </Root>
     );

--- a/src/Popover/PopoverContent.js
+++ b/src/Popover/PopoverContent.js
@@ -22,13 +22,13 @@ import { CardBlock, CardTitle } from '../Card';
 import PopoverArrow from './PopoverArrow';
 
 type Props = {
-  /** Content of the popper */
+  /** Content of the Popover */
   children: React$Node,
   /** Plugins that are used to alter behavior. See https://popper.js.org/popper-documentation.html#modifiers */
   modifiers?: Object,
   /** Include an arrow on the Popover content pointing to the trigger */
   hasArrow?: boolean,
-  /** Placement of the popper */
+  /** Placement of the Popover */
   placement?:
     | 'auto'
     | 'auto-end'
@@ -47,7 +47,7 @@ type Props = {
     | 'top-start',
   /** Subtitle displayed under the title */
   subtitle?: React$Node,
-  /** Title of the popover */
+  /** Title of the Popover */
   title?: React$Node
 };
 

--- a/src/Popover/PopoverTrigger.js
+++ b/src/Popover/PopoverTrigger.js
@@ -17,14 +17,12 @@
 /* @flow */
 import React, { Children, cloneElement, Component } from 'react';
 import { Target } from 'react-popper';
-import { composeEventHandlers, createStyledComponent } from '../utils';
+import { createStyledComponent } from '../utils';
 
 type Props = {
   contentId: string,
   children: React$Node,
   disabled?: boolean,
-  onClick?: (event: SyntheticEvent<>) => void,
-  onKeyDown?: (event: SyntheticEvent<>) => void,
   isOpen: boolean
 };
 
@@ -40,28 +38,17 @@ export default class PopoverTrigger extends Component<Props> {
   props: Props;
 
   render() {
-    const {
-      children,
-      disabled,
-      isOpen,
-      contentId,
-      onClick,
-      onKeyDown,
-      ...restProps
-    } = this.props;
-    const child = Children.only(children);
-    const { onClick: childOnClick, onKeyDown: childOnKeyDown } = child.props;
+    const { children, disabled, isOpen, contentId, ...restProps } = this.props;
     const triggerProps = {
+      'aria-owns': contentId,
       'aria-describedby': contentId,
       'aria-disabled': disabled,
       'aria-expanded': isOpen,
       disabled,
-      onClick: composeEventHandlers(childOnClick, onClick),
-      onKeyDown: composeEventHandlers(childOnKeyDown, onKeyDown),
       role: 'button',
       ...restProps
     };
 
-    return <Root>{cloneElement(child, triggerProps)}</Root>;
+    return <Root>{cloneElement(Children.only(children), triggerProps)}</Root>;
   }
 }

--- a/src/Popover/__tests__/Popover.spec.js
+++ b/src/Popover/__tests__/Popover.spec.js
@@ -119,7 +119,7 @@ describe('Popover', () => {
     });
 
     it('when document is clicked', () => {
-      var event = new MouseEvent('click', {
+      const event = new MouseEvent('click', {
         view: window,
         bubbles: true,
         cancelable: true
@@ -135,7 +135,7 @@ describe('Popover', () => {
     });
 
     it('when pressing escape', () => {
-      var event = new KeyboardEvent('keydown', {
+      const event = new KeyboardEvent('keydown', {
         key: 'Escape',
         view: window,
         bubbles: true,

--- a/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -332,18 +332,18 @@ exports[`Popover demo examples basic 1`] = `
                               aria-describedby="popover-11-popoverContent"
                               aria-disabled={undefined}
                               aria-expanded={false}
+                              aria-owns="popover-11-popoverContent"
                               disabled={undefined}
                               onClick={[Function]}
-                              onKeyDown={undefined}
                               role="button"
                             >
                               <glamorous(button)
                                 aria-describedby="popover-11-popoverContent"
                                 aria-disabled={undefined}
                                 aria-expanded={false}
+                                aria-owns="popover-11-popoverContent"
                                 disabled={undefined}
                                 onClick={[Function]}
-                                onKeyDown={undefined}
                                 role="button"
                                 size="large"
                                 text="Open Popover"
@@ -354,10 +354,10 @@ exports[`Popover demo examples basic 1`] = `
                                   aria-describedby="popover-11-popoverContent"
                                   aria-disabled={undefined}
                                   aria-expanded={false}
+                                  aria-owns="popover-11-popoverContent"
                                   className="glamor-2"
                                   disabled={undefined}
                                   onClick={[Function]}
-                                  onKeyDown={undefined}
                                   role="button"
                                   type="button"
                                 >
@@ -732,8 +732,7 @@ exports[`Popover demo examples controlled 1`] = `
               content={<DemoContent />}
               isOpen={this.state.isOpen}
               onOpen={this.onOpen}
-              onClose={this.onClose}
-              restoreFocus={false}>
+              onClose={this.onClose}>
               <Button>{label}</Button>
             </Popover>
             <Button onClick={this.togglePopover}>{label}</Button>
@@ -783,14 +782,12 @@ exports[`Popover demo examples controlled 1`] = `
                     onClose={[Function]}
                     onOpen={[Function]}
                     placement="bottom"
-                    restoreFocus={false}
                     wrapContent={true}
                   >
                     <Popover
                       isOpen={false}
                       onClose={[Function]}
                       onOpen={[Function]}
-                      restoreFocus={false}
                     >
                       <Manager
                         className="glamor-5"
@@ -816,18 +813,18 @@ exports[`Popover demo examples controlled 1`] = `
                                     aria-describedby="popover-18-popoverContent"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
+                                    aria-owns="popover-18-popoverContent"
                                     disabled={undefined}
                                     onClick={[Function]}
-                                    onKeyDown={undefined}
                                     role="button"
                                   >
                                     <glamorous(button)
                                       aria-describedby="popover-18-popoverContent"
                                       aria-disabled={undefined}
                                       aria-expanded={false}
+                                      aria-owns="popover-18-popoverContent"
                                       disabled={undefined}
                                       onClick={[Function]}
-                                      onKeyDown={undefined}
                                       role="button"
                                       size="large"
                                       text="Open Popover"
@@ -838,10 +835,10 @@ exports[`Popover demo examples controlled 1`] = `
                                         aria-describedby="popover-18-popoverContent"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
+                                        aria-owns="popover-18-popoverContent"
                                         className="glamor-2"
                                         disabled={undefined}
                                         onClick={[Function]}
-                                        onKeyDown={undefined}
                                         role="button"
                                         type="button"
                                       >
@@ -1234,18 +1231,18 @@ exports[`Popover demo examples disabled 1`] = `
                               aria-describedby="popover-17-popoverContent"
                               aria-disabled={true}
                               aria-expanded={false}
+                              aria-owns="popover-17-popoverContent"
                               disabled={true}
                               onClick={undefined}
-                              onKeyDown={undefined}
                               role="button"
                             >
                               <glamorous(button)
                                 aria-describedby="popover-17-popoverContent"
                                 aria-disabled={true}
                                 aria-expanded={false}
+                                aria-owns="popover-17-popoverContent"
                                 disabled={true}
                                 onClick={undefined}
-                                onKeyDown={undefined}
                                 role="button"
                                 size="large"
                                 text="Open Popover"
@@ -1256,10 +1253,10 @@ exports[`Popover demo examples disabled 1`] = `
                                   aria-describedby="popover-17-popoverContent"
                                   aria-disabled={true}
                                   aria-expanded={false}
+                                  aria-owns="popover-17-popoverContent"
                                   className="glamor-2"
                                   disabled={true}
                                   onClick={undefined}
-                                  onKeyDown={undefined}
                                   role="button"
                                   type="button"
                                 >
@@ -1647,18 +1644,18 @@ exports[`Popover demo examples on-open-close 1`] = `
                                 aria-describedby="popover-16-popoverContent"
                                 aria-disabled={undefined}
                                 aria-expanded={false}
+                                aria-owns="popover-16-popoverContent"
                                 disabled={undefined}
                                 onClick={[Function]}
-                                onKeyDown={undefined}
                                 role="button"
                               >
                                 <glamorous(button)
                                   aria-describedby="popover-16-popoverContent"
                                   aria-disabled={undefined}
                                   aria-expanded={false}
+                                  aria-owns="popover-16-popoverContent"
                                   disabled={undefined}
                                   onClick={[Function]}
-                                  onKeyDown={undefined}
                                   role="button"
                                   size="large"
                                   text="Menu"
@@ -1669,10 +1666,10 @@ exports[`Popover demo examples on-open-close 1`] = `
                                     aria-describedby="popover-16-popoverContent"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
+                                    aria-owns="popover-16-popoverContent"
                                     className="glamor-2"
                                     disabled={undefined}
                                     onClick={[Function]}
-                                    onKeyDown={undefined}
                                     role="button"
                                     type="button"
                                   >
@@ -2048,8 +2045,8 @@ exports[`Popover demo examples overflow 1`] = `
       <Popover
         content={<DemoContent />}
         placement=\\"right\\"
-        isOpen={true}>
-        <Button disabled>Open Popover</Button>
+        isOpen>
+        <Button>Open Popover</Button>
       </Popover>
     </OverflowContainer>"
       mountStylesheet={false}
@@ -2116,18 +2113,18 @@ exports[`Popover demo examples overflow 1`] = `
                                   aria-describedby="popover-14-popoverContent"
                                   aria-disabled={undefined}
                                   aria-expanded={true}
+                                  aria-owns="popover-14-popoverContent"
                                   disabled={undefined}
                                   onClick={[Function]}
-                                  onKeyDown={undefined}
                                   role="button"
                                 >
                                   <glamorous(button)
                                     aria-describedby="popover-14-popoverContent"
                                     aria-disabled={undefined}
                                     aria-expanded={true}
+                                    aria-owns="popover-14-popoverContent"
                                     disabled={undefined}
                                     onClick={[Function]}
-                                    onKeyDown={undefined}
                                     role="button"
                                     size="large"
                                     text="Open Popover"
@@ -2138,10 +2135,10 @@ exports[`Popover demo examples overflow 1`] = `
                                       aria-describedby="popover-14-popoverContent"
                                       aria-disabled={undefined}
                                       aria-expanded={true}
+                                      aria-owns="popover-14-popoverContent"
                                       className="glamor-2"
                                       disabled={undefined}
                                       onClick={[Function]}
-                                      onKeyDown={undefined}
                                       role="button"
                                       type="button"
                                     >
@@ -2409,6 +2406,24 @@ exports[`Popover demo examples overflow 1`] = `
                             </Popper>
                           </PopoverContent>
                         </PopoverContent>
+                        <EventListener
+                          listeners={
+                            Array [
+                              Object {
+                                "event": "click",
+                                "handler": [Function],
+                                "options": true,
+                                "target": "document",
+                              },
+                              Object {
+                                "event": "keydown",
+                                "handler": [Function],
+                                "options": true,
+                                "target": "document",
+                              },
+                            ]
+                          }
+                        />
                       </div>
                     </Manager>
                   </Popover>
@@ -2476,34 +2491,6 @@ exports[`Popover demo examples placement 1`] = `
   -webkit-transform: rotate(0deg) scaleX(2);
 }
 
-.glamor-1,
-[data-glamor-1] {
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -moz-inline-box;
-  display: -ms-inline-flexbox;
-  display: -webkit-inline-flex;
-  display: inline-flex;
-  justify-content: center;
-  max-height: 100%;
-  width: 100%;
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-}
-
-.glamor-5,
-[data-glamor-5] {
-  width: 13.75em;
-}
-
-.glamor-13,
-[data-glamor-13] {
-  height: 350px;
-  position: relative;
-}
-
 .glamor-2,
 [data-glamor-2] {
   box-sizing: border-box;
@@ -2519,8 +2506,8 @@ exports[`Popover demo examples placement 1`] = `
   border-width: 1px;
   cursor: pointer;
   font-weight: 600;
-  height: 3.25em;
-  min-width: 3.25em;
+  height: 2.5em;
+  min-width: 2.5em;
   padding: 0 0.5em;
   vertical-align: middle;
 }
@@ -2586,6 +2573,23 @@ exports[`Popover demo examples placement 1`] = `
   margin: 0;
 }
 
+.glamor-1,
+[data-glamor-1] {
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -moz-inline-box;
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+  justify-content: center;
+  max-height: 100%;
+  width: 100%;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+}
+
 .glamor-0,
 [data-glamor-0] {
   display: block;
@@ -2595,7 +2599,7 @@ exports[`Popover demo examples placement 1`] = `
   white-space: nowrap;
   word-wrap: normal;
   font-size: 0.875em;
-  line-height: 3.7142857142857144em;
+  line-height: 2.857142857142857em;
 }
 
 .glamor-0:first-child,
@@ -2610,6 +2614,17 @@ exports[`Popover demo examples placement 1`] = `
 .glamor-0[data-simulate-lastchild],
 [data-glamor-0][data-simulate-lastchild] {
   padding-right: 0.5714285714285714em;
+}
+
+.glamor-5,
+[data-glamor-5] {
+  width: 13.75em;
+}
+
+.glamor-13,
+[data-glamor-13] {
+  height: 350px;
+  position: relative;
 }
 
 <ThemeProvider>
@@ -2759,8 +2774,8 @@ exports[`Popover demo examples placement 1`] = `
       <Popover
         content={<DemoContent />}
         placement=\\"bottom\\"
-        isOpen={true}>
-        <Button size=\\"jumbo\\" disabled>Open Popover</Button>
+        isOpen>
+        <Button>Open Popover</Button>
       </Popover>
     </DemoLayout>"
       mountStylesheet={false}
@@ -2827,21 +2842,20 @@ exports[`Popover demo examples placement 1`] = `
                                   aria-describedby="popover-13-popoverContent"
                                   aria-disabled={undefined}
                                   aria-expanded={true}
+                                  aria-owns="popover-13-popoverContent"
                                   disabled={undefined}
                                   onClick={[Function]}
-                                  onKeyDown={undefined}
                                   role="button"
-                                  size="jumbo"
                                 >
                                   <glamorous(button)
                                     aria-describedby="popover-13-popoverContent"
                                     aria-disabled={undefined}
                                     aria-expanded={true}
+                                    aria-owns="popover-13-popoverContent"
                                     disabled={undefined}
                                     onClick={[Function]}
-                                    onKeyDown={undefined}
                                     role="button"
-                                    size="jumbo"
+                                    size="large"
                                     text="Open Popover"
                                     type="button"
                                     variant="regular"
@@ -2850,10 +2864,10 @@ exports[`Popover demo examples placement 1`] = `
                                       aria-describedby="popover-13-popoverContent"
                                       aria-disabled={undefined}
                                       aria-expanded={true}
+                                      aria-owns="popover-13-popoverContent"
                                       className="glamor-2"
                                       disabled={undefined}
                                       onClick={[Function]}
-                                      onKeyDown={undefined}
                                       role="button"
                                       type="button"
                                     >
@@ -2862,7 +2876,7 @@ exports[`Popover demo examples placement 1`] = `
                                           className="glamor-1"
                                         >
                                           <glamorous(span)
-                                            size="jumbo"
+                                            size="large"
                                           >
                                             <span
                                               className="glamor-0"
@@ -3121,6 +3135,24 @@ exports[`Popover demo examples placement 1`] = `
                             </Popper>
                           </PopoverContent>
                         </PopoverContent>
+                        <EventListener
+                          listeners={
+                            Array [
+                              Object {
+                                "event": "click",
+                                "handler": [Function],
+                                "options": true,
+                                "target": "document",
+                              },
+                              Object {
+                                "event": "keydown",
+                                "handler": [Function],
+                                "options": true,
+                                "target": "document",
+                              },
+                            ]
+                          }
+                        />
                       </div>
                     </Manager>
                   </Popover>
@@ -3586,8 +3618,7 @@ exports[`Popover demo examples scrolling-container 1`] = `
       <Popover
         content={<DemoContent />}
         placement=\\"left\\"
-        isOpen
-        restoreFocus={false}>
+        isOpen>
         <Button>Open Popover</Button>
       </Popover>
     </ScrollParent>
@@ -3643,12 +3674,10 @@ exports[`Popover demo examples scrolling-container 1`] = `
                             hasArrow={true}
                             isOpen={true}
                             placement="left"
-                            restoreFocus={false}
                             wrapContent={true}
                           >
                             <Popover
                               isOpen={true}
-                              restoreFocus={false}
                             >
                               <Manager
                                 className="glamor-11"
@@ -3674,18 +3703,18 @@ exports[`Popover demo examples scrolling-container 1`] = `
                                             aria-describedby="popover-15-popoverContent"
                                             aria-disabled={undefined}
                                             aria-expanded={true}
+                                            aria-owns="popover-15-popoverContent"
                                             disabled={undefined}
                                             onClick={[Function]}
-                                            onKeyDown={undefined}
                                             role="button"
                                           >
                                             <glamorous(button)
                                               aria-describedby="popover-15-popoverContent"
                                               aria-disabled={undefined}
                                               aria-expanded={true}
+                                              aria-owns="popover-15-popoverContent"
                                               disabled={undefined}
                                               onClick={[Function]}
-                                              onKeyDown={undefined}
                                               role="button"
                                               size="large"
                                               text="Open Popover"
@@ -3696,10 +3725,10 @@ exports[`Popover demo examples scrolling-container 1`] = `
                                                 aria-describedby="popover-15-popoverContent"
                                                 aria-disabled={undefined}
                                                 aria-expanded={true}
+                                                aria-owns="popover-15-popoverContent"
                                                 className="glamor-2"
                                                 disabled={undefined}
                                                 onClick={[Function]}
-                                                onKeyDown={undefined}
                                                 role="button"
                                                 type="button"
                                               >
@@ -3967,6 +3996,24 @@ exports[`Popover demo examples scrolling-container 1`] = `
                                       </Popper>
                                     </PopoverContent>
                                   </PopoverContent>
+                                  <EventListener
+                                    listeners={
+                                      Array [
+                                        Object {
+                                          "event": "click",
+                                          "handler": [Function],
+                                          "options": true,
+                                          "target": "document",
+                                        },
+                                        Object {
+                                          "event": "keydown",
+                                          "handler": [Function],
+                                          "options": true,
+                                          "target": "document",
+                                        },
+                                      ]
+                                    }
+                                  />
                                 </div>
                               </Manager>
                             </Popover>
@@ -4391,8 +4438,8 @@ exports[`Popover demo examples title 1`] = `
         placement=\\"right\\"
         subtitle=\\"Subtitle\\"
         title=\\"Title\\"
-        isOpen={true}>
-        <Button disabled>Open Popover</Button>
+        isOpen>
+        <Button>Open Popover</Button>
       </Popover>
     </DemoLayout>"
       mountStylesheet={false}
@@ -4461,18 +4508,18 @@ exports[`Popover demo examples title 1`] = `
                                   aria-describedby="popover-12-popoverContent"
                                   aria-disabled={undefined}
                                   aria-expanded={true}
+                                  aria-owns="popover-12-popoverContent"
                                   disabled={undefined}
                                   onClick={[Function]}
-                                  onKeyDown={undefined}
                                   role="button"
                                 >
                                   <glamorous(button)
                                     aria-describedby="popover-12-popoverContent"
                                     aria-disabled={undefined}
                                     aria-expanded={true}
+                                    aria-owns="popover-12-popoverContent"
                                     disabled={undefined}
                                     onClick={[Function]}
-                                    onKeyDown={undefined}
                                     role="button"
                                     size="large"
                                     text="Open Popover"
@@ -4483,10 +4530,10 @@ exports[`Popover demo examples title 1`] = `
                                       aria-describedby="popover-12-popoverContent"
                                       aria-disabled={undefined}
                                       aria-expanded={true}
+                                      aria-owns="popover-12-popoverContent"
                                       className="glamor-2"
                                       disabled={undefined}
                                       onClick={[Function]}
-                                      onKeyDown={undefined}
                                       role="button"
                                       type="button"
                                     >
@@ -4946,6 +4993,24 @@ exports[`Popover demo examples title 1`] = `
                             </Popper>
                           </PopoverContent>
                         </PopoverContent>
+                        <EventListener
+                          listeners={
+                            Array [
+                              Object {
+                                "event": "click",
+                                "handler": [Function],
+                                "options": true,
+                                "target": "document",
+                              },
+                              Object {
+                                "event": "keydown",
+                                "handler": [Function],
+                                "options": true,
+                                "target": "document",
+                              },
+                            ]
+                          }
+                        />
                       </div>
                     </Manager>
                   </Popover>

--- a/src/website/app/demos/Dropdown/examples/placement.js
+++ b/src/website/app/demos/Dropdown/examples/placement.js
@@ -40,8 +40,11 @@ The Dropdown will react to viewport edges and scrolling.`,
   scope: { Button, data, DemoLayout, Dropdown },
   source: `
     <DemoLayout>
-      <Dropdown placement="bottom-start" data={data} isOpen={true}>
-        <Button size="jumbo" disabled>Menu</Button>
+      <Dropdown
+        placement="bottom-start"
+        data={data}
+        isOpen>
+        <Button>Menu</Button>
       </Dropdown>
     </DemoLayout>`
 };

--- a/src/website/app/demos/Dropdown/examples/scrolling.js
+++ b/src/website/app/demos/Dropdown/examples/scrolling.js
@@ -30,8 +30,7 @@ export default {
       <Dropdown
         data={data}
         isOpen
-        placement="bottom-start"
-        restoreFocus={false}>
+        placement="bottom-start">
         <Button>Menu</Button>
       </Dropdown>
     </ScrollParent>

--- a/src/website/app/demos/Dropdown/examples/wide.js
+++ b/src/website/app/demos/Dropdown/examples/wide.js
@@ -51,8 +51,8 @@ Make sure you have enough room for the wider Menu on the devices you're supporti
   scope: { Button, data, DemoLayout, Dropdown },
   source: `
     <DemoLayout>
-      <Dropdown wide data={data} isOpen={true}>
-        <Button disabled>Menu</Button>
+      <Dropdown wide isOpen data={data}>
+        <Button>Menu</Button>
       </Dropdown>
     </DemoLayout>`
 };

--- a/src/website/app/demos/Popover/bestPractices.js
+++ b/src/website/app/demos/Popover/bestPractices.js
@@ -111,7 +111,6 @@ class PopOverDo extends Component<{}, State> {
         <Popover
           onOpen={this.onOpen}
           onClose={this.onClose}
-          restoreFocus={false}
           isOpen={this.state.isOpen}
           content={DemoContent}>
           <P>Mineral UI</P>

--- a/src/website/app/demos/Popover/examples/controlled.js
+++ b/src/website/app/demos/Popover/examples/controlled.js
@@ -84,8 +84,7 @@ Callbacks for \`onOpen\` and \`onClose\` are also provided.`,
               content={<DemoContent />}
               isOpen={this.state.isOpen}
               onOpen={this.onOpen}
-              onClose={this.onClose}
-              restoreFocus={false}>
+              onClose={this.onClose}>
               <Button>{label}</Button>
             </Popover>
             <Button onClick={this.togglePopover}>{label}</Button>

--- a/src/website/app/demos/Popover/examples/overflow.js
+++ b/src/website/app/demos/Popover/examples/overflow.js
@@ -36,8 +36,8 @@ export default {
       <Popover
         content={<DemoContent />}
         placement="right"
-        isOpen={true}>
-        <Button disabled>Open Popover</Button>
+        isOpen>
+        <Button>Open Popover</Button>
       </Popover>
     </OverflowContainer>`
 };

--- a/src/website/app/demos/Popover/examples/placement.js
+++ b/src/website/app/demos/Popover/examples/placement.js
@@ -43,8 +43,8 @@ The Popover will still react to viewport edges and scrolling.`,
       <Popover
         content={<DemoContent />}
         placement="bottom"
-        isOpen={true}>
-        <Button size="jumbo" disabled>Open Popover</Button>
+        isOpen>
+        <Button>Open Popover</Button>
       </Popover>
     </DemoLayout>`
 };

--- a/src/website/app/demos/Popover/examples/scrolling.js
+++ b/src/website/app/demos/Popover/examples/scrolling.js
@@ -30,8 +30,7 @@ export default {
       <Popover
         content={<DemoContent />}
         placement="left"
-        isOpen
-        restoreFocus={false}>
+        isOpen>
         <Button>Open Popover</Button>
       </Popover>
     </ScrollParent>

--- a/src/website/app/demos/Popover/examples/title.js
+++ b/src/website/app/demos/Popover/examples/title.js
@@ -37,8 +37,8 @@ Subtitles will only be rendered if the \`title\` attribute is present.`,
         placement="right"
         subtitle="Subtitle"
         title="Title"
-        isOpen={true}>
-        <Button disabled>Open Popover</Button>
+        isOpen>
+        <Button>Open Popover</Button>
       </Popover>
     </DemoLayout>`
 };


### PR DESCRIPTION
### Description

This PR extracts the a11y and refactoring improvements from https://github.com/mineral-ui/mineral-ui/pull/414 as the portal related updates are currently blocked by an issue in Popperjs. 

### Motivation and context

I am not sure how long it may take to get a new version of Popper and I would like to get these  improvements into the codebase sooner rather than later.

connects #395 

### Screenshots, videos, or demo, if appropriate

https://395-popover-misc--mineral-ui.netlify.com/

### How to test

1. Mostly just try out Dropdown menus in voiceover.  Focus, nav, and announcements are improved.

_This code has already been reviewed and approved in https://github.com/mineral-ui/mineral-ui/pull/414, so as long as I extracted it cleanly from that PR, we should be good to go._

### Types of changes

- Other (provide details below)

Little bit of everything - improved a11y, refactoring, updating tests

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
