### PR TITLE
chore(website): remove unused styles from homepage

### DIFF
--- a/src/website/app/pages/Home/index.js
+++ b/src/website/app/pages/Home/index.js
@@ -344,13 +344,6 @@ const styles = {
     }
   }),
   getStartedBackgrounds: ({ theme }) => ({
-    '& > :nth-child(1)': {
-      '& > svg': {
-        mixBlendMode: 'luminosity',
-        transform: 'translateX(50%) rotate(180deg) scale(2)'
-      }
-    },
-
     '& > :nth-child(2)': {
       background: `linear-gradient(
         rgba(0,0,0,0.4),
@@ -542,11 +535,7 @@ const styles = {
       ${playgroundThemes[index].color_theme_40},
       ${desaturate(0.5, playgroundThemes[index].color_theme_10)}
     )`,
-    transform: 'scaleX(-1)',
-
-    '& > svg': {
-      transform: 'scale(2)'
-    }
+    transform: 'scaleX(-1)'
   }),
   playgroundSection: ({ index, theme }) => ({
     position: 'relative',


### PR DESCRIPTION
### Description
remove unused styles from homepage

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->

some styles used to be applied to triangles when they were in an svg element, but now they're a background image so they're not being applied anymore.

### Screenshots, videos, or demo, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

https://cleanupstyles--mineral-ui.netlify.com/

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. make sure the homepage looks as expected

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- chore

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - [n/a]
* [x] Automated tests written and passing - [n/a]
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - [n/a]

<!-- If any of the above need further details, you should include those here. -->

