### PR TITLE
Add support for React 16

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     '.*react-docgen-loader.*': '<rootDir>/utils/emptyObject.js',
     '.md$': '<rootDir>/utils/emptyObject.js'
   },
+  setupFiles: ['raf/polyfill'],
   setupTestFrameworkScriptFile: '<rootDir>/utils/setupTestFrameworkScript.js',
   snapshotSerializers: ['enzyme-to-json/serializer']
 };

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   "peerDependencies": {
     "glamor": "^2.0.0",
     "glamorous": "^4.8.0",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "exenv": "1.2.2",
-    "react-popper": "0.7.3"
+    "react-popper": "0.7.4"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -377,10 +377,10 @@ export default class Button extends Component<Props> {
     const Root = this.rootNode;
 
     const startIcon = iconStart
-      ? cloneElement(iconStart, { size: iconSize[size] })
+      ? cloneElement(iconStart, { size: iconSize[size], key: 'iconStart' })
       : null;
     const endIcon = iconEnd
-      ? cloneElement(iconEnd, { size: iconSize[size] })
+      ? cloneElement(iconEnd, { size: iconSize[size], key: 'iconEnd' })
       : null;
 
     return (

--- a/src/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -791,6 +791,7 @@ exports[`Button demo examples circular 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -856,6 +857,7 @@ exports[`Button demo examples circular 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -921,6 +923,7 @@ exports[`Button demo examples circular 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -984,6 +987,7 @@ exports[`Button demo examples circular 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="medium"
                             >
                               <Icon
@@ -1047,6 +1051,7 @@ exports[`Button demo examples circular 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="medium"
                             >
                               <Icon
@@ -1110,6 +1115,7 @@ exports[`Button demo examples circular 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -2802,6 +2808,7 @@ exports[`Button demo examples icon-only 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -2865,6 +2872,7 @@ exports[`Button demo examples icon-only 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -2928,6 +2936,7 @@ exports[`Button demo examples icon-only 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -2989,6 +2998,7 @@ exports[`Button demo examples icon-only 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="medium"
                             >
                               <Icon
@@ -3050,6 +3060,7 @@ exports[`Button demo examples icon-only 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="medium"
                             >
                               <Icon
@@ -3111,6 +3122,7 @@ exports[`Button demo examples icon-only 1`] = `
                             className="glamor-1"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4377,6 +4389,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4453,6 +4466,7 @@ exports[`Button demo examples icons 1`] = `
                               </span>
                             </glamorous(span)>
                             <IconCloud
+                              key="iconEnd"
                               size="1.5em"
                             >
                               <Icon
@@ -4512,6 +4526,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4552,6 +4567,7 @@ exports[`Button demo examples icons 1`] = `
                               </span>
                             </glamorous(span)>
                             <IconCloud
+                              key="iconEnd"
                               size="1.5em"
                             >
                               <Icon
@@ -4614,6 +4630,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4683,6 +4700,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4750,6 +4768,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4817,6 +4836,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4884,6 +4904,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -4954,6 +4975,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -5023,6 +5045,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="medium"
                             >
                               <Icon
@@ -5090,6 +5113,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="medium"
                             >
                               <Icon
@@ -5157,6 +5181,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -5224,6 +5249,7 @@ exports[`Button demo examples icons 1`] = `
                             className="glamor-2"
                           >
                             <IconCloud
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon
@@ -7701,6 +7727,7 @@ exports[`Button demo examples rtl 1`] = `
                             className="glamor-2"
                           >
                             <IconBackspace
+                              key="iconStart"
                               size="1.5em"
                             >
                               <Icon

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -249,10 +249,11 @@ const defaultRender = ({
   let startIcon =
     variant !== undefined && variant !== 'regular' && variantIcons[variant];
   if (iconStart) {
-    startIcon = cloneElement(iconStart, { size: pxToEm(24) });
+    startIcon = cloneElement(iconStart, { size: pxToEm(24), key: 'iconStart' });
   }
 
-  const endIcon = iconEnd && cloneElement(iconEnd, { size: pxToEm(24) });
+  const endIcon =
+    iconEnd && cloneElement(iconEnd, { size: pxToEm(24), key: 'iconEnd' });
 
   // This structure is based on Button
   return (

--- a/src/Menu/__tests__/__snapshots__/Menu.spec.js.snap
+++ b/src/Menu/__tests__/__snapshots__/Menu.spec.js.snap
@@ -779,6 +779,7 @@ exports[`Menu demo examples data 1`] = `
                                         className="glamor-3"
                                       >
                                         <IconCloud
+                                          key="iconStart"
                                           size="1.5em"
                                         >
                                           <Icon
@@ -884,6 +885,7 @@ exports[`Menu demo examples data 1`] = `
                                           </span>
                                         </glamorous(span)>
                                         <IconCloud
+                                          key="iconEnd"
                                           size="1.5em"
                                         >
                                           <Icon
@@ -1910,6 +1912,7 @@ exports[`Menu demo examples menu 1`] = `
                                       className="glamor-3"
                                     >
                                       <IconCloud
+                                        key="iconStart"
                                         size="1.5em"
                                       >
                                         <Icon
@@ -2002,6 +2005,7 @@ exports[`Menu demo examples menu 1`] = `
                                         </span>
                                       </glamorous(span)>
                                       <IconCloud
+                                        key="iconEnd"
                                         size="1.5em"
                                       >
                                         <Icon

--- a/src/Menu/__tests__/__snapshots__/MenuItem.spec.js.snap
+++ b/src/Menu/__tests__/__snapshots__/MenuItem.spec.js.snap
@@ -2700,6 +2700,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                   className="glamor-4"
                                 >
                                   <IconCloud
+                                    key="iconStart"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -2792,6 +2793,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                     </span>
                                   </glamorous(span)>
                                   <IconCloud
+                                    key="iconEnd"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -2849,6 +2851,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                   className="glamor-4"
                                 >
                                   <IconCloud
+                                    key="iconStart"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -2898,6 +2901,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                     </span>
                                   </glamorous(span)>
                                   <IconCloud
+                                    key="iconEnd"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -2963,6 +2967,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                   className="glamor-4"
                                 >
                                   <IconCloud
+                                    key="iconStart"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -3038,6 +3043,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                   className="glamor-4"
                                 >
                                   <IconCloud
+                                    key="iconStart"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -3113,6 +3119,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                   className="glamor-4"
                                 >
                                   <IconCloud
+                                    key="iconStart"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -3188,6 +3195,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                   className="glamor-4"
                                 >
                                   <IconCloud
+                                    key="iconStart"
                                     size="1.5em"
                                   >
                                     <Icon
@@ -3702,6 +3710,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -3751,6 +3760,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -3808,6 +3818,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -3857,6 +3868,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -3914,6 +3926,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -3963,6 +3976,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4021,6 +4035,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4070,6 +4085,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4128,6 +4144,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4177,6 +4194,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4235,6 +4253,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4284,6 +4303,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4342,6 +4362,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4393,6 +4414,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4451,6 +4473,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4502,6 +4525,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4560,6 +4584,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4611,6 +4636,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4669,6 +4695,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4720,6 +4747,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4785,6 +4813,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4834,6 +4863,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4891,6 +4921,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4940,6 +4971,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -4998,6 +5030,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5047,6 +5080,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5105,6 +5139,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5154,6 +5189,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5212,6 +5248,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5263,6 +5300,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5321,6 +5359,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5372,6 +5411,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5430,6 +5470,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5481,6 +5522,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5539,6 +5581,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                 className="glamor-5"
                               >
                                 <IconCloud
+                                  key="iconStart"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -5590,6 +5633,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                   </span>
                                 </glamorous(span)>
                                 <IconCloud
+                                  key="iconEnd"
                                   size="1.5em"
                                 >
                                   <Icon
@@ -6091,6 +6135,7 @@ exports[`MenuItem demo examples rtl 1`] = `
                                     className="glamor-3"
                                   >
                                     <IconHelp
+                                      key="iconStart"
                                       size="1.5em"
                                     >
                                       <Icon
@@ -6183,6 +6228,7 @@ exports[`MenuItem demo examples rtl 1`] = `
                                       </span>
                                     </glamorous(span)>
                                     <IconHelp
+                                      key="iconEnd"
                                       size="1.5em"
                                     >
                                       <Icon

--- a/utils/setupTestFrameworkScript.js
+++ b/utils/setupTestFrameworkScript.js
@@ -17,7 +17,6 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-15';
 import serializer from 'jest-glamor-react';
 import { simulations } from 'glamor';
-import raf from 'raf';
 
 // Configure Enzyme for our version of React
 Enzyme.configure({ adapter: new Adapter() });
@@ -27,6 +26,3 @@ expect.addSnapshotSerializer(serializer);
 
 // Enable Glamor simulate helper
 simulations(true);
-
-// Polyfill requestAnimationFrame
-raf.polyfill();


### PR DESCRIPTION
### Description

Adds support for React 16

**This PR does not update the components, local dev environment, or website to use React 16.**  It simply updates the versions in package.json to allow Mineral UI to be consumed in a React 16 app and includes a fix for an issue discovered when testing the package inside of CRA using React 16.

### Motivation and context

closes #422

### Screenshots, videos, or demo, if appropriate

https://422-react-16--mineral-ui.netlify.com/

### How to test

1. Builds and works as normal
2. How I tested in CRA.  Build the package using release script, without publishing.  NOTE: `npm link` doesn't seem to work well here, so...  From mineral-ui/dist, run `npm pack` to generate a tarball. `npm i pathToTarball` in CRA.  Import and render components and ensure all works as expected.  Tested in CRA using React 15.6.1 and React 16.0.0.

### Types of changes

- Other (provide details below)

Add support for React 16.  Sort of a new feature, sort of a chore.

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - **[n/a]**" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change