### PR TITLE
build(test): Update to happo.io 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "glamor": "2.20.40",
     "glamorous": "4.9.7",
     "glob": "7.1.2",
-    "happo.io": "0.4.0",
+    "happo.io": "0.5.1",
     "html-webpack-plugin": "2.30.1",
     "husky": "0.14.3",
     "inquirer": "3.3.0",


### PR DESCRIPTION
This version has a bugfix for missing svg images. See
https://github.com/enduire/happo.io/issues/3 for more on the issue.