### PR TITLE
[Website] fix bug in palette demo

### DIFF
--- a/src/website/app/pages/PaletteDemo/ControlPanel.js
+++ b/src/website/app/pages/PaletteDemo/ControlPanel.js
@@ -23,10 +23,9 @@ import ColorRamp from './ColorRamp';
 import Picker from './Picker';
 
 type Props = {
-  activeColor: string,
+  activeColor: Colors,
   availableThemes: { [Colors]: string },
   changeTheme: Colors => void,
-  defaultColor: Colors,
   theme: { [string]: any }
 };
 
@@ -76,7 +75,6 @@ export default function ControlPanel({
   activeColor,
   availableThemes,
   changeTheme,
-  defaultColor,
   theme
 }: Props) {
   const primaries = createColorRamp('color_theme', activeColor, theme);
@@ -87,7 +85,7 @@ export default function ControlPanel({
       <ThemeProvider theme={theme}>
         <div>
           <Picker
-            defaultColor={defaultColor}
+            activeColor={activeColor}
             availableThemes={availableThemes}
             changeTheme={changeTheme}
           />

--- a/src/website/app/pages/PaletteDemo/Picker.js
+++ b/src/website/app/pages/PaletteDemo/Picker.js
@@ -26,13 +26,12 @@ import Heading from '../../Heading';
 import Paragraph from '../../Paragraph';
 
 type Props = {
-  defaultColor: Colors,
+  activeColor: Colors,
   availableThemes: { [Colors]: string },
   changeTheme: Colors => void
 };
 
 type State = {
-  activeColor: Colors,
   isOpen: boolean,
   visibleThemeCount: number
 };
@@ -236,7 +235,6 @@ const Flip = ({
 
 export default class Picker extends Component<Props, State> {
   state: State = {
-    activeColor: this.props.defaultColor,
     isOpen: false,
     visibleThemeCount: 0
   };
@@ -244,8 +242,8 @@ export default class Picker extends Component<Props, State> {
   toggleInterval: ?number;
 
   render() {
-    const { availableThemes } = this.props;
-    const { activeColor, isOpen, visibleThemeCount } = this.state;
+    const { availableThemes, activeColor } = this.props;
+    const { isOpen, visibleThemeCount } = this.state;
 
     return (
       <Root>
@@ -285,7 +283,6 @@ export default class Picker extends Component<Props, State> {
 
   handleColorChange = (color: Colors) => {
     this.props.changeTheme(color);
-    this.setState({ activeColor: color });
   };
 
   open = () => {

--- a/src/website/app/pages/PaletteDemo/index.js
+++ b/src/website/app/pages/PaletteDemo/index.js
@@ -119,7 +119,6 @@ export default class PaletteDemo extends Component<Props, State> {
       activeColor,
       availableThemes,
       theme,
-      defaultColor: mineralColor,
       changeTheme: this.handleThemeChange
     };
 


### PR DESCRIPTION
### Description
There was a bug in the palette demo where a different color would be shown as active for different screen sizes. This PR fixes that 🐞 

### Motivation and context
the Picker component was keeping track of its color in state, which was pointless. There are two instances of ControlPanel (and thus Pickers) due to how I'm handling responsive layout. Now there is only one source of truth for `activeColor` in the `PaletteDemo/index` file and it's passed through props.

https://palette-color-bug--mineral-ui.netlify.com/

### How to test

1. `cd mineral-ui && npm start`
2. Navigate to the Palette Demo
3. Pick a non-blue color in the sidebar
4. Drag the window until the picker is in the flow of the page (tablet or smaller)
5. Pick a different color. Upon dragging the window to the full width, the active color should stay the same

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
![killin dem bugs](https://media.giphy.com/media/HVSIfsotI4lry/giphy.gif)
