### PR TITLE
Mock popper.js to avoid console messages when running tests

### DIFF
--- a/__mocks__/popper.js.js
+++ b/__mocks__/popper.js.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import PopperJs from 'popper.js';
+
+export default class Popper {
+  static placements = PopperJs.placements;
+
+  constructor() {
+    return {
+      destroy: () => {},
+      scheduleUpdate: () => {}
+    };
+  }
+}


### PR DESCRIPTION
### Description

Mock popper.js to avoid console warnings while running tests.

### Motivation and context

Recently, a bunch of console messages about `document.createRange` began appearing when running the test suite.  These are coming from `popper.js`.  Note, `jsdom` does not support `document.createRange`.

Tried polyfilling `document.createRange`, but it surfaced other issues.  Mocking popper.js is the approach recommended by the popper.js author.

### Screenshots, videos, or demo, if appropriate

https://create-range-polyfill--mineral-ui.netlify.com/

### How to test

1. View the travis build build log for this branch or checkout this branch and run `npm run jest`
1. Note the console warnings about `document.createRange` are gone

### Types of changes

- Other (provide details below)

Removes console warnings during tests

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
