### PR TITLE
Optimize glob to speed up build:icons script

### DIFF
--- a/scripts/build-icons.js
+++ b/scripts/build-icons.js
@@ -15,7 +15,7 @@ const SVGO = require('svgo');
 const { VERBOSE } = process.env;
 
 const SVG_DIR = path.join(__dirname, '../node_modules/material-design-icons');
-const SVG_GLOB = '**/production/*_24px.svg';
+const SVG_GLOB = '*/svg/production/*_24px.svg';
 const ICON_SRC_DIR = path.join(__dirname, '../src/Icon');
 const ICON_COMPONENTS_DIR = ICON_SRC_DIR;
 const ICON_COMPONENT_TEMPLATE_PATH = path.join(


### PR DESCRIPTION
### Description

Speeds up `build-icons` npm script, thus also speeds up npm installs.  What used to take ~6s now takes <1s.

### Motivation and context

Noticed the optimization while exploring the possibility of extracting icons to a separate package.  We can get this performance benefit now, without needing to wait for the new package.

### Screenshots, videos, or demo, if appropriate

https://build-icons--mineral-ui.netlify.com/

<img width="426" alt="screen shot 2017-11-04 at 10 41 20 am" src="https://user-images.githubusercontent.com/202773/32407311-d07491d2-c14c-11e7-89ed-d33f17a5e9fd.png">


### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. Compare the speed of either `npm i` or `npm run build:icons` on master vs this branch
1. Ensure all of the icons are still there.

### Types of changes

- Other (provide details below)

Performance optimization of `build:icons` script

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
