### PR TITLE
[Website] enable API & Theme tab for every component

### DIFF
--- a/src/website/app/pages/ComponentDoc/DocSubNav.js
+++ b/src/website/app/pages/ComponentDoc/DocSubNav.js
@@ -23,7 +23,6 @@ import Section from './DocSection';
 type Props = {
   bestPractices?: Array<Object>,
   examples?: Array<any>,
-  props?: boolean,
   whenHowToUse?: string
 };
 
@@ -65,7 +64,6 @@ const NavElement = createStyledComponent(Link, styles.navElement);
 export default function DocSubNav({
   bestPractices,
   examples,
-  props,
   whenHowToUse,
   ...restProps
 }: Props) {
@@ -84,13 +82,11 @@ export default function DocSubNav({
     );
   }
 
-  if (props) {
-    navElements.push(
-      <NavElement href="#api-and-theme" key="api-and-theme">
-        API & Theme
-      </NavElement>
-    );
-  }
+  navElements.push(
+    <NavElement href="#api-and-theme" key="api-and-theme">
+      API & Theme
+    </NavElement>
+  );
 
   if (whenHowToUse || bestPractices) {
     navElements.push(

--- a/src/website/app/pages/ComponentDoc/index.js
+++ b/src/website/app/pages/ComponentDoc/index.js
@@ -39,7 +39,6 @@ type Props = {
   description?: React$Node,
   doc: Object,
   examples?: Array<any>,
-  hidePropDoc?: boolean,
   pageMeta: {
     title: string,
     canonicalLink: string
@@ -93,7 +92,6 @@ export default function ComponentDoc({
   bestPractices,
   doc,
   examples,
-  hidePropDoc,
   componentTheme,
   title,
   whenHowToUse,
@@ -104,7 +102,6 @@ export default function ComponentDoc({
     bestPractices,
     componentTheme,
     examples,
-    props: !!(propDoc || componentTheme),
     whenHowToUse
   };
   const rootProps = {
@@ -125,10 +122,8 @@ export default function ComponentDoc({
       <DocSubNav {...subNavProps} />
       {examples && <DocHeading id="examples">Examples</DocHeading>}
       {examples && <DocExamples examples={examples} />}
-      {(!hidePropDoc || componentTheme) && (
-        <DocHeading id="api-and-theme">API & Theme</DocHeading>
-      )}
-      {!hidePropDoc && <DocProps {...propProps} />}
+      <DocHeading id="api-and-theme">API & Theme</DocHeading>
+      <DocProps {...propProps} />
       {componentTheme && <DocThemeVariables {...themeVariablesProps} />}
       {(whenHowToUse || bestPractices) && (
         <DocHeading id="usage">Usage</DocHeading>


### PR DESCRIPTION
closes #506 

### Description
This PR makes it so the API & Theme subnav link is _always_ shown on the component page. Also removes some unused variables.

### Motivation and context
@coldpour noticed that _only_ the CardImage page didn't have the API & Theme link, while the seemingly similar page MenuDivider did show the link. This was because MenuDivider has some theme variables, while CardImage does not. The confusing part is because at some point we made it so the API & Theme header would always show to head up the `CardImage does not have properties of its own. Undocumented properties...` callout that is _always_ shown. Now since that section is always there and contains something, it makes sense to just show the link in the subnav.

I also removed the `hidePropDoc` since we're not using it anywhere. The theory is that we were using it for the old implementation of `ThemeProvider` or something.

https://506-missing-subnav--mineral-ui.netlify.com/

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Click through all the component pages.
3. Every page should have an API & Theme subnav link, and content when you click that link.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
![polish](https://media.giphy.com/media/106Ws1hA5R2AlW/giphy.gif)
