### PR TITLE
[Website] Update nav to collapse subcomponents until active

### DIFF
--- a/src/website/app/App.js
+++ b/src/website/app/App.js
@@ -31,12 +31,16 @@ declare var GOOGLE_TRACKING_ID: string;
 type Props = {
   children?: any,
   className?: string,
-  demoRoutes: { [string]: DemoRoute },
+  demoRoutes: Array<DemoRoute>,
   history: Object,
   location?: any
 };
 
-type DemoRoute = { slug: string, title: string, description: string };
+type DemoRoute = {
+  description: string,
+  slug: string,
+  title: string
+};
 
 const siteTheme = {
   baseline_1: pxToEm(12),

--- a/src/website/app/Nav.js
+++ b/src/website/app/Nav.js
@@ -17,8 +17,13 @@
 /* @flow */
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { createStyledComponent, pxToEm } from '../../styles';
-import { ThemeProvider } from '../../themes';
+import { darken, rgba } from 'polished';
+import {
+  createStyledComponent,
+  getNormalizedValue,
+  pxToEm
+} from '../../styles';
+import { mineralTheme, ThemeProvider } from '../../themes';
 import _Logo from './Logo';
 import Heading from './SiteHeading';
 import _Link from './SiteLink';
@@ -26,28 +31,96 @@ import siteColors from './siteColors';
 import sections from './pages';
 
 type Props = {
-  demoRoutes: { [string]: DemoRoute },
-  contextualTheme?: Object
+  currentDemo?: string,
+  demoRoutes: Array<DemoRoute>,
+  wide?: Boolean
 };
 
-type DemoRoute = { slug: string, title: string };
+type DemoRoute = {
+  description: string,
+  slug: string,
+  title: string
+};
+
+const navTheme = {
+  Heading_color_4: mineralTheme.color_gray_30,
+
+  SiteLink_borderColor_focus: mineralTheme.color_white,
+  SiteLink_color: mineralTheme.color_gray_30,
+  SiteLink_color_focus: mineralTheme.color_white,
+  SiteLink_color_hover: mineralTheme.color_white
+};
+
+const navThemeWide = {
+  Heading_color_4: siteColors.slateDarker,
+
+  SiteLink_borderColor_focus: siteColors.slateDarker_focus,
+  SiteLink_color: siteColors.slateDarker,
+  SiteLink_color_active: siteColors.slateDarker_active,
+  SiteLink_color_focus: siteColors.slateDarker_focus,
+  SiteLink_color_hover: siteColors.slateDarker_hover
+};
 
 const styles = {
-  heading: {
-    margin: 0
-  },
-  link: ({ theme }) => ({
-    display: 'block',
-    fontWeight: theme.fontWeight_regular,
-    // top & bottom: results of `getNormalizedValue(pxToEm(5), theme.fontSize_ui)`
-    // (6px for bottom), rounded down for baseline alignment
-    padding: '0.35em 0 0.4em',
-    textDecoration: 'none',
-
-    '&.active': {
-      color: theme.color_text_primary
-    }
+  heading: ({ theme, wide }) => ({
+    margin: 0,
+    paddingRight: wide ? getNormalizedValue(pxToEm(8), theme.fontSize_h4) : null
   }),
+  link: ({ theme, wide }) => {
+    const fontSize = theme.fontSize_ui;
+    const styles = [
+      {
+        display: 'block',
+        fontWeight: theme.fontWeight_regular,
+        // top & bottom: results of `getNormalizedValue(pxToEm(5), fontSize)`
+        // (6px for bottom), rounded down for baseline alignment
+        padding: '0.35em 0 0.4em',
+        textDecoration: 'none'
+      }
+    ];
+
+    styles.push(
+      wide
+        ? {
+            paddingLeft: getNormalizedValue(pxToEm(8), fontSize),
+            paddingRight: getNormalizedValue(pxToEm(8), fontSize),
+
+            '&.active': {
+              backgroundColor: rgba(theme.color_text_primary, 0.15),
+              color: darken(0.1, theme.color_text_primary),
+              position: 'relative',
+
+              '&::before': {
+                backgroundColor: theme.color_text_primary,
+                bottom: 0,
+                content: '""',
+                position: 'absolute',
+                right: `-${getNormalizedValue(pxToEm(3), fontSize)}`,
+                top: 0,
+                width: getNormalizedValue(pxToEm(3), fontSize)
+              }
+            }
+          }
+        : {
+            '&.active': {
+              color: theme.navLink_color_active_narrow,
+              position: 'relative',
+
+              '&::before': {
+                backgroundColor: theme.navLink_color_active_narrow,
+                bottom: 0,
+                content: '""',
+                left: `-${getNormalizedValue(pxToEm(18), fontSize)}`,
+                position: 'absolute',
+                top: 0,
+                width: getNormalizedValue(pxToEm(6), fontSize)
+              }
+            }
+          }
+    );
+
+    return styles;
+  },
   list: {
     listStyle: 'none',
     margin: `0 0 ${pxToEm(44)}`, // to baseline
@@ -61,9 +134,12 @@ const styles = {
     }
   }),
   // [1] to align first SectionHeading with baseline of third intro line
-  logoHeading: {
+  logoHeading: ({ theme, wide }) => ({
     fontSize: '1em',
     margin: `0 0 ${pxToEm(9)}`, // [1]
+    paddingRight: wide
+      ? getNormalizedValue(pxToEm(8), theme.fontSize_h4)
+      : null,
 
     '& svg': {
       width: 29, // 36px tall is the important dimension
@@ -72,10 +148,52 @@ const styles = {
       '& .band-2': { fill: siteColors.orange },
       '& .band-3': { fill: siteColors.slate }
     }
+  }),
+  subList: ({ open, theme, wide }) => {
+    const styles = [
+      {
+        listStyle: 'none',
+        margin: 0,
+        padding: 0,
+        position: 'relative'
+      }
+    ];
+
+    if (open) {
+      styles.push(
+        wide
+          ? {
+              '&::before': {
+                backgroundColor: rgba(theme.color_text_primary, 0.25),
+                bottom: 0,
+                content: '""',
+                position: 'absolute',
+                right: `-${getNormalizedValue(pxToEm(3), theme.fontSize_ui)}`,
+                top: 0,
+                width: getNormalizedValue(pxToEm(3), theme.fontSize_ui)
+              }
+            }
+          : {
+              '&::before': {
+                backgroundColor: rgba(theme.color_text_primary, 0.5),
+                bottom: 0,
+                content: '""',
+                left: `-${pxToEm(18)}`,
+                position: 'absolute',
+                top: 0,
+                width: pxToEm(6)
+              }
+            }
+      );
+    }
+
+    return styles;
   }
 };
 
-const Link = createStyledComponent(_Link, styles.link).withProps({
+const Link = createStyledComponent(_Link, styles.link, {
+  filterProps: ['wide']
+}).withProps({
   element: NavLink
 });
 const List = createStyledComponent('ol', styles.list);
@@ -87,6 +205,7 @@ const SectionHeading = createStyledComponent(
   as: 'h2',
   level: 4
 });
+const SubList = createStyledComponent('ol', styles.subList);
 const LogoHeading = createStyledComponent(
   Heading,
   styles.logoHeading
@@ -94,55 +213,82 @@ const LogoHeading = createStyledComponent(
   level: 1
 });
 
-const Logo = () => (
-  <LogoHeading>
+const Logo = wide => (
+  <LogoHeading wide={wide}>
     <Link exact to="/">
       <_Logo />
     </Link>
   </LogoHeading>
 );
 
-const pages = sections.map((section, index) => {
-  return (
-    <div key={index}>
-      <SectionHeading>{section.heading}</SectionHeading>
-      <List>
-        {section.pages.map(page => {
-          return (
-            !page.hiddenInNav && (
-              <ListItem key={page.title}>
-                <Link to={page.path}>{page.title}</Link>
-              </ListItem>
-            )
-          );
-        })}
-      </List>
-    </div>
-  );
-});
+const pages = wide => {
+  return sections.map((section, index) => {
+    return (
+      <div key={index}>
+        <SectionHeading wide={wide}>{section.heading}</SectionHeading>
+        <List>
+          {section.pages.map(page => {
+            return (
+              !page.hiddenInNav && (
+                <ListItem key={page.title}>
+                  <Link to={page.path} wide={wide}>
+                    {page.title}
+                  </Link>
+                </ListItem>
+              )
+            );
+          })}
+        </List>
+      </div>
+    );
+  });
+};
+
+const renderItem = (slug, title, wide) => (
+  <ListItem key={slug}>
+    <Link to={`/components/${slug}`} wide={wide}>
+      {title}
+    </Link>
+  </ListItem>
+);
 
 export default function Nav({
+  currentDemo,
   demoRoutes,
-  contextualTheme,
+  wide,
   ...restProps
 }: Props) {
   const rootProps = { ...restProps };
 
-  const demoLinks = Object.keys(demoRoutes).map(slug => {
-    const demo = demoRoutes[slug];
-    return (
-      <ListItem key={slug}>
-        <Link to={`/components/${slug}`}>{demo.title}</Link>
-      </ListItem>
-    );
+  const demoLinks = demoRoutes.map(route => {
+    if (Array.isArray(route)) {
+      const open = route.filter(subRoute => subRoute.slug === currentDemo)
+        .length;
+      const subListProps = {
+        key: route[0].slug,
+        open,
+        wide
+      };
+      return (
+        <SubList {...subListProps}>
+          {route.map((subRoute, index) => {
+            const { slug, title } = subRoute;
+            return index === 0 || open ? renderItem(slug, title, wide) : null;
+          })}
+        </SubList>
+      );
+    } else {
+      const { slug, title } = route;
+      return renderItem(slug, title, wide);
+    }
   });
 
   return (
-    <ThemeProvider theme={contextualTheme}>
+    <ThemeProvider theme={wide ? navThemeWide : navTheme}>
       <nav {...rootProps}>
-        <Logo />
-        {pages}
-        <SectionHeading>Components</SectionHeading>
+        <Logo wide={wide} />
+        {pages(wide)}
+        <SectionHeading wide={wide}>Components</SectionHeading>
         <List>{demoLinks}</List>
       </nav>
     </ThemeProvider>

--- a/src/website/app/Page.js
+++ b/src/website/app/Page.js
@@ -27,7 +27,7 @@ import {
   getNormalizedValue,
   pxToEm
 } from '../../styles';
-import { mineralTheme, ThemeProvider } from '../../themes';
+import { ThemeProvider } from '../../themes';
 import Button from '../../Button';
 import IconClose from 'mineral-ui-icons/IconClose';
 import IconMenu from 'mineral-ui-icons/IconMenu';
@@ -42,17 +42,22 @@ import { heroTheme } from './pages/Home/index';
 type Props = {
   children: React$Node,
   chromeless?: boolean,
-  demoRoutes?: { [string]: DemoRoute },
+  demoRoutes?: Array<DemoRoute>,
   headerContent?: React$Node,
   pageMeta?: {
     canonicalLink?: string,
     description?: string,
     title?: string
   },
+  slug?: string,
   type?: number
 };
 
-type DemoRoute = { slug: string, title: string, description: string };
+type DemoRoute = {
+  description: string,
+  slug: string,
+  title: string
+};
 
 type State = {
   isNavOpen: boolean
@@ -117,25 +122,6 @@ const pageThemes = [
     SiteLink_color_hover: siteColors.orangePunch_hover
   }
 ];
-
-const navTheme = {
-  Heading_color_4: mineralTheme.color_gray_30,
-
-  SiteLink_borderColor_focus: mineralTheme.color_white,
-  SiteLink_color: mineralTheme.color_gray_30,
-  SiteLink_color_focus: mineralTheme.color_white,
-  SiteLink_color_hover: mineralTheme.color_white
-};
-
-const navThemeWide = {
-  Heading_color_4: siteColors.slateDarker,
-
-  SiteLink_borderColor_focus: siteColors.slateDarker_focus,
-  SiteLink_color: siteColors.slateDarker,
-  SiteLink_color_active: siteColors.slateDarker_active,
-  SiteLink_color_focus: siteColors.slateDarker_focus,
-  SiteLink_color_hover: siteColors.slateDarker_hover
-};
 
 /*
  * [1] The left bleed of the Section needs adjusting due to the nav sidebar.
@@ -338,31 +324,6 @@ const styles = {
           '@supports(position:sticky)': {
             maxHeight: '100vh',
             position: 'sticky'
-          },
-
-          '& h2': {
-            paddingRight: getNormalizedValue(pxToEm(8), theme.fontSize_h4)
-          },
-
-          '& a': {
-            paddingLeft: getNormalizedValue(pxToEm(8), theme.fontSize_ui),
-            paddingRight: getNormalizedValue(pxToEm(8), theme.fontSize_ui),
-
-            '&.active': {
-              backgroundColor: rgba(theme.color_text_primary, 0.15),
-              color: darken(0.1, theme.color_text_primary),
-              position: 'relative',
-
-              '&::before': {
-                backgroundColor: theme.color_text_primary,
-                bottom: 0,
-                content: '""',
-                position: 'absolute',
-                right: `-${pxToEm(3)}`,
-                top: 0,
-                width: pxToEm(3)
-              }
-            }
           }
         }
       : {
@@ -371,26 +332,7 @@ const styles = {
           overflowY: 'scroll', // [3]
           WebkitOverflowScrolling: 'touch', // [3]
           // 30px to match Section padding, 80px to make room for close button
-          padding: `${pxToEm(30)} ${pxToEm(80)} ${pxToEm(30)} ${pxToEm(30)}`,
-
-          '& a': {
-            paddingLeft: 0,
-
-            '&.active': {
-              color: theme.navLink_color_active_narrow,
-              position: 'relative',
-
-              '&::before': {
-                backgroundColor: theme.navLink_color_active_narrow,
-                bottom: 2,
-                content: '""',
-                left: `-${pxToEm(18)}`,
-                position: 'absolute',
-                top: 2,
-                width: pxToEm(6)
-              }
-            }
-          }
+          padding: `${pxToEm(30)} ${pxToEm(80)} ${pxToEm(30)} ${pxToEm(30)}`
         };
   },
   root: ({ theme }) => ({
@@ -429,7 +371,7 @@ const Header = createStyledComponent(Section, styles.header).withProps({
 const MenuButton = createStyledComponent(Button, styles.menuButton).withProps({
   circular: true
 });
-const Nav = createStyledComponent(_Nav, styles.nav, { filterProps: ['wide'] });
+const Nav = createStyledComponent(_Nav, styles.nav);
 const Wrap = createStyledComponent('div', styles.wrap);
 const WrapInner = createStyledComponent('div', styles.wrapInner);
 
@@ -449,6 +391,7 @@ export default class Page extends Component<Props, State> {
       demoRoutes,
       headerContent,
       pageMeta,
+      slug,
       type,
       ...restProps
     } = this.props;
@@ -458,6 +401,10 @@ export default class Page extends Component<Props, State> {
     const wrapProps = {
       isNavOpen,
       tabIndex: isNavOpen ? '-1' : undefined
+    };
+    const navProps = {
+      currentDemo: slug,
+      demoRoutes
     };
 
     const helmetItems = pageMeta && (
@@ -487,7 +434,7 @@ export default class Page extends Component<Props, State> {
                   inDialog
                   onClick={this.close.bind(this)}
                 />
-                <Nav demoRoutes={demoRoutes} contextualTheme={navTheme} />
+                <Nav {...navProps} />
               </Dialog>
             </div>
           );
@@ -535,13 +482,7 @@ export default class Page extends Component<Props, State> {
                       </Header>
                     </ThemeProvider>
                   )}
-                  {moreSpacious && (
-                    <Nav
-                      demoRoutes={demoRoutes}
-                      contextualTheme={navThemeWide}
-                      wide
-                    />
-                  )}
+                  {moreSpacious && <Nav {...navProps} wide />}
                   <Content>{children}</Content>
                 </WrapInner>
                 <Footer />

--- a/src/website/app/demos/routes.js
+++ b/src/website/app/demos/routes.js
@@ -15,170 +15,181 @@
  */
 
 /* @flow */
-export default {
-  avatar: {
+export default [
+  {
     description:
       'Avatar provides a graphic representation of an identity. It can display an image, text, or an icon.',
     slug: 'avatar',
     title: 'Avatar'
   },
-  button: {
+  {
     description:
       'Buttons trigger actions or state changes in your app. Choose a button color to match the intent of the action.',
     slug: 'button',
     title: 'Button'
   },
-  card: {
-    description:
-      'Cards group related elements and actions. Use a Card to display content that doesn’t fit neatly into a table row or grid cell.',
-    slug: 'card',
-    title: 'Card'
-  },
-  'card-actions': {
-    description:
-      'CardActions lays out actions like Buttons or Links in the body of the Card.',
-    slug: 'card-actions',
-    title: 'CardActions'
-  },
-  'card-block': {
-    description:
-      'CardBlock lays out content that’s not a title or an image in the body of the Card.',
-    slug: 'card-block',
-    title: 'CardBlock'
-  },
-  'card-divider': {
-    description: 'CardDivider visually seperates sections of content in Card.',
-    slug: 'card-divider',
-    title: 'CardDivider'
-  },
-  'card-footer': {
-    description: 'CardFooter provides a stateful extension to Card.',
-    slug: 'card-footer',
-    title: 'CardFooter'
-  },
-  'card-image': {
-    description:
-      'CardImages reinforce the intent of the Card. Images shouldn’t be used alone in a Card, but should be paired with a call to action and/or a CardTitle.',
-    slug: 'card-image',
-    title: 'CardImage'
-  },
-  'card-status': {
-    description:
-      "CardStatus provides a standard way of displaying a Card's current status.",
-    slug: 'card-status',
-    title: 'CardStatus'
-  },
-  'card-title': {
-    description:
-      'CardTitles provide a consistently styled heading for your Card. Use a subtitle to provide supporting information for the data displayed in the Card.',
-    slug: 'card-title',
-    title: 'CardTitle'
-  },
-  checkbox: {
-    description:
-      'Checkboxes allows users to select one or more options from a list. Use Checkboxes to accept multiple choice input from a user.',
-    slug: 'checkbox',
-    title: 'Checkbox'
-  },
-  'checkbox-group': {
-    description:
-      'CheckboxGroup allows users to construct a group of Checkboxes and provides a simpler API than working with Checkbox directly',
-    slug: 'checkbox-group',
-    title: 'CheckboxGroup'
-  },
-  dropdown: {
+  [
+    {
+      description:
+        'Cards group related elements and actions. Use a Card to display content that doesn’t fit neatly into a table row or grid cell.',
+      slug: 'card',
+      title: 'Card'
+    },
+    {
+      description:
+        'CardActions lays out actions like Buttons or Links in the body of the Card.',
+      slug: 'card-actions',
+      title: 'CardActions'
+    },
+    {
+      description:
+        'CardBlock lays out content that’s not a title or an image in the body of the Card.',
+      slug: 'card-block',
+      title: 'CardBlock'
+    },
+    {
+      description:
+        'CardDivider visually seperates sections of content in Card.',
+      slug: 'card-divider',
+      title: 'CardDivider'
+    },
+    {
+      description: 'CardFooter provides a stateful extension to Card.',
+      slug: 'card-footer',
+      title: 'CardFooter'
+    },
+    {
+      description:
+        'CardImages reinforce the intent of the Card. Images shouldn’t be used alone in a Card, but should be paired with a call to action and/or a CardTitle.',
+      slug: 'card-image',
+      title: 'CardImage'
+    },
+    {
+      description:
+        "CardStatus provides a standard way of displaying a Card's current status.",
+      slug: 'card-status',
+      title: 'CardStatus'
+    },
+    {
+      description:
+        'CardTitles provide a consistently styled heading for your Card. Use a subtitle to provide supporting information for the data displayed in the Card.',
+      slug: 'card-title',
+      title: 'CardTitle'
+    }
+  ],
+  [
+    {
+      description:
+        'Checkboxes allows users to select one or more options from a list. Use Checkboxes to accept multiple choice input from a user.',
+      slug: 'checkbox',
+      title: 'Checkbox'
+    },
+    {
+      description:
+        'CheckboxGroup allows users to construct a group of Checkboxes and provides a simpler API than working with Checkbox directly',
+      slug: 'checkbox-group',
+      title: 'CheckboxGroup'
+    }
+  ],
+  {
     description:
       'Dropdowns display a hidden Menu, available upon user interaction. Use Dropdowns for non-primary actions only.',
     slug: 'dropdown',
     title: 'Dropdown'
   },
-  'form-field': {
-    description:
-      'FormFields wrap an input with a label and other features.  Wrap each input in your app with a FormField for appropriate accessibilty and styling.',
-    slug: 'form-field',
-    title: 'FormField'
-  },
-  'form-fieldset': {
-    description:
-      'FormFieldsets wrap related FormFields and provide a legend.  Wrap related FormFields in a FormFieldset with a useful legend to help communicate relationships.',
-    slug: 'form-fieldset',
-    title: 'FormFieldset'
-  },
-  'form-field-divider': {
-    description:
-      'FormFieldDividers separate FormFields.  FormFieldDividers are best used to call attention to a subtle difference between fields.',
-    slug: 'form-field-divider',
-    title: 'FormFieldDivider'
-  },
-  icon: {
+  [
+    {
+      description:
+        'FormFields wrap an input with a label and other features.  Wrap each input in your app with a FormField for appropriate accessibilty and styling.',
+      slug: 'form-field',
+      title: 'FormField'
+    },
+    {
+      description:
+        'FormFieldsets wrap related FormFields and provide a legend.  Wrap related FormFields in a FormFieldset with a useful legend to help communicate relationships.',
+      slug: 'form-fieldset',
+      title: 'FormFieldset'
+    },
+    {
+      description:
+        'FormFieldDividers separate FormFields.  FormFieldDividers are best used to call attention to a subtle difference between fields.',
+      slug: 'form-field-divider',
+      title: 'FormFieldDivider'
+    }
+  ],
+  {
     description:
       'Icons symbolize actions and objects in your interface. Use icons in combination with labels to help users more quickly process your UI.',
     slug: 'icon',
     title: 'Icon'
   },
-  link: {
+  {
     description:
       'Links change the users’ browser location, and clearly express the intended destination.',
     slug: 'link',
     title: 'Link'
   },
-  menu: {
-    description:
-      'Menus group related actions or links for your user. Use Menus to toggle features or to group navigation options.',
-    slug: 'menu',
-    title: 'Menu'
-  },
-  'menu-divider': {
-    description:
-      'MenuDividers visually separate MenuGroups or individual MenuItems to increase usability in your Menu.',
-    slug: 'menu-divider',
-    title: 'MenuDivider'
-  },
-  'menu-group': {
-    description: 'MenuGroups classify similar actions and provide labels.',
-    slug: 'menu-group',
-    title: 'MenuGroup'
-  },
-  'menu-item': {
-    description:
-      'MenuItems represent an option in a Menu. Use MenuItems to trigger actions or navigate to a new location.',
-    slug: 'menu-item',
-    title: 'MenuItem'
-  },
-  popover: {
+  [
+    {
+      description:
+        'Menus group related actions or links for your user. Use Menus to toggle features or to group navigation options.',
+      slug: 'menu',
+      title: 'Menu'
+    },
+    {
+      description:
+        'MenuDividers visually separate MenuGroups or individual MenuItems to increase usability in your Menu.',
+      slug: 'menu-divider',
+      title: 'MenuDivider'
+    },
+    {
+      description: 'MenuGroups classify similar actions and provide labels.',
+      slug: 'menu-group',
+      title: 'MenuGroup'
+    },
+    {
+      description:
+        'MenuItems represent an option in a Menu. Use MenuItems to trigger actions or navigate to a new location.',
+      slug: 'menu-item',
+      title: 'MenuItem'
+    }
+  ],
+  {
     description:
       'Popovers display supporting content when your user interacts with an associated trigger. Use Popovers to implement other custom behaviors or widgets.',
     slug: 'popover',
     title: 'Popover'
   },
-  radio: {
-    description:
-      'Radios allows users to select a single option from a list. Use Radios to accept limited choice input from a user.',
-    slug: 'radio',
-    title: 'Radio'
-  },
-  'radio-group': {
-    description:
-      'RadioGroup allows users to construct a group of Radios and provides a simpler API than working with Radio directly',
-    slug: 'radio-group',
-    title: 'RadioGroup'
-  },
-  'text-area': {
+  [
+    {
+      description:
+        'Radios allows users to select a single option from a list. Use Radios to accept limited choice input from a user.',
+      slug: 'radio',
+      title: 'Radio'
+    },
+    {
+      description:
+        'RadioGroup allows users to construct a group of Radios and provides a simpler API than working with Radio directly',
+      slug: 'radio-group',
+      title: 'RadioGroup'
+    }
+  ],
+  {
     description:
       'TextAreas accept data from the user.  Use a TextArea to accept potentially lengthy, free-form input from a user',
     slug: 'text-area',
     title: 'TextArea'
   },
-  'text-input': {
+  {
     description:
       'TextInputs accept data from the user.  Use a TextInput to accept brief, free-form input from a user',
     slug: 'text-input',
     title: 'TextInput'
   },
-  'theme-provider': {
+  {
     description:
       'ThemeProvider applies styles to a section of your app. Nesting enables multiple themes.',
     slug: 'theme-provider',
     title: 'ThemeProvider'
   }
-};
+];


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
The nav currently shows all components in a flat list. This PR will collapse subcomponents under their parent component unless either that parent or a subcomponent is active. It also adds some styles to visually connect those subcomponents to their parent.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Closes #471.

Worth noting:
1. It was decided that our components (so far) require documentation that is too complex to display more than one per page, so we're closing that issue by only updating the navigation.
2. It was also decided that without going "full accordion" with our navigation, we wanted to avoid having two click/tap targets on a menu item to either navigate to that item or expand its subcomponents. Thus, you only see subcomponents after navigating to their parent or a sibling.

### Screenshots, videos, or demo, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

https://471-site-nav-subcomponents--mineral-ui.netlify.com/components/card

![screen shot 2018-01-22 at 12 05 38 pm](https://user-images.githubusercontent.com/486540/35239076-a1f0fe46-ff6c-11e7-97d9-7b3620aebcbd.png)
Note how you only see ‘Menu’ here.

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Navigate to Button and confirm that you can only see Card and Menu (and not their subcomponents)
3. Navigate to Card and confirm that you can now see its subcomponents (but still not Menu's)
4. Navigate to CardBlock and confirm that all Card subcomponents stay expanded
5. Repeat steps 3 & 4 with Menu & MenuGroup

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- New feature (non-breaking change which adds functionality)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Much better](https://media.giphy.com/media/ALWsTtMzfjai4/giphy.gif)
