### PR TITLE
Fix Dropdown keyboard nav

### DIFF
--- a/src/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -766,11 +766,16 @@ exports[`Button demo examples circular 1`] = `
                   <Button
                     aria-label="Cloud"
                     circular={true}
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
                       circular={true}
+                      element="button"
                       size="large"
                       text={undefined}
                       type="button"
@@ -824,12 +829,17 @@ exports[`Button demo examples circular 1`] = `
                   <Button
                     aria-label="Cloud"
                     circular={true}
+                    element="button"
                     iconStart={<IconCloud />}
                     primary={true}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
                       circular={true}
+                      element="button"
                       primary={true}
                       size="large"
                       text={undefined}
@@ -884,12 +894,17 @@ exports[`Button demo examples circular 1`] = `
                   <Button
                     aria-label="Cloud"
                     circular={true}
+                    element="button"
                     iconStart={<IconCloud />}
                     minimal={true}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
                       circular={true}
+                      element="button"
                       minimal={true}
                       size="large"
                       text={undefined}
@@ -944,12 +959,16 @@ exports[`Button demo examples circular 1`] = `
                   <Button
                     aria-label="Cloud"
                     circular={true}
+                    element="button"
                     iconStart={<IconCloud />}
                     size="small"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
                       circular={true}
+                      element="button"
                       size="small"
                       text={undefined}
                       type="button"
@@ -1003,12 +1022,16 @@ exports[`Button demo examples circular 1`] = `
                   <Button
                     aria-label="Cloud"
                     circular={true}
+                    element="button"
                     iconStart={<IconCloud />}
                     size="medium"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
                       circular={true}
+                      element="button"
                       size="medium"
                       text={undefined}
                       type="button"
@@ -1062,12 +1085,16 @@ exports[`Button demo examples circular 1`] = `
                   <Button
                     aria-label="Cloud"
                     circular={true}
+                    element="button"
                     iconStart={<IconCloud />}
                     size="jumbo"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
                       circular={true}
+                      element="button"
                       size="jumbo"
                       text={undefined}
                       type="button"
@@ -1797,8 +1824,14 @@ exports[`Button demo examples default 1`] = `
               <div
                 className="glamor-15"
               >
-                <Button>
+                <Button
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
+                >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Default"
                     type="button"
@@ -1827,9 +1860,13 @@ exports[`Button demo examples default 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Success"
                     type="button"
@@ -1858,9 +1895,13 @@ exports[`Button demo examples default 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Warning"
                     type="button"
@@ -1889,9 +1930,13 @@ exports[`Button demo examples default 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Danger"
                     type="button"
@@ -1921,9 +1966,14 @@ exports[`Button demo examples default 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     size="large"
                     text="Disabled"
                     type="button"
@@ -2728,10 +2778,15 @@ exports[`Button demo examples icon-only 1`] = `
                 >
                   <Button
                     aria-label="Cloud"
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
+                      element="button"
                       size="large"
                       text={undefined}
                       type="button"
@@ -2784,11 +2839,16 @@ exports[`Button demo examples icon-only 1`] = `
                   </Button>
                   <Button
                     aria-label="Cloud"
+                    element="button"
                     iconStart={<IconCloud />}
                     primary={true}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
+                      element="button"
                       primary={true}
                       size="large"
                       text={undefined}
@@ -2842,11 +2902,16 @@ exports[`Button demo examples icon-only 1`] = `
                   </Button>
                   <Button
                     aria-label="Cloud"
+                    element="button"
                     iconStart={<IconCloud />}
                     minimal={true}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
+                      element="button"
                       minimal={true}
                       size="large"
                       text={undefined}
@@ -2900,11 +2965,15 @@ exports[`Button demo examples icon-only 1`] = `
                   </Button>
                   <Button
                     aria-label="Cloud"
+                    element="button"
                     iconStart={<IconCloud />}
                     size="small"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
+                      element="button"
                       size="small"
                       text={undefined}
                       type="button"
@@ -2957,11 +3026,15 @@ exports[`Button demo examples icon-only 1`] = `
                   </Button>
                   <Button
                     aria-label="Cloud"
+                    element="button"
                     iconStart={<IconCloud />}
                     size="medium"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
+                      element="button"
                       size="medium"
                       text={undefined}
                       type="button"
@@ -3014,11 +3087,15 @@ exports[`Button demo examples icon-only 1`] = `
                   </Button>
                   <Button
                     aria-label="Cloud"
+                    element="button"
                     iconStart={<IconCloud />}
                     size="jumbo"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       aria-label="Cloud"
+                      element="button"
                       size="jumbo"
                       text={undefined}
                       type="button"
@@ -4278,9 +4355,14 @@ exports[`Button demo examples icons 1`] = `
                   className="glamor-53"
                 >
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="Start icon"
                       type="button"
@@ -4340,9 +4422,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconEnd={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="End icon"
                       type="button"
@@ -4402,10 +4489,15 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconEnd={<IconCloud />}
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="Both icons"
                       type="button"
@@ -4498,10 +4590,15 @@ exports[`Button demo examples icons 1`] = `
                   <br />
                   <br />
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
                     primary={true}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       primary={true}
                       size="large"
                       text="Primary"
@@ -4562,10 +4659,15 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
                     minimal={true}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       minimal={true}
                       size="large"
                       text="Minimal"
@@ -4626,10 +4728,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
                     variant="danger"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="Danger"
                       type="button"
@@ -4689,10 +4795,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
                     variant="success"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="Success"
                       type="button"
@@ -4752,10 +4862,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
                     variant="warning"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="Warning"
                       type="button"
@@ -4816,10 +4930,15 @@ exports[`Button demo examples icons 1`] = `
                   </Button>
                   <Button
                     disabled={true}
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
                       disabled={true}
+                      element="button"
                       size="large"
                       text="Disabled"
                       type="button"
@@ -4882,10 +5001,14 @@ exports[`Button demo examples icons 1`] = `
                   <br />
                   <br />
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
                     size="small"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="small"
                       text="Small"
                       type="button"
@@ -4945,10 +5068,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
                     size="medium"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="medium"
                       text="Medium"
                       type="button"
@@ -5008,9 +5135,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="Large"
                       type="button"
@@ -5070,10 +5202,14 @@ exports[`Button demo examples icons 1`] = `
                     </glamorous(button)>
                   </Button>
                   <Button
+                    element="button"
                     iconStart={<IconCloud />}
                     size="jumbo"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="jumbo"
                       text="Jumbo"
                       type="button"
@@ -5442,8 +5578,12 @@ exports[`Button demo examples link 1`] = `
             <Button
               element="a"
               href="#link"
+              size="large"
+              type="button"
+              variant="regular"
             >
               <glamorous(a)
+                element="a"
                 href="#link"
                 size="large"
                 text="Link"
@@ -6143,9 +6283,14 @@ exports[`Button demo examples minimal 1`] = `
                 className="glamor-15"
               >
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Default"
@@ -6175,10 +6320,14 @@ exports[`Button demo examples minimal 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Success"
@@ -6208,10 +6357,14 @@ exports[`Button demo examples minimal 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Warning"
@@ -6241,10 +6394,14 @@ exports[`Button demo examples minimal 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Danger"
@@ -6275,10 +6432,15 @@ exports[`Button demo examples minimal 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Disabled"
@@ -6987,9 +7149,14 @@ exports[`Button demo examples primary 1`] = `
                 className="glamor-15"
               >
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Default"
@@ -7019,10 +7186,14 @@ exports[`Button demo examples primary 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Success"
@@ -7052,10 +7223,14 @@ exports[`Button demo examples primary 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Warning"
@@ -7085,10 +7260,14 @@ exports[`Button demo examples primary 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Danger"
@@ -7119,10 +7298,15 @@ exports[`Button demo examples primary 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     primary={true}
                     size="large"
                     text="Disabled"
@@ -7495,9 +7679,14 @@ exports[`Button demo examples rtl 1`] = `
                   }
                 >
                   <Button
+                    element="button"
                     iconStart={<IconBackspace />}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       size="large"
                       text="قم بعمل ما"
                       type="button"
@@ -8294,9 +8483,13 @@ exports[`Button demo examples sizes 1`] = `
                 className="glamor-15"
               >
                 <Button
+                  element="button"
                   size="small"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     size="small"
                     text="Small"
                     type="button"
@@ -8325,9 +8518,13 @@ exports[`Button demo examples sizes 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   size="medium"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     size="medium"
                     text="Medium"
                     type="button"
@@ -8355,8 +8552,14 @@ exports[`Button demo examples sizes 1`] = `
                     </button>
                   </glamorous(button)>
                 </Button>
-                <Button>
+                <Button
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
+                >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Large"
                     type="button"
@@ -8385,9 +8588,13 @@ exports[`Button demo examples sizes 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   size="jumbo"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     size="jumbo"
                     text="Jumbo"
                     type="button"
@@ -8416,9 +8623,14 @@ exports[`Button demo examples sizes 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   fullWidth={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     fullWidth={true}
                     size="large"
                     text="Full Width"
@@ -10415,8 +10627,14 @@ exports[`Button demo examples states 1`] = `
               <div
                 className="glamor-252"
               >
-                <Button>
+                <Button
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
+                >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Regular"
                     type="button"
@@ -10445,9 +10663,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Primary"
@@ -10477,9 +10700,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Minimal"
@@ -10512,9 +10740,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Hover"
                     type="button"
@@ -10545,10 +10778,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Hover"
@@ -10580,10 +10818,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Hover"
@@ -10617,9 +10860,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus"
                     type="button"
@@ -10650,10 +10898,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus"
@@ -10685,10 +10938,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus"
@@ -10723,10 +10981,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Focus & Hover"
                     type="button"
@@ -10759,11 +11022,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Hover"
@@ -10797,11 +11065,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Hover"
@@ -10837,10 +11110,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus & Active"
                     type="button"
@@ -10873,11 +11151,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Active"
@@ -10911,11 +11194,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Active"
@@ -10950,9 +11238,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-active=""
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     size="large"
                     text="Active"
                     type="button"
@@ -10983,10 +11276,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Active"
@@ -11018,10 +11316,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Active"
@@ -11055,9 +11358,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   disabled={true}
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     size="large"
                     text="Disabled"
                     type="button"
@@ -11088,10 +11396,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     primary={true}
                     size="large"
                     text="Disabled"
@@ -11123,10 +11436,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
+                  variant="regular"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Disabled"
@@ -11160,9 +11478,13 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <br />
                 <Button
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Regular"
                     type="button"
@@ -11191,10 +11513,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Primary"
@@ -11224,10 +11550,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Minimal"
@@ -11260,10 +11590,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Hover"
                     type="button"
@@ -11294,11 +11628,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Hover"
@@ -11330,11 +11668,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Hover"
@@ -11368,10 +11710,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus"
                     type="button"
@@ -11402,11 +11748,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus"
@@ -11438,11 +11788,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus"
@@ -11477,11 +11831,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Focus & Hover"
                     type="button"
@@ -11514,12 +11872,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Hover"
@@ -11553,12 +11915,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Hover"
@@ -11594,11 +11960,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus & Active"
                     type="button"
@@ -11631,12 +12001,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Active"
@@ -11670,12 +12044,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Active"
@@ -11710,10 +12088,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-active=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     size="large"
                     text="Active"
                     type="button"
@@ -11744,11 +12126,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Active"
@@ -11780,11 +12166,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Active"
@@ -11818,10 +12208,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   disabled={true}
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     size="large"
                     text="Disabled"
                     type="button"
@@ -11852,11 +12246,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     primary={true}
                     size="large"
                     text="Disabled"
@@ -11888,11 +12286,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Disabled"
@@ -11926,9 +12328,13 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <br />
                 <Button
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Regular"
                     type="button"
@@ -11957,10 +12363,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Primary"
@@ -11990,10 +12400,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Minimal"
@@ -12026,10 +12440,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Hover"
                     type="button"
@@ -12060,11 +12478,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Hover"
@@ -12096,11 +12518,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Hover"
@@ -12134,10 +12560,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus"
                     type="button"
@@ -12168,11 +12598,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus"
@@ -12204,11 +12638,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus"
@@ -12243,11 +12681,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Focus & Hover"
                     type="button"
@@ -12280,12 +12722,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Hover"
@@ -12319,12 +12765,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Hover"
@@ -12360,11 +12810,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus & Active"
                     type="button"
@@ -12397,12 +12851,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Active"
@@ -12436,12 +12894,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Active"
@@ -12476,10 +12938,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-active=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     size="large"
                     text="Active"
                     type="button"
@@ -12510,11 +12976,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Active"
@@ -12546,11 +13016,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="success"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Active"
@@ -12584,10 +13058,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   disabled={true}
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     size="large"
                     text="Disabled"
                     type="button"
@@ -12618,11 +13096,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     primary={true}
                     size="large"
                     text="Disabled"
@@ -12654,11 +13136,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Disabled"
@@ -12692,9 +13178,13 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <br />
                 <Button
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Regular"
                     type="button"
@@ -12723,10 +13213,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
+                    element="button"
                     primary={true}
                     size="large"
                     text="Primary"
@@ -12756,10 +13250,14 @@ exports[`Button demo examples states 1`] = `
                   </glamorous(button)>
                 </Button>
                 <Button
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Minimal"
@@ -12792,10 +13290,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Hover"
                     type="button"
@@ -12826,11 +13328,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Hover"
@@ -12862,11 +13368,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Hover"
@@ -12900,10 +13410,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus"
                     type="button"
@@ -12934,11 +13448,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus"
@@ -12970,11 +13488,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus"
@@ -13009,11 +13531,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     size="large"
                     text="Focus & Hover"
                     type="button"
@@ -13046,12 +13572,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Hover"
@@ -13085,12 +13615,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-focus=""
                   data-simulate-hover=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-focus=""
                     data-simulate-hover=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Hover"
@@ -13126,11 +13660,15 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     size="large"
                     text="Focus & Active"
                     type="button"
@@ -13163,12 +13701,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Focus & Active"
@@ -13202,12 +13744,16 @@ exports[`Button demo examples states 1`] = `
                 <Button
                   data-simulate-active=""
                   data-simulate-focus=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-active=""
                     data-simulate-focus=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Focus & Active"
@@ -13242,10 +13788,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   data-simulate-active=""
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     size="large"
                     text="Active"
                     type="button"
@@ -13276,11 +13826,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     primary={true}
                     size="large"
                     text="Active"
@@ -13312,11 +13866,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   data-simulate-active=""
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="warning"
                 >
                   <glamorous(button)
                     data-simulate-active=""
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Active"
@@ -13350,10 +13908,14 @@ exports[`Button demo examples states 1`] = `
                 <br />
                 <Button
                   disabled={true}
+                  element="button"
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     size="large"
                     text="Disabled"
                     type="button"
@@ -13384,11 +13946,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   primary={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     primary={true}
                     size="large"
                     text="Disabled"
@@ -13420,11 +13986,15 @@ exports[`Button demo examples states 1`] = `
                 </Button>
                 <Button
                   disabled={true}
+                  element="button"
                   minimal={true}
+                  size="large"
+                  type="button"
                   variant="danger"
                 >
                   <glamorous(button)
                     disabled={true}
+                    element="button"
                     minimal={true}
                     size="large"
                     text="Disabled"
@@ -13776,8 +14346,14 @@ exports[`Button demo examples truncation 1`] = `
               <div
                 className="glamor-3"
               >
-                <Button>
+                <Button
+                  element="button"
+                  size="large"
+                  type="button"
+                  variant="regular"
+                >
                   <glamorous(button)
+                    element="button"
                     size="large"
                     text="Supercalifragilisticexpialidocious"
                     type="button"

--- a/src/Card/__tests__/__snapshots__/Card.spec.js.snap
+++ b/src/Card/__tests__/__snapshots__/Card.spec.js.snap
@@ -780,9 +780,14 @@ exports[`Card demo examples children 1`] = `
                           className="glamor-5"
                         >
                           <Button
+                            element="button"
                             fullWidth={true}
+                            size="large"
+                            type="button"
+                            variant="regular"
                           >
                             <glamorous(button)
+                              element="button"
                               fullWidth={true}
                               size="large"
                               text="Button"
@@ -1265,9 +1270,14 @@ exports[`Card demo examples children 2`] = `
                                 className="glamor-5"
                               >
                                 <Button
+                                  element="button"
                                   fullWidth={true}
+                                  size="large"
+                                  type="button"
+                                  variant="regular"
                                 >
                                   <glamorous(button)
+                                    element="button"
                                     fullWidth={true}
                                     size="large"
                                     text="Button"

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -444,9 +444,13 @@ exports[`Dropdown demo examples basic 1`] = `
                                 aria-haspopup={true}
                                 aria-owns="dropdown-42-dropdownContent"
                                 disabled={undefined}
+                                element="button"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="button"
+                                size="large"
+                                type="button"
+                                variant="regular"
                               >
                                 <glamorous(button)
                                   aria-activedescendant={undefined}
@@ -456,6 +460,7 @@ exports[`Dropdown demo examples basic 1`] = `
                                   aria-haspopup={true}
                                   aria-owns="dropdown-42-dropdownContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
@@ -1040,9 +1045,13 @@ exports[`Dropdown demo examples controlled 1`] = `
                                       aria-haspopup={true}
                                       aria-owns="dropdown-56-dropdownContent"
                                       disabled={undefined}
+                                      element="button"
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       role="button"
+                                      size="large"
+                                      type="button"
+                                      variant="regular"
                                     >
                                       <glamorous(button)
                                         aria-activedescendant={undefined}
@@ -1052,6 +1061,7 @@ exports[`Dropdown demo examples controlled 1`] = `
                                         aria-haspopup={true}
                                         aria-owns="dropdown-56-dropdownContent"
                                         disabled={undefined}
+                                        element="button"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         role="button"
@@ -1102,9 +1112,14 @@ exports[`Dropdown demo examples controlled 1`] = `
                     </Popover>
                   </Dropdown>
                   <Button
+                    element="button"
                     onClick={[Function]}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       onClick={[Function]}
                       size="large"
                       text="Open Dropdown"
@@ -1662,9 +1677,13 @@ exports[`Dropdown demo examples data 1`] = `
                                   aria-haspopup={true}
                                   aria-owns="dropdown-44-dropdownContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  size="large"
+                                  type="button"
+                                  variant="regular"
                                 >
                                   <glamorous(button)
                                     aria-activedescendant={undefined}
@@ -1674,6 +1693,7 @@ exports[`Dropdown demo examples data 1`] = `
                                     aria-haspopup={true}
                                     aria-owns="dropdown-44-dropdownContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="button"
@@ -2176,9 +2196,13 @@ exports[`Dropdown demo examples disabled 1`] = `
                                 aria-haspopup={true}
                                 aria-owns="dropdown-54-dropdownContent"
                                 disabled={true}
+                                element="button"
                                 onClick={undefined}
                                 onKeyDown={[Function]}
                                 role="button"
+                                size="large"
+                                type="button"
+                                variant="regular"
                               >
                                 <glamorous(button)
                                   aria-activedescendant={undefined}
@@ -2188,6 +2212,7 @@ exports[`Dropdown demo examples disabled 1`] = `
                                   aria-haspopup={true}
                                   aria-owns="dropdown-54-dropdownContent"
                                   disabled={true}
+                                  element="button"
                                   onClick={undefined}
                                   onKeyDown={[Function]}
                                   role="button"
@@ -2704,9 +2729,13 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                                   aria-haspopup={true}
                                   aria-owns="dropdown-52-dropdownContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  size="large"
+                                  type="button"
+                                  variant="regular"
                                 >
                                   <glamorous(button)
                                     aria-activedescendant={undefined}
@@ -2716,6 +2745,7 @@ exports[`Dropdown demo examples on-open-close 1`] = `
                                     aria-haspopup={true}
                                     aria-owns="dropdown-52-dropdownContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="button"
@@ -3401,9 +3431,13 @@ exports[`Dropdown demo examples placement 1`] = `
                                     aria-haspopup={true}
                                     aria-owns="dropdown-48-dropdownContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="button"
+                                    size="large"
+                                    type="button"
+                                    variant="regular"
                                   >
                                     <glamorous(button)
                                       aria-activedescendant="dropdown-48-dropdownContent-menu"
@@ -3413,6 +3447,7 @@ exports[`Dropdown demo examples placement 1`] = `
                                       aria-haspopup={true}
                                       aria-owns="dropdown-48-dropdownContent"
                                       disabled={undefined}
+                                      element="button"
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       role="button"
@@ -4626,9 +4661,13 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                               aria-haspopup={true}
                                               aria-owns="dropdown-50-dropdownContent"
                                               disabled={undefined}
+                                              element="button"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
                                               role="button"
+                                              size="large"
+                                              type="button"
+                                              variant="regular"
                                             >
                                               <glamorous(button)
                                                 aria-activedescendant="dropdown-50-dropdownContent-menu"
@@ -4638,6 +4677,7 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                                                 aria-haspopup={true}
                                                 aria-owns="dropdown-50-dropdownContent"
                                                 disabled={undefined}
+                                                element="button"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 role="button"
@@ -5086,12 +5126,16 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
                   >
                     <Button
                       className="glamor-36"
+                      element="button"
                       minimal={true}
                       onClick={[Function]}
                       size="small"
+                      type="button"
+                      variant="regular"
                     >
                       <glamorous(button)
                         className="glamor-36"
+                        element="button"
                         minimal={true}
                         onClick={[Function]}
                         size="small"
@@ -5758,9 +5802,13 @@ exports[`Dropdown demo examples wide 1`] = `
                                     aria-haspopup={true}
                                     aria-owns="dropdown-46-dropdownContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="button"
+                                    size="large"
+                                    type="button"
+                                    variant="regular"
                                   >
                                     <glamorous(button)
                                       aria-activedescendant="dropdown-46-dropdownContent-menu"
@@ -5770,6 +5818,7 @@ exports[`Dropdown demo examples wide 1`] = `
                                       aria-haspopup={true}
                                       aria-owns="dropdown-46-dropdownContent"
                                       disabled={undefined}
+                                      element="button"
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       role="button"

--- a/src/Link/__tests__/__snapshots__/Link.spec.js.snap
+++ b/src/Link/__tests__/__snapshots__/Link.spec.js.snap
@@ -640,8 +640,12 @@ exports[`Link demo examples button 1`] = `
             <Button
               element="a"
               href="#button"
+              size="large"
+              type="button"
+              variant="regular"
             >
               <glamorous(a)
+                element="a"
                 href="#button"
                 size="large"
                 text="Link"

--- a/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -341,8 +341,12 @@ exports[`Popover demo examples basic 1`] = `
                               aria-expanded={false}
                               aria-owns="popover-11-popoverContent"
                               disabled={undefined}
+                              element="button"
                               onClick={[Function]}
                               role="button"
+                              size="large"
+                              type="button"
+                              variant="regular"
                             >
                               <glamorous(button)
                                 aria-describedby="popover-11-popoverContent"
@@ -350,6 +354,7 @@ exports[`Popover demo examples basic 1`] = `
                                 aria-expanded={false}
                                 aria-owns="popover-11-popoverContent"
                                 disabled={undefined}
+                                element="button"
                                 onClick={[Function]}
                                 role="button"
                                 size="large"
@@ -829,8 +834,12 @@ exports[`Popover demo examples controlled 1`] = `
                                     aria-expanded={false}
                                     aria-owns="popover-18-popoverContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     role="button"
+                                    size="large"
+                                    type="button"
+                                    variant="regular"
                                   >
                                     <glamorous(button)
                                       aria-describedby="popover-18-popoverContent"
@@ -838,6 +847,7 @@ exports[`Popover demo examples controlled 1`] = `
                                       aria-expanded={false}
                                       aria-owns="popover-18-popoverContent"
                                       disabled={undefined}
+                                      element="button"
                                       onClick={[Function]}
                                       role="button"
                                       size="large"
@@ -883,9 +893,14 @@ exports[`Popover demo examples controlled 1`] = `
                     </Popover>
                   </Popover>
                   <Button
+                    element="button"
                     onClick={[Function]}
+                    size="large"
+                    type="button"
+                    variant="regular"
                   >
                     <glamorous(button)
+                      element="button"
                       onClick={[Function]}
                       size="large"
                       text="Open Popover"
@@ -1266,8 +1281,12 @@ exports[`Popover demo examples disabled 1`] = `
                               aria-expanded={false}
                               aria-owns="popover-17-popoverContent"
                               disabled={true}
+                              element="button"
                               onClick={undefined}
                               role="button"
+                              size="large"
+                              type="button"
+                              variant="regular"
                             >
                               <glamorous(button)
                                 aria-describedby="popover-17-popoverContent"
@@ -1275,6 +1294,7 @@ exports[`Popover demo examples disabled 1`] = `
                                 aria-expanded={false}
                                 aria-owns="popover-17-popoverContent"
                                 disabled={true}
+                                element="button"
                                 onClick={undefined}
                                 role="button"
                                 size="large"
@@ -1686,8 +1706,12 @@ exports[`Popover demo examples on-open-close 1`] = `
                                 aria-expanded={false}
                                 aria-owns="popover-16-popoverContent"
                                 disabled={undefined}
+                                element="button"
                                 onClick={[Function]}
                                 role="button"
+                                size="large"
+                                type="button"
+                                variant="regular"
                               >
                                 <glamorous(button)
                                   aria-describedby="popover-16-popoverContent"
@@ -1695,6 +1719,7 @@ exports[`Popover demo examples on-open-close 1`] = `
                                   aria-expanded={false}
                                   aria-owns="popover-16-popoverContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   role="button"
                                   size="large"
@@ -2162,8 +2187,12 @@ exports[`Popover demo examples overflow 1`] = `
                                   aria-expanded={true}
                                   aria-owns="popover-14-popoverContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   role="button"
+                                  size="large"
+                                  type="button"
+                                  variant="regular"
                                 >
                                   <glamorous(button)
                                     aria-describedby="popover-14-popoverContent"
@@ -2171,6 +2200,7 @@ exports[`Popover demo examples overflow 1`] = `
                                     aria-expanded={true}
                                     aria-owns="popover-14-popoverContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     role="button"
                                     size="large"
@@ -2898,8 +2928,12 @@ exports[`Popover demo examples placement 1`] = `
                                   aria-expanded={true}
                                   aria-owns="popover-13-popoverContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   role="button"
+                                  size="large"
+                                  type="button"
+                                  variant="regular"
                                 >
                                   <glamorous(button)
                                     aria-describedby="popover-13-popoverContent"
@@ -2907,6 +2941,7 @@ exports[`Popover demo examples placement 1`] = `
                                     aria-expanded={true}
                                     aria-owns="popover-13-popoverContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     role="button"
                                     size="large"
@@ -3773,8 +3808,12 @@ exports[`Popover demo examples scrolling-container 1`] = `
                                             aria-expanded={true}
                                             aria-owns="popover-15-popoverContent"
                                             disabled={undefined}
+                                            element="button"
                                             onClick={[Function]}
                                             role="button"
+                                            size="large"
+                                            type="button"
+                                            variant="regular"
                                           >
                                             <glamorous(button)
                                               aria-describedby="popover-15-popoverContent"
@@ -3782,6 +3821,7 @@ exports[`Popover demo examples scrolling-container 1`] = `
                                               aria-expanded={true}
                                               aria-owns="popover-15-popoverContent"
                                               disabled={undefined}
+                                              element="button"
                                               onClick={[Function]}
                                               role="button"
                                               size="large"
@@ -4097,12 +4137,16 @@ exports[`Popover demo examples scrolling-container 1`] = `
                   >
                     <Button
                       className="glamor-18"
+                      element="button"
                       minimal={true}
                       onClick={[Function]}
                       size="small"
+                      type="button"
+                      variant="regular"
                     >
                       <glamorous(button)
                         className="glamor-18"
+                        element="button"
                         minimal={true}
                         onClick={[Function]}
                         size="small"
@@ -4585,8 +4629,12 @@ exports[`Popover demo examples title 1`] = `
                                   aria-expanded={true}
                                   aria-owns="popover-12-popoverContent"
                                   disabled={undefined}
+                                  element="button"
                                   onClick={[Function]}
                                   role="button"
+                                  size="large"
+                                  type="button"
+                                  variant="regular"
                                 >
                                   <glamorous(button)
                                     aria-describedby="popover-12-popoverContent"
@@ -4594,6 +4642,7 @@ exports[`Popover demo examples title 1`] = `
                                     aria-expanded={true}
                                     aria-owns="popover-12-popoverContent"
                                     disabled={undefined}
+                                    element="button"
                                     onClick={[Function]}
                                     role="button"
                                     size="large"

--- a/src/styles/createStyledComponent.js
+++ b/src/styles/createStyledComponent.js
@@ -21,7 +21,7 @@ import componentStyleReset from './componentStyleReset';
 export default function createStyledComponent(
   element:
     | React$StatelessFunctionalComponent<*>
-    | Class<React$ComponentType<*>>
+    | React$ComponentType<*>
     | string,
   styles: Object | ((props: Object, context?: Object) => Object),
   options?: Object = {}


### PR DESCRIPTION
### Description

Fixes Dropdown Keyboard nav by making Button only re-render its DOM element when the element prop is changed.  This allows the button to retain focus across renders, which is needed for Dropdown event listeners to function properly.

### Motivation and context

closes #443

### Screenshots, videos, or demo, if appropriate

https://443-dropdown-keyboard-nav--mineral-ui.netlify.com/

### How to test

1. View Dropdown demo
2. Tab to the Button in the first Dropdown example
3. Hit the up or down arrow once to open the Dropdown
4. Hit the up or down arrow again to navigate the menu items
5. View the Button demo
6. Ensure everything behaves as expected

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
