### PR TITLE
[Website] update intros and usage sections for form components

### DIFF
--- a/src/Form/FormField.js
+++ b/src/Form/FormField.js
@@ -123,8 +123,11 @@ const SecondaryText = createStyledComponent('span', styles.secondaryText);
 const Caption = createStyledComponent('div', styles.caption);
 
 /**
+ * Mineral UI allows your app to highly customize the appearance of form inputs.
+ *
  * The FormField component wraps an input with an accessible label and displays
  * optional secondary text or a message.
+ * Styling will be applied if the wrapped element is a [TextField](../text-field).
  */
 export default class FormField extends Component<Props> {
   static defaultProps = {

--- a/src/Form/FormFieldDivider.js
+++ b/src/Form/FormFieldDivider.js
@@ -45,7 +45,11 @@ const Root = createStyledComponent(
 );
 
 /**
- * FormFieldDivider separates [FormFields](../form-field).
+ * FormFieldDivider separates [FormFields](../form-field) to group form inputs.
+ *
+ * FormFieldDividers help your users grok forms with several inputs by hinting
+ * at related fields, without explicitly adding a legend. Too many dividers will
+ * add unnecessary weight to your form.
  */
 export default function FormFieldDivider(props: Props) {
   return <Root {...props} role="separator" />;

--- a/src/Form/FormFieldset.js
+++ b/src/Form/FormFieldset.js
@@ -68,7 +68,8 @@ const Root = createStyledComponent(
 );
 
 /**
- * FormFieldset wraps related [FormFields](../form-field) and provides a legend.
+ * FormFieldsets group related [FormFields](../form-field) and provide a legend.
+ * Grouping FormFields provides context clues to users and enhances accessibility.
  */
 export default function FormFieldset({
   children,

--- a/src/TextInput/TextInput.js
+++ b/src/TextInput/TextInput.js
@@ -341,8 +341,11 @@ function getIcons({
 }
 
 /**
- * TextInput accepts a text value from the user. It supports any of the
- * text-based input types, such as `number` or `email`.
+ * TextInput allows your app to accept a text value from the user. It supports
+ * any of the text-based input types, such as `number` or `email`.
+ *
+ * TextInputs can be composed into other components, such as search fields and dialogs.
+ * Mineral UI provides [FormField](../form-field) to add labeling and accessibility.
  */
 export default function TextInput({
   className,

--- a/src/website/app/demos/Form/examples/form-field-divider/basic.js
+++ b/src/website/app/demos/Form/examples/form-field-divider/basic.js
@@ -22,7 +22,7 @@ import { FormField, FormFieldDivider } from '../../../../../../Form';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  description: `Use a FormFieldDivider to create groups of
+  description: `Use a FormFieldDivider to create implicit groups of
 [FormFields](../form-field). For more semantic grouping, use a
 [FormFieldset](../form-fieldset).`,
   scope: { DemoLayout, FormField, FormFieldDivider, TextInput },

--- a/src/website/app/demos/Form/examples/form-field/basic.js
+++ b/src/website/app/demos/Form/examples/form-field/basic.js
@@ -22,7 +22,7 @@ import FormField from '../../../../../../Form/FormField';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  description: `FormField can contain any input and will accessibly connect the
+  description: `FormField accepts any input, either to the \`input\` prop or as a child, accessibly connecting the
 label to it.`,
   scope: { DemoLayout, FormField, TextInput },
   source: `

--- a/src/website/app/demos/Form/examples/form-field/caption.js
+++ b/src/website/app/demos/Form/examples/form-field/caption.js
@@ -22,7 +22,7 @@ export default {
   id: 'caption',
   title: 'Caption',
   description: `Use a \`caption\` to display not-so-brief additional information,
-such as help text or an [error message](#validation).`,
+such as help text or, along with a [variant](#variants), an [error message](#validation).`,
   scope: { FormField, TextInput },
   source: `
     <FormField

--- a/src/website/app/demos/Form/examples/form-field/hideLabel.js
+++ b/src/website/app/demos/Form/examples/form-field/hideLabel.js
@@ -22,9 +22,9 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'hide-label',
   title: 'Visually Hidden Label',
-  description: `If the purpose of a FormField is obvious from context and would
+  description: `If the purpose of a FormField is obvious from context and adding a label would
 negatively affect the design, as in the example below, you can use \`hideLabel\`
-to visually hide the label in a way that is still accessible.`,
+to visually hide the label while retaining accessibility.`,
   scope: { DemoLayout, FormField, TextInput },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Form/examples/form-field/required.js
+++ b/src/website/app/demos/Form/examples/form-field/required.js
@@ -22,8 +22,9 @@ import FormField from '../../../../../../Form/FormField';
 export default {
   id: 'required',
   title: 'Required',
-  description: `Marking a FormField as required will display the \`requiredText\`
-and pass along the \`required\` prop to the child input.`,
+  description: `Mark a FormField as required to display the \`requiredText\`
+and pass the \`required\` prop along to the child input.
+Required text takes precedence over any provided \`secondaryText\`.`,
   scope: { DemoLayout, FormField, TextInput },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Form/examples/form-field/secondaryText.js
+++ b/src/website/app/demos/Form/examples/form-field/secondaryText.js
@@ -22,8 +22,8 @@ export default {
   id: 'secondaryText',
   title: 'Secondary Text',
   description: `Use the \`secondaryText\` prop to provide brief additional
-details to the label text. Note that if \`secondaryText\` is provided, it will
-display instead of \`requiredText\`.`,
+details to the label text. Note that if \`requiredText\` is provided, it
+displays instead of \`secondaryText\`.`,
   scope: { FormField, TextInput },
   source: `
     <FormField

--- a/src/website/app/demos/Form/examples/form-fieldset/basic.js
+++ b/src/website/app/demos/Form/examples/form-fieldset/basic.js
@@ -23,8 +23,8 @@ export default {
   id: 'basic',
   title: 'Basic Usage',
   description: `Wrap any number of [FormFields](../form-field) in a FormFieldset
-to group them together semantically. A brief, descriptive legend is especially
-useful for users of Accessibility Technology (AT), such as a screen reader.`,
+to semantically group them. A brief, descriptive legend is especially
+useful for users of Assistive Technology (AT), such as a screen reader.`,
   scope: { DemoLayout, FormField, FormFieldset, TextInput },
   source: `
     <FormFieldset legend="Login">

--- a/src/website/app/demos/Form/index.js
+++ b/src/website/app/demos/Form/index.js
@@ -46,7 +46,19 @@ export default [
     slug: 'form-field',
     title: 'FormField',
     whenHowToUse: `Wrap each input in your app with a FormField for appropriate
-accessibility and styling.`
+accessibility and styling.
+
+Labels should be short (1-3 words) and indicate the type of input requested.
+Labels are not meant to explain the intent of the form as a whole.
+
+Only use [Sentence case](https://en.wikipedia.org/wiki/Letter_case#Sentence_case) for labels.
+
+Placeholder texts are example input values, not instructions, as the contrast is too low to be accessible.
+
+Do not use an asterisk in labels for required fields; use the \`required\` attribute instead.
+
+Error text should be short and concise, telling the user how to fix the problem.
+Form errors should be shown next to the pertinent input field – as opposed to the top of the form – so the user knows exactly what to change.`
   },
   {
     bestPractices: bestPractices.formFieldset,
@@ -55,9 +67,10 @@ accessibility and styling.`
     examples: formFieldsetExamples,
     slug: 'form-fieldset',
     title: 'FormFieldset',
-    whenHowToUse: `Groups of related inputs (which themselves should be wrapped
-in [FormFields](../form-field)) should be wrapped in a FormFieldset with a
-useful legend.`
+    whenHowToUse: `Wrap groups of related inputs (which themselves should be wrapped
+in [FormFields](../form-field)) in a FormFieldset with a useful legend.
+
+Consider using FormFieldset instead of a heading element to improve accessibility.`
   },
   {
     bestPractices: bestPractices.formFieldDivider,

--- a/src/website/app/demos/TextInput/examples/controlled.js
+++ b/src/website/app/demos/TextInput/examples/controlled.js
@@ -23,8 +23,8 @@ export default {
   id: 'controlled',
   title: 'Controlled',
   description: `In a controlled TextInput, the value is handled by a React
-component.  The value is set with the \`value\` prop and an \`onChange\`
-handler must be provided.`,
+component.  Set the value with the \`value\` prop and provide an \`onChange\`
+handler.`,
   scope: { Component, DemoLayout, TextInput },
   source: `
   () => {

--- a/src/website/app/demos/TextInput/examples/disabled.js
+++ b/src/website/app/demos/TextInput/examples/disabled.js
@@ -20,7 +20,7 @@ import TextInput from '../../../../../TextInput';
 export default {
   id: 'disabled',
   title: 'Disabled',
-  description: `The \`disabled\` prop indicates that the input is not available
+  description: `Use the \`disabled\` prop to indicate that your input is not available
 for interaction.`,
   scope: { TextInput },
   source: `

--- a/src/website/app/demos/TextInput/index.js
+++ b/src/website/app/demos/TextInput/index.js
@@ -40,6 +40,13 @@ export default [
     whenHowToUse: `Use a TextInput to accept brief, free-form input from a user.
 Make sure you use the proper type, which is especially important for mobile users.
 Additionally, you should rarely use a TextInput outside of a
-[FormField](../form-field).`
+[FormField](../form-field).
+TextInputs should always be associated with a label so the user knows what information to provide.
+
+Be specific when choosing the \`type\` for your TextInput.
+Mobile devices will display different keyboards depending on the input type.
+
+Provide [additional attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) to aid frictionless interaction with your forms.
+E.g. \`autocorrect="off"\` on an input accepting a user's name.`
   }
 ];


### PR DESCRIPTION
### Description
This PR attempts to align the form component intros and usage sections with our existing copy.

### Motivation and context
We want to have consistency in our docs.
connect #137

There was plenty of stuff pertaining to forms as a whole that didn't really live on any one component, so I documented it here. https://docs.google.com/document/d/1KDYL35fbqEZqCINzw5h9LpBFoCTKc9LpQNP7LsvMysI/edit

https://textinput-text-input--mineral-ui.netlify.com/

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. View the intro and Usage sections for TextInput, FormField, FormFieldset, FormFieldDivider
3. We want to be prescriptive, but did I talk too much? Did I miss anything?
4. I used the word "grok". Will normal people understand this? It _is_ a page for developers.

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Other (provide details below)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) [n/a]
* [x] Automated tests written and passing [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
![winky face](https://media.giphy.com/media/7z8aKcwnco5wc/giphy.gif)