### PR TITLE
Improve Icon a11y by using role="img"

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -213,7 +213,7 @@ const styles = {
       },
       '&::-moz-focus-inner': { border: 0 },
 
-      '& [role="icon"]': {
+      '& [role="img"]': {
         boxSizing: 'content-box',
         fill:
           disabled || primary || minimal || variant !== 'regular'

--- a/src/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -107,25 +107,25 @@ exports[`Button demo examples circular 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -196,25 +196,25 @@ exports[`Button demo examples circular 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -284,25 +284,25 @@ exports[`Button demo examples circular 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -373,25 +373,25 @@ exports[`Button demo examples circular 1`] = `
   border: 0;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-11 [role="icon"]:only-child,
-[data-glamor-11] [role="icon"]:only-child {
+.glamor-11 [role="img"]:only-child,
+[data-glamor-11] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -462,25 +462,25 @@ exports[`Button demo examples circular 1`] = `
   border: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-14 [role="icon"]:only-child,
-[data-glamor-14] [role="icon"]:only-child {
+.glamor-14 [role="img"]:only-child,
+[data-glamor-14] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -551,25 +551,25 @@ exports[`Button demo examples circular 1`] = `
   border: 0;
 }
 
-.glamor-17 [role="icon"],
-[data-glamor-17] [role="icon"] {
+.glamor-17 [role="img"],
+[data-glamor-17] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-17 [role="icon"]:first-child,
-[data-glamor-17] [role="icon"]:first-child {
+.glamor-17 [role="img"]:first-child,
+[data-glamor-17] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-17 [role="icon"]:last-child,
-[data-glamor-17] [role="icon"]:last-child {
+.glamor-17 [role="img"]:last-child,
+[data-glamor-17] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-17 [role="icon"]:only-child,
-[data-glamor-17] [role="icon"]:only-child {
+.glamor-17 [role="img"]:only-child,
+[data-glamor-17] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -802,7 +802,7 @@ exports[`Button demo examples circular 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -811,7 +811,7 @@ exports[`Button demo examples circular 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -868,7 +868,7 @@ exports[`Button demo examples circular 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -877,7 +877,7 @@ exports[`Button demo examples circular 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -934,7 +934,7 @@ exports[`Button demo examples circular 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -943,7 +943,7 @@ exports[`Button demo examples circular 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -998,7 +998,7 @@ exports[`Button demo examples circular 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="medium"
                                   viewBox="0 0 24 24"
@@ -1007,7 +1007,7 @@ exports[`Button demo examples circular 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-9"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -1062,7 +1062,7 @@ exports[`Button demo examples circular 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="medium"
                                   viewBox="0 0 24 24"
@@ -1071,7 +1071,7 @@ exports[`Button demo examples circular 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-9"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -1126,7 +1126,7 @@ exports[`Button demo examples circular 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -1135,7 +1135,7 @@ exports[`Button demo examples circular 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -1280,25 +1280,25 @@ exports[`Button demo examples default 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1369,25 +1369,25 @@ exports[`Button demo examples default 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1458,25 +1458,25 @@ exports[`Button demo examples default 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1547,25 +1547,25 @@ exports[`Button demo examples default 1`] = `
   border: 0;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-11 [role="icon"]:only-child,
-[data-glamor-11] [role="icon"]:only-child {
+.glamor-11 [role="img"]:only-child,
+[data-glamor-11] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1634,25 +1634,25 @@ exports[`Button demo examples default 1`] = `
   border: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-14 [role="icon"]:only-child,
-[data-glamor-14] [role="icon"]:only-child {
+.glamor-14 [role="img"]:only-child,
+[data-glamor-14] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2127,25 +2127,25 @@ exports[`Button demo examples icon-only 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2216,25 +2216,25 @@ exports[`Button demo examples icon-only 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2304,25 +2304,25 @@ exports[`Button demo examples icon-only 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2393,25 +2393,25 @@ exports[`Button demo examples icon-only 1`] = `
   border: 0;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-11 [role="icon"]:only-child,
-[data-glamor-11] [role="icon"]:only-child {
+.glamor-11 [role="img"]:only-child,
+[data-glamor-11] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2482,25 +2482,25 @@ exports[`Button demo examples icon-only 1`] = `
   border: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-14 [role="icon"]:only-child,
-[data-glamor-14] [role="icon"]:only-child {
+.glamor-14 [role="img"]:only-child,
+[data-glamor-14] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2571,25 +2571,25 @@ exports[`Button demo examples icon-only 1`] = `
   border: 0;
 }
 
-.glamor-17 [role="icon"],
-[data-glamor-17] [role="icon"] {
+.glamor-17 [role="img"],
+[data-glamor-17] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-17 [role="icon"]:first-child,
-[data-glamor-17] [role="icon"]:first-child {
+.glamor-17 [role="img"]:first-child,
+[data-glamor-17] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-17 [role="icon"]:last-child,
-[data-glamor-17] [role="icon"]:last-child {
+.glamor-17 [role="img"]:last-child,
+[data-glamor-17] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-17 [role="icon"]:only-child,
-[data-glamor-17] [role="icon"]:only-child {
+.glamor-17 [role="img"]:only-child,
+[data-glamor-17] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2821,7 +2821,7 @@ exports[`Button demo examples icon-only 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -2830,7 +2830,7 @@ exports[`Button demo examples icon-only 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -2885,7 +2885,7 @@ exports[`Button demo examples icon-only 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -2894,7 +2894,7 @@ exports[`Button demo examples icon-only 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -2949,7 +2949,7 @@ exports[`Button demo examples icon-only 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -2958,7 +2958,7 @@ exports[`Button demo examples icon-only 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -3011,7 +3011,7 @@ exports[`Button demo examples icon-only 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="medium"
                                   viewBox="0 0 24 24"
@@ -3020,7 +3020,7 @@ exports[`Button demo examples icon-only 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-9"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -3073,7 +3073,7 @@ exports[`Button demo examples icon-only 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="medium"
                                   viewBox="0 0 24 24"
@@ -3082,7 +3082,7 @@ exports[`Button demo examples icon-only 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-9"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -3135,7 +3135,7 @@ exports[`Button demo examples icon-only 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -3144,7 +3144,7 @@ exports[`Button demo examples icon-only 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -3246,25 +3246,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-16 [role="icon"],
-[data-glamor-16] [role="icon"] {
+.glamor-16 [role="img"],
+[data-glamor-16] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-16 [role="icon"]:first-child,
-[data-glamor-16] [role="icon"]:first-child {
+.glamor-16 [role="img"]:first-child,
+[data-glamor-16] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-16 [role="icon"]:last-child,
-[data-glamor-16] [role="icon"]:last-child {
+.glamor-16 [role="img"]:last-child,
+[data-glamor-16] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-16 [role="icon"]:only-child,
-[data-glamor-16] [role="icon"]:only-child {
+.glamor-16 [role="img"]:only-child,
+[data-glamor-16] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3378,25 +3378,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-3 [role="icon"],
-[data-glamor-3] [role="icon"] {
+.glamor-3 [role="img"],
+[data-glamor-3] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-3 [role="icon"]:first-child,
-[data-glamor-3] [role="icon"]:first-child {
+.glamor-3 [role="img"]:first-child,
+[data-glamor-3] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-3 [role="icon"]:last-child,
-[data-glamor-3] [role="icon"]:last-child {
+.glamor-3 [role="img"]:last-child,
+[data-glamor-3] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-3 [role="icon"]:only-child,
-[data-glamor-3] [role="icon"]:only-child {
+.glamor-3 [role="img"]:only-child,
+[data-glamor-3] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3467,25 +3467,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-28 [role="icon"],
-[data-glamor-28] [role="icon"] {
+.glamor-28 [role="img"],
+[data-glamor-28] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-28 [role="icon"]:first-child,
-[data-glamor-28] [role="icon"]:first-child {
+.glamor-28 [role="img"]:first-child,
+[data-glamor-28] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-28 [role="icon"]:last-child,
-[data-glamor-28] [role="icon"]:last-child {
+.glamor-28 [role="img"]:last-child,
+[data-glamor-28] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-28 [role="icon"]:only-child,
-[data-glamor-28] [role="icon"]:only-child {
+.glamor-28 [role="img"]:only-child,
+[data-glamor-28] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3556,25 +3556,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-32 [role="icon"],
-[data-glamor-32] [role="icon"] {
+.glamor-32 [role="img"],
+[data-glamor-32] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-32 [role="icon"]:first-child,
-[data-glamor-32] [role="icon"]:first-child {
+.glamor-32 [role="img"]:first-child,
+[data-glamor-32] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-32 [role="icon"]:last-child,
-[data-glamor-32] [role="icon"]:last-child {
+.glamor-32 [role="img"]:last-child,
+[data-glamor-32] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-32 [role="icon"]:only-child,
-[data-glamor-32] [role="icon"]:only-child {
+.glamor-32 [role="img"]:only-child,
+[data-glamor-32] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3645,25 +3645,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-24 [role="icon"],
-[data-glamor-24] [role="icon"] {
+.glamor-24 [role="img"],
+[data-glamor-24] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-24 [role="icon"]:first-child,
-[data-glamor-24] [role="icon"]:first-child {
+.glamor-24 [role="img"]:first-child,
+[data-glamor-24] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-24 [role="icon"]:last-child,
-[data-glamor-24] [role="icon"]:last-child {
+.glamor-24 [role="img"]:last-child,
+[data-glamor-24] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-24 [role="icon"]:only-child,
-[data-glamor-24] [role="icon"]:only-child {
+.glamor-24 [role="img"]:only-child,
+[data-glamor-24] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3732,25 +3732,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-36 [role="icon"],
-[data-glamor-36] [role="icon"] {
+.glamor-36 [role="img"],
+[data-glamor-36] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-36 [role="icon"]:first-child,
-[data-glamor-36] [role="icon"]:first-child {
+.glamor-36 [role="img"]:first-child,
+[data-glamor-36] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-36 [role="icon"]:last-child,
-[data-glamor-36] [role="icon"]:last-child {
+.glamor-36 [role="img"]:last-child,
+[data-glamor-36] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-36 [role="icon"]:only-child,
-[data-glamor-36] [role="icon"]:only-child {
+.glamor-36 [role="img"]:only-child,
+[data-glamor-36] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3820,25 +3820,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-20 [role="icon"],
-[data-glamor-20] [role="icon"] {
+.glamor-20 [role="img"],
+[data-glamor-20] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-20 [role="icon"]:first-child,
-[data-glamor-20] [role="icon"]:first-child {
+.glamor-20 [role="img"]:first-child,
+[data-glamor-20] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-20 [role="icon"]:last-child,
-[data-glamor-20] [role="icon"]:last-child {
+.glamor-20 [role="img"]:last-child,
+[data-glamor-20] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-20 [role="icon"]:only-child,
-[data-glamor-20] [role="icon"]:only-child {
+.glamor-20 [role="img"]:only-child,
+[data-glamor-20] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3909,25 +3909,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-40 [role="icon"],
-[data-glamor-40] [role="icon"] {
+.glamor-40 [role="img"],
+[data-glamor-40] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-40 [role="icon"]:first-child,
-[data-glamor-40] [role="icon"]:first-child {
+.glamor-40 [role="img"]:first-child,
+[data-glamor-40] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-40 [role="icon"]:last-child,
-[data-glamor-40] [role="icon"]:last-child {
+.glamor-40 [role="img"]:last-child,
+[data-glamor-40] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-40 [role="icon"]:only-child,
-[data-glamor-40] [role="icon"]:only-child {
+.glamor-40 [role="img"]:only-child,
+[data-glamor-40] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -4010,25 +4010,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-44 [role="icon"],
-[data-glamor-44] [role="icon"] {
+.glamor-44 [role="img"],
+[data-glamor-44] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-44 [role="icon"]:first-child,
-[data-glamor-44] [role="icon"]:first-child {
+.glamor-44 [role="img"]:first-child,
+[data-glamor-44] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-44 [role="icon"]:last-child,
-[data-glamor-44] [role="icon"]:last-child {
+.glamor-44 [role="img"]:last-child,
+[data-glamor-44] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-44 [role="icon"]:only-child,
-[data-glamor-44] [role="icon"]:only-child {
+.glamor-44 [role="img"]:only-child,
+[data-glamor-44] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -4111,25 +4111,25 @@ exports[`Button demo examples icons 1`] = `
   border: 0;
 }
 
-.glamor-52 [role="icon"],
-[data-glamor-52] [role="icon"] {
+.glamor-52 [role="img"],
+[data-glamor-52] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-52 [role="icon"]:first-child,
-[data-glamor-52] [role="icon"]:first-child {
+.glamor-52 [role="img"]:first-child,
+[data-glamor-52] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-52 [role="icon"]:last-child,
-[data-glamor-52] [role="icon"]:last-child {
+.glamor-52 [role="img"]:last-child,
+[data-glamor-52] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-52 [role="icon"]:only-child,
-[data-glamor-52] [role="icon"]:only-child {
+.glamor-52 [role="img"]:only-child,
+[data-glamor-52] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -4403,7 +4403,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4412,7 +4412,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4480,7 +4480,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4489,7 +4489,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4540,7 +4540,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4549,7 +4549,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4581,7 +4581,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4590,7 +4590,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4644,7 +4644,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4653,7 +4653,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4714,7 +4714,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4723,7 +4723,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4782,7 +4782,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4791,7 +4791,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4850,7 +4850,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4859,7 +4859,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4918,7 +4918,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4927,7 +4927,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -4989,7 +4989,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -4998,7 +4998,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -5059,7 +5059,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="medium"
                                   viewBox="0 0 24 24"
@@ -5068,7 +5068,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-37"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -5127,7 +5127,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="medium"
                                   viewBox="0 0 24 24"
@@ -5136,7 +5136,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-37"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -5195,7 +5195,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -5204,7 +5204,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -5263,7 +5263,7 @@ exports[`Button demo examples icons 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={false}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -5272,7 +5272,7 @@ exports[`Button demo examples icons 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -5420,25 +5420,25 @@ exports[`Button demo examples link 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -5766,25 +5766,25 @@ exports[`Button demo examples minimal 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -5854,25 +5854,25 @@ exports[`Button demo examples minimal 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -5942,25 +5942,25 @@ exports[`Button demo examples minimal 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6030,25 +6030,25 @@ exports[`Button demo examples minimal 1`] = `
   border: 0;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-11 [role="icon"]:only-child,
-[data-glamor-11] [role="icon"]:only-child {
+.glamor-11 [role="img"]:only-child,
+[data-glamor-11] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6116,25 +6116,25 @@ exports[`Button demo examples minimal 1`] = `
   border: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-14 [role="icon"]:only-child,
-[data-glamor-14] [role="icon"]:only-child {
+.glamor-14 [role="img"]:only-child,
+[data-glamor-14] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6585,25 +6585,25 @@ exports[`Button demo examples primary 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6717,25 +6717,25 @@ exports[`Button demo examples primary 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6806,25 +6806,25 @@ exports[`Button demo examples primary 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6895,25 +6895,25 @@ exports[`Button demo examples primary 1`] = `
   border: 0;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-11 [role="icon"]:only-child,
-[data-glamor-11] [role="icon"]:only-child {
+.glamor-11 [role="img"]:only-child,
+[data-glamor-11] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -6982,25 +6982,25 @@ exports[`Button demo examples primary 1`] = `
   border: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-14 [role="icon"]:only-child,
-[data-glamor-14] [role="icon"]:only-child {
+.glamor-14 [role="img"]:only-child,
+[data-glamor-14] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -7463,25 +7463,25 @@ exports[`Button demo examples rtl 1`] = `
   border: 0;
 }
 
-.glamor-3 [role="icon"],
-[data-glamor-3] [role="icon"] {
+.glamor-3 [role="img"],
+[data-glamor-3] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-3 [role="icon"]:first-child,
-[data-glamor-3] [role="icon"]:first-child {
+.glamor-3 [role="img"]:first-child,
+[data-glamor-3] [role="img"]:first-child {
   margin-left: 0.5em;
 }
 
-.glamor-3 [role="icon"]:last-child,
-[data-glamor-3] [role="icon"]:last-child {
+.glamor-3 [role="img"]:last-child,
+[data-glamor-3] [role="img"]:last-child {
   margin-right: 0.5em;
 }
 
-.glamor-3 [role="icon"]:only-child,
-[data-glamor-3] [role="icon"]:only-child {
+.glamor-3 [role="img"]:only-child,
+[data-glamor-3] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -7743,7 +7743,7 @@ exports[`Button demo examples rtl 1`] = `
                                 <glamorous(svg)
                                   aria-hidden={true}
                                   aria-labelledby={undefined}
-                                  role="icon"
+                                  role="img"
                                   rtl={true}
                                   size="1.5em"
                                   viewBox="0 0 24 24"
@@ -7752,7 +7752,7 @@ exports[`Button demo examples rtl 1`] = `
                                     aria-hidden={true}
                                     aria-labelledby={undefined}
                                     className="glamor-0"
-                                    role="icon"
+                                    role="img"
                                     viewBox="0 0 24 24"
                                   >
                                     <g>
@@ -7906,25 +7906,25 @@ exports[`Button demo examples sizes 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -7995,25 +7995,25 @@ exports[`Button demo examples sizes 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -8096,25 +8096,25 @@ exports[`Button demo examples sizes 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -8197,25 +8197,25 @@ exports[`Button demo examples sizes 1`] = `
   border: 0;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-11 [role="icon"]:only-child,
-[data-glamor-11] [role="icon"]:only-child {
+.glamor-11 [role="img"]:only-child,
+[data-glamor-11] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -8313,25 +8313,25 @@ exports[`Button demo examples sizes 1`] = `
   border: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-14 [role="icon"]:only-child,
-[data-glamor-14] [role="icon"]:only-child {
+.glamor-14 [role="img"]:only-child,
+[data-glamor-14] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -8766,25 +8766,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-5 [role="icon"]:only-child,
-[data-glamor-5] [role="icon"]:only-child {
+.glamor-5 [role="img"]:only-child,
+[data-glamor-5] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -8898,25 +8898,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-131 [role="icon"],
-[data-glamor-131] [role="icon"] {
+.glamor-131 [role="img"],
+[data-glamor-131] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-131 [role="icon"]:first-child,
-[data-glamor-131] [role="icon"]:first-child {
+.glamor-131 [role="img"]:first-child,
+[data-glamor-131] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-131 [role="icon"]:last-child,
-[data-glamor-131] [role="icon"]:last-child {
+.glamor-131 [role="img"]:last-child,
+[data-glamor-131] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-131 [role="icon"]:only-child,
-[data-glamor-131] [role="icon"]:only-child {
+.glamor-131 [role="img"]:only-child,
+[data-glamor-131] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -8987,25 +8987,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-194 [role="icon"],
-[data-glamor-194] [role="icon"] {
+.glamor-194 [role="img"],
+[data-glamor-194] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-194 [role="icon"]:first-child,
-[data-glamor-194] [role="icon"]:first-child {
+.glamor-194 [role="img"]:first-child,
+[data-glamor-194] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-194 [role="icon"]:last-child,
-[data-glamor-194] [role="icon"]:last-child {
+.glamor-194 [role="img"]:last-child,
+[data-glamor-194] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-194 [role="icon"]:only-child,
-[data-glamor-194] [role="icon"]:only-child {
+.glamor-194 [role="img"]:only-child,
+[data-glamor-194] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9076,25 +9076,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-68 [role="icon"],
-[data-glamor-68] [role="icon"] {
+.glamor-68 [role="img"],
+[data-glamor-68] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-68 [role="icon"]:first-child,
-[data-glamor-68] [role="icon"]:first-child {
+.glamor-68 [role="img"]:first-child,
+[data-glamor-68] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-68 [role="icon"]:last-child,
-[data-glamor-68] [role="icon"]:last-child {
+.glamor-68 [role="img"]:last-child,
+[data-glamor-68] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-68 [role="icon"]:only-child,
-[data-glamor-68] [role="icon"]:only-child {
+.glamor-68 [role="img"]:only-child,
+[data-glamor-68] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9163,25 +9163,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-59 [role="icon"],
-[data-glamor-59] [role="icon"] {
+.glamor-59 [role="img"],
+[data-glamor-59] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-59 [role="icon"]:first-child,
-[data-glamor-59] [role="icon"]:first-child {
+.glamor-59 [role="img"]:first-child,
+[data-glamor-59] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-59 [role="icon"]:last-child,
-[data-glamor-59] [role="icon"]:last-child {
+.glamor-59 [role="img"]:last-child,
+[data-glamor-59] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-59 [role="icon"]:only-child,
-[data-glamor-59] [role="icon"]:only-child {
+.glamor-59 [role="img"]:only-child,
+[data-glamor-59] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9252,25 +9252,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9341,25 +9341,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-128 [role="icon"],
-[data-glamor-128] [role="icon"] {
+.glamor-128 [role="img"],
+[data-glamor-128] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-128 [role="icon"]:first-child,
-[data-glamor-128] [role="icon"]:first-child {
+.glamor-128 [role="img"]:first-child,
+[data-glamor-128] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-128 [role="icon"]:last-child,
-[data-glamor-128] [role="icon"]:last-child {
+.glamor-128 [role="img"]:last-child,
+[data-glamor-128] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-128 [role="icon"]:only-child,
-[data-glamor-128] [role="icon"]:only-child {
+.glamor-128 [role="img"]:only-child,
+[data-glamor-128] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9430,25 +9430,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-191 [role="icon"],
-[data-glamor-191] [role="icon"] {
+.glamor-191 [role="img"],
+[data-glamor-191] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-191 [role="icon"]:first-child,
-[data-glamor-191] [role="icon"]:first-child {
+.glamor-191 [role="img"]:first-child,
+[data-glamor-191] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-191 [role="icon"]:last-child,
-[data-glamor-191] [role="icon"]:last-child {
+.glamor-191 [role="img"]:last-child,
+[data-glamor-191] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-191 [role="icon"]:only-child,
-[data-glamor-191] [role="icon"]:only-child {
+.glamor-191 [role="img"]:only-child,
+[data-glamor-191] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9519,25 +9519,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-65 [role="icon"],
-[data-glamor-65] [role="icon"] {
+.glamor-65 [role="img"],
+[data-glamor-65] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-65 [role="icon"]:first-child,
-[data-glamor-65] [role="icon"]:first-child {
+.glamor-65 [role="img"]:first-child,
+[data-glamor-65] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-65 [role="icon"]:last-child,
-[data-glamor-65] [role="icon"]:last-child {
+.glamor-65 [role="img"]:last-child,
+[data-glamor-65] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-65 [role="icon"]:only-child,
-[data-glamor-65] [role="icon"]:only-child {
+.glamor-65 [role="img"]:only-child,
+[data-glamor-65] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9606,25 +9606,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-56 [role="icon"],
-[data-glamor-56] [role="icon"] {
+.glamor-56 [role="img"],
+[data-glamor-56] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-56 [role="icon"]:first-child,
-[data-glamor-56] [role="icon"]:first-child {
+.glamor-56 [role="img"]:first-child,
+[data-glamor-56] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-56 [role="icon"]:last-child,
-[data-glamor-56] [role="icon"]:last-child {
+.glamor-56 [role="img"]:last-child,
+[data-glamor-56] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-56 [role="icon"]:only-child,
-[data-glamor-56] [role="icon"]:only-child {
+.glamor-56 [role="img"]:only-child,
+[data-glamor-56] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9694,25 +9694,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-8 [role="icon"],
-[data-glamor-8] [role="icon"] {
+.glamor-8 [role="img"],
+[data-glamor-8] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-8 [role="icon"]:first-child,
-[data-glamor-8] [role="icon"]:first-child {
+.glamor-8 [role="img"]:first-child,
+[data-glamor-8] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-8 [role="icon"]:last-child,
-[data-glamor-8] [role="icon"]:last-child {
+.glamor-8 [role="img"]:last-child,
+[data-glamor-8] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-8 [role="icon"]:only-child,
-[data-glamor-8] [role="icon"]:only-child {
+.glamor-8 [role="img"]:only-child,
+[data-glamor-8] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9782,25 +9782,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-134 [role="icon"],
-[data-glamor-134] [role="icon"] {
+.glamor-134 [role="img"],
+[data-glamor-134] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-134 [role="icon"]:first-child,
-[data-glamor-134] [role="icon"]:first-child {
+.glamor-134 [role="img"]:first-child,
+[data-glamor-134] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-134 [role="icon"]:last-child,
-[data-glamor-134] [role="icon"]:last-child {
+.glamor-134 [role="img"]:last-child,
+[data-glamor-134] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-134 [role="icon"]:only-child,
-[data-glamor-134] [role="icon"]:only-child {
+.glamor-134 [role="img"]:only-child,
+[data-glamor-134] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9870,25 +9870,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-197 [role="icon"],
-[data-glamor-197] [role="icon"] {
+.glamor-197 [role="img"],
+[data-glamor-197] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-197 [role="icon"]:first-child,
-[data-glamor-197] [role="icon"]:first-child {
+.glamor-197 [role="img"]:first-child,
+[data-glamor-197] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-197 [role="icon"]:last-child,
-[data-glamor-197] [role="icon"]:last-child {
+.glamor-197 [role="img"]:last-child,
+[data-glamor-197] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-197 [role="icon"]:only-child,
-[data-glamor-197] [role="icon"]:only-child {
+.glamor-197 [role="img"]:only-child,
+[data-glamor-197] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -9958,25 +9958,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-71 [role="icon"],
-[data-glamor-71] [role="icon"] {
+.glamor-71 [role="img"],
+[data-glamor-71] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-71 [role="icon"]:first-child,
-[data-glamor-71] [role="icon"]:first-child {
+.glamor-71 [role="img"]:first-child,
+[data-glamor-71] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-71 [role="icon"]:last-child,
-[data-glamor-71] [role="icon"]:last-child {
+.glamor-71 [role="img"]:last-child,
+[data-glamor-71] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-71 [role="icon"]:only-child,
-[data-glamor-71] [role="icon"]:only-child {
+.glamor-71 [role="img"]:only-child,
+[data-glamor-71] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -10044,25 +10044,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-62 [role="icon"],
-[data-glamor-62] [role="icon"] {
+.glamor-62 [role="img"],
+[data-glamor-62] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-62 [role="icon"]:first-child,
-[data-glamor-62] [role="icon"]:first-child {
+.glamor-62 [role="img"]:first-child,
+[data-glamor-62] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-62 [role="icon"]:last-child,
-[data-glamor-62] [role="icon"]:last-child {
+.glamor-62 [role="img"]:last-child,
+[data-glamor-62] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-62 [role="icon"]:only-child,
-[data-glamor-62] [role="icon"]:only-child {
+.glamor-62 [role="img"]:only-child,
+[data-glamor-62] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -10137,25 +10137,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-119 [role="icon"],
-[data-glamor-119] [role="icon"] {
+.glamor-119 [role="img"],
+[data-glamor-119] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-119 [role="icon"]:first-child,
-[data-glamor-119] [role="icon"]:first-child {
+.glamor-119 [role="img"]:first-child,
+[data-glamor-119] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-119 [role="icon"]:last-child,
-[data-glamor-119] [role="icon"]:last-child {
+.glamor-119 [role="img"]:last-child,
+[data-glamor-119] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-119 [role="icon"]:only-child,
-[data-glamor-119] [role="icon"]:only-child {
+.glamor-119 [role="img"]:only-child,
+[data-glamor-119] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -10224,25 +10224,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-122 [role="icon"],
-[data-glamor-122] [role="icon"] {
+.glamor-122 [role="img"],
+[data-glamor-122] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-122 [role="icon"]:first-child,
-[data-glamor-122] [role="icon"]:first-child {
+.glamor-122 [role="img"]:first-child,
+[data-glamor-122] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-122 [role="icon"]:last-child,
-[data-glamor-122] [role="icon"]:last-child {
+.glamor-122 [role="img"]:last-child,
+[data-glamor-122] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-122 [role="icon"]:only-child,
-[data-glamor-122] [role="icon"]:only-child {
+.glamor-122 [role="img"]:only-child,
+[data-glamor-122] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -10310,25 +10310,25 @@ exports[`Button demo examples states 1`] = `
   border: 0;
 }
 
-.glamor-125 [role="icon"],
-[data-glamor-125] [role="icon"] {
+.glamor-125 [role="img"],
+[data-glamor-125] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-125 [role="icon"]:first-child,
-[data-glamor-125] [role="icon"]:first-child {
+.glamor-125 [role="img"]:first-child,
+[data-glamor-125] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-125 [role="icon"]:last-child,
-[data-glamor-125] [role="icon"]:last-child {
+.glamor-125 [role="img"]:last-child,
+[data-glamor-125] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-125 [role="icon"]:only-child,
-[data-glamor-125] [role="icon"]:only-child {
+.glamor-125 [role="img"]:only-child,
+[data-glamor-125] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -14176,25 +14176,25 @@ exports[`Button demo examples truncation 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 

--- a/src/Card/__tests__/__snapshots__/Card.spec.js.snap
+++ b/src/Card/__tests__/__snapshots__/Card.spec.js.snap
@@ -482,25 +482,25 @@ exports[`Card demo examples children 1`] = `
   border: 0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-4 [role="icon"]:only-child,
-[data-glamor-4] [role="icon"]:only-child {
+.glamor-4 [role="img"]:only-child,
+[data-glamor-4] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -957,25 +957,25 @@ exports[`Card demo examples children 2`] = `
   border: 0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-4 [role="icon"]:only-child,
-[data-glamor-4] [role="icon"]:only-child {
+.glamor-4 [role="img"]:only-child,
+[data-glamor-4] [role="img"]:only-child {
   margin: 0;
 }
 

--- a/src/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -73,25 +73,25 @@ exports[`Dropdown demo examples basic 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -591,25 +591,25 @@ exports[`Dropdown demo examples controlled 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1233,25 +1233,25 @@ exports[`Dropdown demo examples data 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1866,25 +1866,25 @@ exports[`Dropdown demo examples disabled 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2343,25 +2343,25 @@ exports[`Dropdown demo examples on-open-close 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2909,8 +2909,8 @@ exports[`Dropdown demo examples placement 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-9 [role="icon"],
-[data-glamor-9] [role="icon"] {
+.glamor-9 [role="img"],
+[data-glamor-9] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -2918,13 +2918,13 @@ exports[`Dropdown demo examples placement 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-9 [role="icon"]:first-child,
-[data-glamor-9] [role="icon"]:first-child {
+.glamor-9 [role="img"]:first-child,
+[data-glamor-9] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-9 [role="icon"]:last-child,
-[data-glamor-9] [role="icon"]:last-child {
+.glamor-9 [role="img"]:last-child,
+[data-glamor-9] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -3042,25 +3042,25 @@ exports[`Dropdown demo examples placement 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -4000,8 +4000,8 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-9 [role="icon"],
-[data-glamor-9] [role="icon"] {
+.glamor-9 [role="img"],
+[data-glamor-9] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -4009,13 +4009,13 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-9 [role="icon"]:first-child,
-[data-glamor-9] [role="icon"]:first-child {
+.glamor-9 [role="img"]:first-child,
+[data-glamor-9] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-9 [role="icon"]:last-child,
-[data-glamor-9] [role="icon"]:last-child {
+.glamor-9 [role="img"]:last-child,
+[data-glamor-9] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -4133,25 +4133,25 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -4292,25 +4292,25 @@ exports[`Dropdown demo examples scrolling-container 1`] = `
   border: 0;
 }
 
-.glamor-35 [role="icon"],
-[data-glamor-35] [role="icon"] {
+.glamor-35 [role="img"],
+[data-glamor-35] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-35 [role="icon"]:first-child,
-[data-glamor-35] [role="icon"]:first-child {
+.glamor-35 [role="img"]:first-child,
+[data-glamor-35] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-35 [role="icon"]:last-child,
-[data-glamor-35] [role="icon"]:last-child {
+.glamor-35 [role="img"]:last-child,
+[data-glamor-35] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-35 [role="icon"]:only-child,
-[data-glamor-35] [role="icon"]:only-child {
+.glamor-35 [role="img"]:only-child,
+[data-glamor-35] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -5252,8 +5252,8 @@ exports[`Dropdown demo examples wide 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-9 [role="icon"],
-[data-glamor-9] [role="icon"] {
+.glamor-9 [role="img"],
+[data-glamor-9] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -5261,13 +5261,13 @@ exports[`Dropdown demo examples wide 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-9 [role="icon"]:first-child,
-[data-glamor-9] [role="icon"]:first-child {
+.glamor-9 [role="img"]:first-child,
+[data-glamor-9] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-9 [role="icon"]:last-child,
-[data-glamor-9] [role="icon"]:last-child {
+.glamor-9 [role="img"]:last-child,
+[data-glamor-9] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -5385,25 +5385,25 @@ exports[`Dropdown demo examples wide 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -70,16 +70,15 @@ export default class Icon extends Component<Props> {
 
   props: Props;
 
-  uniqueId: string = generateId();
+  id: string = `icon-${generateId()}`;
 
   render() {
-    const { size, title, children, ...restProps } = this.props;
-    const titleElementId = `Icon-title-${this.uniqueId}`;
+    const { title, children, ...restProps } = this.props;
+    const titleElementId = `icon-title-${this.id}`;
     const rootProps = {
       'aria-hidden': title ? null : true,
       'aria-labelledby': title && titleElementId,
-      role: 'icon',
-      size,
+      role: 'img',
       viewBox: '0 0 24 24',
       ...restProps
     };

--- a/src/Icon/__tests__/__snapshots__/Icon.spec.js.snap
+++ b/src/Icon/__tests__/__snapshots__/Icon.spec.js.snap
@@ -184,7 +184,7 @@ exports[`Icon demo examples color 1`] = `
                   aria-hidden={true}
                   aria-labelledby={undefined}
                   color="coral"
-                  role="icon"
+                  role="img"
                   rtl={false}
                   size="medium"
                   viewBox="0 0 24 24"
@@ -194,7 +194,7 @@ exports[`Icon demo examples color 1`] = `
                     aria-labelledby={undefined}
                     className="glamor-0"
                     color="coral"
-                    role="icon"
+                    role="img"
                     viewBox="0 0 24 24"
                   >
                     <g>
@@ -428,20 +428,20 @@ exports[`Icon demo examples custom 1`] = `
             >
               <glamorous(svg)
                 aria-hidden={null}
-                aria-labelledby="Icon-title-9"
-                role="icon"
+                aria-labelledby="icon-title-icon-9"
+                role="img"
                 size="7em"
                 viewBox="0 0 24 24"
               >
                 <svg
                   aria-hidden={null}
-                  aria-labelledby="Icon-title-9"
+                  aria-labelledby="icon-title-icon-9"
                   className="glamor-0"
-                  role="icon"
+                  role="img"
                   viewBox="0 0 24 24"
                 >
                   <title
-                    id="Icon-title-9"
+                    id="icon-title-icon-9"
                   >
                     CA Technologies
                   </title>
@@ -694,7 +694,7 @@ exports[`Icon demo examples icon 1`] = `
                 <glamorous(svg)
                   aria-hidden={true}
                   aria-labelledby={undefined}
-                  role="icon"
+                  role="img"
                   rtl={false}
                   size="medium"
                   viewBox="0 0 24 24"
@@ -703,7 +703,7 @@ exports[`Icon demo examples icon 1`] = `
                     aria-hidden={true}
                     aria-labelledby={undefined}
                     className="glamor-0"
-                    role="icon"
+                    role="img"
                     viewBox="0 0 24 24"
                   >
                     <g>
@@ -934,7 +934,7 @@ exports[`Icon demo examples rtl 1`] = `
                     <glamorous(svg)
                       aria-hidden={true}
                       aria-labelledby={undefined}
-                      role="icon"
+                      role="img"
                       rtl={true}
                       size="medium"
                       viewBox="0 0 24 24"
@@ -943,7 +943,7 @@ exports[`Icon demo examples rtl 1`] = `
                         aria-hidden={true}
                         aria-labelledby={undefined}
                         className="glamor-0"
-                        role="icon"
+                        role="img"
                         viewBox="0 0 24 24"
                       >
                         <g>
@@ -1178,7 +1178,7 @@ exports[`Icon demo examples sizes 1`] = `
                   <glamorous(svg)
                     aria-hidden={true}
                     aria-labelledby={undefined}
-                    role="icon"
+                    role="img"
                     rtl={false}
                     size="small"
                     viewBox="0 0 24 24"
@@ -1187,7 +1187,7 @@ exports[`Icon demo examples sizes 1`] = `
                       aria-hidden={true}
                       aria-labelledby={undefined}
                       className="glamor-0"
-                      role="icon"
+                      role="img"
                       viewBox="0 0 24 24"
                     >
                       <g>
@@ -1217,7 +1217,7 @@ exports[`Icon demo examples sizes 1`] = `
                   <glamorous(svg)
                     aria-hidden={true}
                     aria-labelledby={undefined}
-                    role="icon"
+                    role="img"
                     rtl={false}
                     size="medium"
                     viewBox="0 0 24 24"
@@ -1226,7 +1226,7 @@ exports[`Icon demo examples sizes 1`] = `
                       aria-hidden={true}
                       aria-labelledby={undefined}
                       className="glamor-1"
-                      role="icon"
+                      role="img"
                       viewBox="0 0 24 24"
                     >
                       <g>
@@ -1258,7 +1258,7 @@ exports[`Icon demo examples sizes 1`] = `
                   <glamorous(svg)
                     aria-hidden={true}
                     aria-labelledby={undefined}
-                    role="icon"
+                    role="img"
                     rtl={false}
                     size="large"
                     viewBox="0 0 24 24"
@@ -1267,7 +1267,7 @@ exports[`Icon demo examples sizes 1`] = `
                       aria-hidden={true}
                       aria-labelledby={undefined}
                       className="glamor-2"
-                      role="icon"
+                      role="img"
                       viewBox="0 0 24 24"
                     >
                       <g>
@@ -1299,7 +1299,7 @@ exports[`Icon demo examples sizes 1`] = `
                   <glamorous(svg)
                     aria-hidden={true}
                     aria-labelledby={undefined}
-                    role="icon"
+                    role="img"
                     rtl={false}
                     size="7em"
                     viewBox="0 0 24 24"
@@ -1308,7 +1308,7 @@ exports[`Icon demo examples sizes 1`] = `
                       aria-hidden={true}
                       aria-labelledby={undefined}
                       className="glamor-3"
-                      role="icon"
+                      role="img"
                       viewBox="0 0 24 24"
                     >
                       <g>
@@ -1521,21 +1521,21 @@ exports[`Icon demo examples title 1`] = `
               >
                 <glamorous(svg)
                   aria-hidden={null}
-                  aria-labelledby="Icon-title-7"
-                  role="icon"
+                  aria-labelledby="icon-title-icon-7"
+                  role="img"
                   rtl={false}
                   size="medium"
                   viewBox="0 0 24 24"
                 >
                   <svg
                     aria-hidden={null}
-                    aria-labelledby="Icon-title-7"
+                    aria-labelledby="icon-title-icon-7"
                     className="glamor-0"
-                    role="icon"
+                    role="img"
                     viewBox="0 0 24 24"
                   >
                     <title
-                      id="Icon-title-7"
+                      id="icon-title-icon-7"
                     >
                       smiley-face
                     </title>

--- a/src/Link/__tests__/__snapshots__/Link.spec.js.snap
+++ b/src/Link/__tests__/__snapshots__/Link.spec.js.snap
@@ -409,25 +409,25 @@ exports[`Link demo examples button 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -138,7 +138,7 @@ const styles = {
         backgroundColor: !disabled && theme.MenuItem_backgroundColor_active
       },
 
-      '& [role="icon"]': {
+      '& [role="img"]': {
         boxSizing: 'content-box',
         display: 'block',
         fill:

--- a/src/Menu/__tests__/__snapshots__/Menu.spec.js.snap
+++ b/src/Menu/__tests__/__snapshots__/Menu.spec.js.snap
@@ -63,8 +63,8 @@ exports[`Menu demo examples basic 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -72,13 +72,13 @@ exports[`Menu demo examples basic 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -201,8 +201,8 @@ exports[`Menu demo examples basic 1`] = `
   background-color: #f79999;
 }
 
-.glamor-29 [role="icon"],
-[data-glamor-29] [role="icon"] {
+.glamor-29 [role="img"],
+[data-glamor-29] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -210,13 +210,13 @@ exports[`Menu demo examples basic 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-29 [role="icon"]:first-child,
-[data-glamor-29] [role="icon"]:first-child {
+.glamor-29 [role="img"]:first-child,
+[data-glamor-29] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-29 [role="icon"]:last-child,
-[data-glamor-29] [role="icon"]:last-child {
+.glamor-29 [role="img"]:last-child,
+[data-glamor-29] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -235,8 +235,8 @@ exports[`Menu demo examples basic 1`] = `
   outline: 0;
 }
 
-.glamor-34 [role="icon"],
-[data-glamor-34] [role="icon"] {
+.glamor-34 [role="img"],
+[data-glamor-34] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -244,13 +244,13 @@ exports[`Menu demo examples basic 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-34 [role="icon"]:first-child,
-[data-glamor-34] [role="icon"]:first-child {
+.glamor-34 [role="img"]:first-child,
+[data-glamor-34] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-34 [role="icon"]:last-child,
-[data-glamor-34] [role="icon"]:last-child {
+.glamor-34 [role="img"]:last-child,
+[data-glamor-34] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -588,7 +588,7 @@ exports[`Menu demo examples basic 1`] = `
                                           <glamorous(svg)
                                             aria-hidden={true}
                                             aria-labelledby={undefined}
-                                            role="icon"
+                                            role="img"
                                             rtl={false}
                                             size="1.5em"
                                             viewBox="0 0 24 24"
@@ -597,7 +597,7 @@ exports[`Menu demo examples basic 1`] = `
                                               aria-hidden={true}
                                               aria-labelledby={undefined}
                                               className="glamor-11"
-                                              role="icon"
+                                              role="img"
                                               viewBox="0 0 24 24"
                                             >
                                               <g>
@@ -681,7 +681,7 @@ exports[`Menu demo examples basic 1`] = `
                                           <glamorous(svg)
                                             aria-hidden={true}
                                             aria-labelledby={undefined}
-                                            role="icon"
+                                            role="img"
                                             rtl={false}
                                             size="1.5em"
                                             viewBox="0 0 24 24"
@@ -690,7 +690,7 @@ exports[`Menu demo examples basic 1`] = `
                                               aria-hidden={true}
                                               aria-labelledby={undefined}
                                               className="glamor-11"
-                                              role="icon"
+                                              role="img"
                                               viewBox="0 0 24 24"
                                             >
                                               <g>
@@ -747,7 +747,7 @@ exports[`Menu demo examples basic 1`] = `
                                           <glamorous(svg)
                                             aria-hidden={true}
                                             aria-labelledby={undefined}
-                                            role="icon"
+                                            role="img"
                                             rtl={false}
                                             size="1.5em"
                                             viewBox="0 0 24 24"
@@ -756,7 +756,7 @@ exports[`Menu demo examples basic 1`] = `
                                               aria-hidden={true}
                                               aria-labelledby={undefined}
                                               className="glamor-11"
-                                              role="icon"
+                                              role="img"
                                               viewBox="0 0 24 24"
                                             >
                                               <g
@@ -922,8 +922,8 @@ exports[`Menu demo examples data 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -931,13 +931,13 @@ exports[`Menu demo examples data 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -1060,8 +1060,8 @@ exports[`Menu demo examples data 1`] = `
   background-color: #f79999;
 }
 
-.glamor-30 [role="icon"],
-[data-glamor-30] [role="icon"] {
+.glamor-30 [role="img"],
+[data-glamor-30] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -1069,13 +1069,13 @@ exports[`Menu demo examples data 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-30 [role="icon"]:first-child,
-[data-glamor-30] [role="icon"]:first-child {
+.glamor-30 [role="img"]:first-child,
+[data-glamor-30] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-30 [role="icon"]:last-child,
-[data-glamor-30] [role="icon"]:last-child {
+.glamor-30 [role="img"]:last-child,
+[data-glamor-30] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -1094,8 +1094,8 @@ exports[`Menu demo examples data 1`] = `
   outline: 0;
 }
 
-.glamor-35 [role="icon"],
-[data-glamor-35] [role="icon"] {
+.glamor-35 [role="img"],
+[data-glamor-35] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -1103,13 +1103,13 @@ exports[`Menu demo examples data 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-35 [role="icon"]:first-child,
-[data-glamor-35] [role="icon"]:first-child {
+.glamor-35 [role="img"]:first-child,
+[data-glamor-35] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-35 [role="icon"]:last-child,
-[data-glamor-35] [role="icon"]:last-child {
+.glamor-35 [role="img"]:last-child,
+[data-glamor-35] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -1648,7 +1648,7 @@ exports[`Menu demo examples data 1`] = `
                                             <glamorous(svg)
                                               aria-hidden={true}
                                               aria-labelledby={undefined}
-                                              role="icon"
+                                              role="img"
                                               rtl={false}
                                               size="1.5em"
                                               viewBox="0 0 24 24"
@@ -1657,7 +1657,7 @@ exports[`Menu demo examples data 1`] = `
                                                 aria-hidden={true}
                                                 aria-labelledby={undefined}
                                                 className="glamor-12"
-                                                role="icon"
+                                                role="img"
                                                 viewBox="0 0 24 24"
                                               >
                                                 <g>
@@ -1754,7 +1754,7 @@ exports[`Menu demo examples data 1`] = `
                                             <glamorous(svg)
                                               aria-hidden={true}
                                               aria-labelledby={undefined}
-                                              role="icon"
+                                              role="img"
                                               rtl={false}
                                               size="1.5em"
                                               viewBox="0 0 24 24"
@@ -1763,7 +1763,7 @@ exports[`Menu demo examples data 1`] = `
                                                 aria-hidden={true}
                                                 aria-labelledby={undefined}
                                                 className="glamor-12"
-                                                role="icon"
+                                                role="img"
                                                 viewBox="0 0 24 24"
                                               >
                                                 <g>
@@ -1835,7 +1835,7 @@ exports[`Menu demo examples data 1`] = `
                                             <glamorous(svg)
                                               aria-hidden={true}
                                               aria-labelledby={undefined}
-                                              role="icon"
+                                              role="img"
                                               rtl={false}
                                               size="1.5em"
                                               viewBox="0 0 24 24"
@@ -1844,7 +1844,7 @@ exports[`Menu demo examples data 1`] = `
                                                 aria-hidden={true}
                                                 aria-labelledby={undefined}
                                                 className="glamor-12"
-                                                role="icon"
+                                                role="img"
                                                 viewBox="0 0 24 24"
                                               >
                                                 <g

--- a/src/Menu/__tests__/__snapshots__/MenuDivider.spec.js.snap
+++ b/src/Menu/__tests__/__snapshots__/MenuDivider.spec.js.snap
@@ -63,8 +63,8 @@ exports[`MenuDivider demo examples separating-items 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -72,13 +72,13 @@ exports[`MenuDivider demo examples separating-items 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 

--- a/src/Menu/__tests__/__snapshots__/MenuGroup.spec.js.snap
+++ b/src/Menu/__tests__/__snapshots__/MenuGroup.spec.js.snap
@@ -90,8 +90,8 @@ exports[`MenuGroup demo examples menu-group 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -99,13 +99,13 @@ exports[`MenuGroup demo examples menu-group 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 

--- a/src/Menu/__tests__/__snapshots__/MenuItem.spec.js.snap
+++ b/src/Menu/__tests__/__snapshots__/MenuItem.spec.js.snap
@@ -31,8 +31,8 @@ exports[`MenuItem demo examples basic 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -40,13 +40,13 @@ exports[`MenuItem demo examples basic 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -1665,8 +1665,8 @@ exports[`MenuItem demo examples disabled 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -1674,13 +1674,13 @@ exports[`MenuItem demo examples disabled 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -1746,8 +1746,8 @@ exports[`MenuItem demo examples disabled 1`] = `
   outline: 0;
 }
 
-.glamor-14 [role="icon"],
-[data-glamor-14] [role="icon"] {
+.glamor-14 [role="img"],
+[data-glamor-14] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -1755,13 +1755,13 @@ exports[`MenuItem demo examples disabled 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-14 [role="icon"]:first-child,
-[data-glamor-14] [role="icon"]:first-child {
+.glamor-14 [role="img"]:first-child,
+[data-glamor-14] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-14 [role="icon"]:last-child,
-[data-glamor-14] [role="icon"]:last-child {
+.glamor-14 [role="img"]:last-child,
+[data-glamor-14] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -2194,8 +2194,8 @@ exports[`MenuItem demo examples icons 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -2203,13 +2203,13 @@ exports[`MenuItem demo examples icons 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -2275,8 +2275,8 @@ exports[`MenuItem demo examples icons 1`] = `
   outline: 0;
 }
 
-.glamor-43 [role="icon"],
-[data-glamor-43] [role="icon"] {
+.glamor-43 [role="img"],
+[data-glamor-43] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -2284,13 +2284,13 @@ exports[`MenuItem demo examples icons 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-43 [role="icon"]:first-child,
-[data-glamor-43] [role="icon"]:first-child {
+.glamor-43 [role="img"]:first-child,
+[data-glamor-43] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-43 [role="icon"]:last-child,
-[data-glamor-43] [role="icon"]:last-child {
+.glamor-43 [role="img"]:last-child,
+[data-glamor-43] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -2356,8 +2356,8 @@ exports[`MenuItem demo examples icons 1`] = `
   background-color: #f79999;
 }
 
-.glamor-25 [role="icon"],
-[data-glamor-25] [role="icon"] {
+.glamor-25 [role="img"],
+[data-glamor-25] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -2365,13 +2365,13 @@ exports[`MenuItem demo examples icons 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-25 [role="icon"]:first-child,
-[data-glamor-25] [role="icon"]:first-child {
+.glamor-25 [role="img"]:first-child,
+[data-glamor-25] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-25 [role="icon"]:last-child,
-[data-glamor-25] [role="icon"]:last-child {
+.glamor-25 [role="img"]:last-child,
+[data-glamor-25] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -2413,8 +2413,8 @@ exports[`MenuItem demo examples icons 1`] = `
   background-color: #95f5c3;
 }
 
-.glamor-31 [role="icon"],
-[data-glamor-31] [role="icon"] {
+.glamor-31 [role="img"],
+[data-glamor-31] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -2422,13 +2422,13 @@ exports[`MenuItem demo examples icons 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-31 [role="icon"]:first-child,
-[data-glamor-31] [role="icon"]:first-child {
+.glamor-31 [role="img"]:first-child,
+[data-glamor-31] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-31 [role="icon"]:last-child,
-[data-glamor-31] [role="icon"]:last-child {
+.glamor-31 [role="img"]:last-child,
+[data-glamor-31] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -2462,8 +2462,8 @@ exports[`MenuItem demo examples icons 1`] = `
   background-color: #fab69d;
 }
 
-.glamor-37 [role="icon"],
-[data-glamor-37] [role="icon"] {
+.glamor-37 [role="img"],
+[data-glamor-37] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -2471,13 +2471,13 @@ exports[`MenuItem demo examples icons 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-37 [role="icon"]:first-child,
-[data-glamor-37] [role="icon"]:first-child {
+.glamor-37 [role="img"]:first-child,
+[data-glamor-37] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-37 [role="icon"]:last-child,
-[data-glamor-37] [role="icon"]:last-child {
+.glamor-37 [role="img"]:last-child,
+[data-glamor-37] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -2710,7 +2710,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -2719,7 +2719,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -2803,7 +2803,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -2812,7 +2812,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -2861,7 +2861,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -2870,7 +2870,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -2911,7 +2911,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -2920,7 +2920,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -2977,7 +2977,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -2986,7 +2986,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -3053,7 +3053,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -3062,7 +3062,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -3129,7 +3129,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -3138,7 +3138,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -3205,7 +3205,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                       <glamorous(svg)
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
-                                        role="icon"
+                                        role="img"
                                         rtl={false}
                                         size="1.5em"
                                         viewBox="0 0 24 24"
@@ -3214,7 +3214,7 @@ exports[`MenuItem demo examples icons 1`] = `
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
                                           className="glamor-0"
-                                          role="icon"
+                                          role="img"
                                           viewBox="0 0 24 24"
                                         >
                                           <g>
@@ -3294,8 +3294,8 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-6 [role="icon"],
-[data-glamor-6] [role="icon"] {
+.glamor-6 [role="img"],
+[data-glamor-6] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -3303,13 +3303,13 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-6 [role="icon"]:first-child,
-[data-glamor-6] [role="icon"]:first-child {
+.glamor-6 [role="img"]:first-child,
+[data-glamor-6] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-6 [role="icon"]:last-child,
-[data-glamor-6] [role="icon"]:last-child {
+.glamor-6 [role="img"]:last-child,
+[data-glamor-6] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -3720,7 +3720,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -3729,7 +3729,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -3770,7 +3770,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -3779,7 +3779,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -3828,7 +3828,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -3837,7 +3837,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -3878,7 +3878,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -3887,7 +3887,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -3936,7 +3936,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -3945,7 +3945,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -3986,7 +3986,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -3995,7 +3995,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4045,7 +4045,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4054,7 +4054,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4095,7 +4095,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4104,7 +4104,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4154,7 +4154,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4163,7 +4163,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4204,7 +4204,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4213,7 +4213,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4263,7 +4263,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4272,7 +4272,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4313,7 +4313,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4322,7 +4322,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4372,7 +4372,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4381,7 +4381,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4424,7 +4424,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4433,7 +4433,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4483,7 +4483,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4492,7 +4492,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4535,7 +4535,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4544,7 +4544,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4594,7 +4594,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4603,7 +4603,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4646,7 +4646,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4655,7 +4655,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4705,7 +4705,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4714,7 +4714,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4757,7 +4757,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4766,7 +4766,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4823,7 +4823,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4832,7 +4832,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4873,7 +4873,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4882,7 +4882,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4931,7 +4931,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4940,7 +4940,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -4981,7 +4981,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -4990,7 +4990,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5040,7 +5040,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5049,7 +5049,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5090,7 +5090,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5099,7 +5099,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5149,7 +5149,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5158,7 +5158,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5199,7 +5199,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5208,7 +5208,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5258,7 +5258,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5267,7 +5267,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5310,7 +5310,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5319,7 +5319,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5369,7 +5369,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5378,7 +5378,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5421,7 +5421,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5430,7 +5430,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5480,7 +5480,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5489,7 +5489,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5532,7 +5532,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5541,7 +5541,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5591,7 +5591,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5600,7 +5600,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5643,7 +5643,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -5652,7 +5652,7 @@ exports[`MenuItem demo examples kitchen-sink 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g>
@@ -5786,8 +5786,8 @@ exports[`MenuItem demo examples rtl 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -5795,13 +5795,13 @@ exports[`MenuItem demo examples rtl 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-left: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-right: 0.5em;
 }
 
@@ -6145,7 +6145,7 @@ exports[`MenuItem demo examples rtl 1`] = `
                                         <glamorous(svg)
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
-                                          role="icon"
+                                          role="img"
                                           rtl={true}
                                           size="1.5em"
                                           viewBox="0 0 24 24"
@@ -6154,7 +6154,7 @@ exports[`MenuItem demo examples rtl 1`] = `
                                             aria-hidden={true}
                                             aria-labelledby={undefined}
                                             className="glamor-10"
-                                            role="icon"
+                                            role="img"
                                             viewBox="0 0 24 24"
                                           >
                                             <g>
@@ -6238,7 +6238,7 @@ exports[`MenuItem demo examples rtl 1`] = `
                                         <glamorous(svg)
                                           aria-hidden={true}
                                           aria-labelledby={undefined}
-                                          role="icon"
+                                          role="img"
                                           rtl={true}
                                           size="1.5em"
                                           viewBox="0 0 24 24"
@@ -6247,7 +6247,7 @@ exports[`MenuItem demo examples rtl 1`] = `
                                             aria-hidden={true}
                                             aria-labelledby={undefined}
                                             className="glamor-10"
-                                            role="icon"
+                                            role="img"
                                             viewBox="0 0 24 24"
                                           >
                                             <g>
@@ -6310,8 +6310,8 @@ exports[`MenuItem demo examples secondary-text 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -6319,13 +6319,13 @@ exports[`MenuItem demo examples secondary-text 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -6776,8 +6776,8 @@ exports[`MenuItem demo examples states 1`] = `
   background-color: #c8d1e0;
 }
 
-.glamor-4 [role="icon"],
-[data-glamor-4] [role="icon"] {
+.glamor-4 [role="img"],
+[data-glamor-4] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: #2e6fd9;
@@ -6785,13 +6785,13 @@ exports[`MenuItem demo examples states 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-4 [role="icon"]:first-child,
-[data-glamor-4] [role="icon"]:first-child {
+.glamor-4 [role="img"]:first-child,
+[data-glamor-4] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-4 [role="icon"]:last-child,
-[data-glamor-4] [role="icon"]:last-child {
+.glamor-4 [role="img"]:last-child,
+[data-glamor-4] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -6857,8 +6857,8 @@ exports[`MenuItem demo examples states 1`] = `
   outline: 0;
 }
 
-.glamor-148 [role="icon"],
-[data-glamor-148] [role="icon"] {
+.glamor-148 [role="img"],
+[data-glamor-148] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -6866,13 +6866,13 @@ exports[`MenuItem demo examples states 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-148 [role="icon"]:first-child,
-[data-glamor-148] [role="icon"]:first-child {
+.glamor-148 [role="img"]:first-child,
+[data-glamor-148] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-148 [role="icon"]:last-child,
-[data-glamor-148] [role="icon"]:last-child {
+.glamor-148 [role="img"]:last-child,
+[data-glamor-148] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -6938,8 +6938,8 @@ exports[`MenuItem demo examples states 1`] = `
   background-color: #f79999;
 }
 
-.glamor-10 [role="icon"],
-[data-glamor-10] [role="icon"] {
+.glamor-10 [role="img"],
+[data-glamor-10] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -6947,13 +6947,13 @@ exports[`MenuItem demo examples states 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-10 [role="icon"]:first-child,
-[data-glamor-10] [role="icon"]:first-child {
+.glamor-10 [role="img"]:first-child,
+[data-glamor-10] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-10 [role="icon"]:last-child,
-[data-glamor-10] [role="icon"]:last-child {
+.glamor-10 [role="img"]:last-child,
+[data-glamor-10] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -6995,8 +6995,8 @@ exports[`MenuItem demo examples states 1`] = `
   background-color: #95f5c3;
 }
 
-.glamor-16 [role="icon"],
-[data-glamor-16] [role="icon"] {
+.glamor-16 [role="img"],
+[data-glamor-16] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -7004,13 +7004,13 @@ exports[`MenuItem demo examples states 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-16 [role="icon"]:first-child,
-[data-glamor-16] [role="icon"]:first-child {
+.glamor-16 [role="img"]:first-child,
+[data-glamor-16] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-16 [role="icon"]:last-child,
-[data-glamor-16] [role="icon"]:last-child {
+.glamor-16 [role="img"]:last-child,
+[data-glamor-16] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -7044,8 +7044,8 @@ exports[`MenuItem demo examples states 1`] = `
   background-color: #fab69d;
 }
 
-.glamor-22 [role="icon"],
-[data-glamor-22] [role="icon"] {
+.glamor-22 [role="img"],
+[data-glamor-22] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -7053,13 +7053,13 @@ exports[`MenuItem demo examples states 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-22 [role="icon"]:first-child,
-[data-glamor-22] [role="icon"]:first-child {
+.glamor-22 [role="img"]:first-child,
+[data-glamor-22] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-22 [role="icon"]:last-child,
-[data-glamor-22] [role="icon"]:last-child {
+.glamor-22 [role="img"]:last-child,
+[data-glamor-22] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -7412,7 +7412,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -7421,7 +7421,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -7494,7 +7494,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -7503,7 +7503,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -7576,7 +7576,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -7585,7 +7585,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -7714,7 +7714,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -7723,7 +7723,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -7799,7 +7799,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -7808,7 +7808,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -7884,7 +7884,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -7893,7 +7893,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8022,7 +8022,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8031,7 +8031,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8107,7 +8107,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8116,7 +8116,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8192,7 +8192,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8201,7 +8201,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8336,7 +8336,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8345,7 +8345,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8424,7 +8424,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8433,7 +8433,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8512,7 +8512,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8521,7 +8521,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8656,7 +8656,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8665,7 +8665,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8744,7 +8744,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8753,7 +8753,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8832,7 +8832,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8841,7 +8841,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -8970,7 +8970,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -8979,7 +8979,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -9055,7 +9055,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -9064,7 +9064,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -9140,7 +9140,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -9149,7 +9149,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -9274,7 +9274,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -9283,7 +9283,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -9357,7 +9357,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -9366,7 +9366,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -9440,7 +9440,7 @@ exports[`MenuItem demo examples states 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -9449,7 +9449,7 @@ exports[`MenuItem demo examples states 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-5"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -9615,8 +9615,8 @@ exports[`MenuItem demo examples variants 1`] = `
   background-color: #f79999;
 }
 
-.glamor-5 [role="icon"],
-[data-glamor-5] [role="icon"] {
+.glamor-5 [role="img"],
+[data-glamor-5] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -9624,13 +9624,13 @@ exports[`MenuItem demo examples variants 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-5 [role="icon"]:first-child,
-[data-glamor-5] [role="icon"]:first-child {
+.glamor-5 [role="img"]:first-child,
+[data-glamor-5] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-5 [role="icon"]:last-child,
-[data-glamor-5] [role="icon"]:last-child {
+.glamor-5 [role="img"]:last-child,
+[data-glamor-5] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -9672,8 +9672,8 @@ exports[`MenuItem demo examples variants 1`] = `
   background-color: #95f5c3;
 }
 
-.glamor-11 [role="icon"],
-[data-glamor-11] [role="icon"] {
+.glamor-11 [role="img"],
+[data-glamor-11] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -9681,13 +9681,13 @@ exports[`MenuItem demo examples variants 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-11 [role="icon"]:first-child,
-[data-glamor-11] [role="icon"]:first-child {
+.glamor-11 [role="img"]:first-child,
+[data-glamor-11] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-11 [role="icon"]:last-child,
-[data-glamor-11] [role="icon"]:last-child {
+.glamor-11 [role="img"]:last-child,
+[data-glamor-11] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -9721,8 +9721,8 @@ exports[`MenuItem demo examples variants 1`] = `
   background-color: #fab69d;
 }
 
-.glamor-17 [role="icon"],
-[data-glamor-17] [role="icon"] {
+.glamor-17 [role="img"],
+[data-glamor-17] [role="img"] {
   box-sizing: content-box;
   display: block;
   fill: currentColor;
@@ -9730,13 +9730,13 @@ exports[`MenuItem demo examples variants 1`] = `
   -webkit-flex: 0 0 auto;
 }
 
-.glamor-17 [role="icon"]:first-child,
-[data-glamor-17] [role="icon"]:first-child {
+.glamor-17 [role="img"]:first-child,
+[data-glamor-17] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-17 [role="icon"]:last-child,
-[data-glamor-17] [role="icon"]:last-child {
+.glamor-17 [role="img"]:last-child,
+[data-glamor-17] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
@@ -9959,7 +9959,7 @@ exports[`MenuItem demo examples variants 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -9968,7 +9968,7 @@ exports[`MenuItem demo examples variants 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -10041,7 +10041,7 @@ exports[`MenuItem demo examples variants 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -10050,7 +10050,7 @@ exports[`MenuItem demo examples variants 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g
@@ -10123,7 +10123,7 @@ exports[`MenuItem demo examples variants 1`] = `
                                     <glamorous(svg)
                                       aria-hidden={true}
                                       aria-labelledby={undefined}
-                                      role="icon"
+                                      role="img"
                                       rtl={false}
                                       size="1.5em"
                                       viewBox="0 0 24 24"
@@ -10132,7 +10132,7 @@ exports[`MenuItem demo examples variants 1`] = `
                                         aria-hidden={true}
                                         aria-labelledby={undefined}
                                         className="glamor-0"
-                                        role="icon"
+                                        role="img"
                                         viewBox="0 0 24 24"
                                       >
                                         <g

--- a/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -73,25 +73,25 @@ exports[`Popover demo examples basic 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -480,25 +480,25 @@ exports[`Popover demo examples controlled 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1055,25 +1055,25 @@ exports[`Popover demo examples disabled 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1420,25 +1420,25 @@ exports[`Popover demo examples on-open-close 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -1893,25 +1893,25 @@ exports[`Popover demo examples overflow 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -2635,25 +2635,25 @@ exports[`Popover demo examples placement 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3376,25 +3376,25 @@ exports[`Popover demo examples scrolling-container 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -3540,25 +3540,25 @@ exports[`Popover demo examples scrolling-container 1`] = `
   border: 0;
 }
 
-.glamor-17 [role="icon"],
-[data-glamor-17] [role="icon"] {
+.glamor-17 [role="img"],
+[data-glamor-17] [role="img"] {
   box-sizing: content-box;
   fill: currentColor;
   display: block;
 }
 
-.glamor-17 [role="icon"]:first-child,
-[data-glamor-17] [role="icon"]:first-child {
+.glamor-17 [role="img"]:first-child,
+[data-glamor-17] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-17 [role="icon"]:last-child,
-[data-glamor-17] [role="icon"]:last-child {
+.glamor-17 [role="img"]:last-child,
+[data-glamor-17] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-17 [role="icon"]:only-child,
-[data-glamor-17] [role="icon"]:only-child {
+.glamor-17 [role="img"]:only-child,
+[data-glamor-17] [role="img"]:only-child {
   margin: 0;
 }
 
@@ -4309,25 +4309,25 @@ exports[`Popover demo examples title 1`] = `
   border: 0;
 }
 
-.glamor-2 [role="icon"],
-[data-glamor-2] [role="icon"] {
+.glamor-2 [role="img"],
+[data-glamor-2] [role="img"] {
   box-sizing: content-box;
   fill: #2e6fd9;
   display: block;
 }
 
-.glamor-2 [role="icon"]:first-child,
-[data-glamor-2] [role="icon"]:first-child {
+.glamor-2 [role="img"]:first-child,
+[data-glamor-2] [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.glamor-2 [role="icon"]:last-child,
-[data-glamor-2] [role="icon"]:last-child {
+.glamor-2 [role="img"]:last-child,
+[data-glamor-2] [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.glamor-2 [role="icon"]:only-child,
-[data-glamor-2] [role="icon"]:only-child {
+.glamor-2 [role="img"]:only-child,
+[data-glamor-2] [role="img"]:only-child {
   margin: 0;
 }
 

--- a/src/website/app/Page.js
+++ b/src/website/app/Page.js
@@ -308,7 +308,7 @@ const styles = {
       backgroundColor: siteColors.slateDarker_active
     },
 
-    '& [role="icon"]': {
+    '& [role="img"]': {
       fill: theme.color_white
     }
   }),

--- a/src/website/app/demos/Icon/components/Figure.js
+++ b/src/website/app/demos/Icon/components/Figure.js
@@ -30,7 +30,7 @@ export default createStyledComponent(
       outline: '1px dotted currentColor'
     },
 
-    '& > [role="icon"]': {
+    '& > [role="img"]': {
       marginRight: theme.space_inline_xs
     }
   }),

--- a/src/website/app/pages/ComponentDoc/DocPractice.js
+++ b/src/website/app/pages/ComponentDoc/DocPractice.js
@@ -70,7 +70,7 @@ const styles = {
       flex: `1 1 ${5 / 12 * 100}%`
     },
 
-    '& > [role="icon"]': {
+    '& > [role="img"]': {
       backgroundColor:
         type === 'do'
           ? rgba(theme.borderColor_success, 0.2)


### PR DESCRIPTION
### Description

* Updates the Icon component to use role="img" instead of role="icon"
* Updates other component contextual icon CSS selectors

### Motivation and context

closes #463 

### Screenshots, videos, or demo, if appropriate

https://463-icon-role--mineral-ui.netlify.com/

### How to test

1. Run a a11y check on the Icon demo page using chrome devTools and note that there are no longer any warnings about invalid role attribute on the Icon svg's
2. Add a title and a tabIndex to an Icon component in the demo and verify that it is announced properly, and better than it was previously.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

Fixes invalid role attribute

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
