### PR TITLE
[website] Add error boundaries for examples & other improvements

### DIFF
--- a/src/website/app/ComponentDocExample.js
+++ b/src/website/app/ComponentDocExample.js
@@ -23,6 +23,7 @@ import {
 } from '../../styles';
 import IconArrowBack from 'mineral-ui-icons/IconArrowBack';
 import Callout from './Callout';
+import ErrorBoundary from './ErrorBoundary';
 import Heading from './SiteHeading';
 import Link from './SiteLink';
 import LiveProvider from './LiveProvider';
@@ -66,7 +67,9 @@ const styles = {
     // Specificity hack
     // Sometimes Page's intro styling needs undone
     '& > p[class][class]': {
+      color: 'inherit',
       fontSize: theme.fontSize_prose,
+      fontWeight: 'inherit',
       maxWidth: theme.maxTextWidth
     }
   }),
@@ -159,7 +162,7 @@ export default function ComponentDocExample({
         {!standalone ? <Link to={id}>{title}</Link> : title}
       </Title>
       <Description scope={{ Callout }}>{description || ''}</Description>
-      {liveCode}
+      <ErrorBoundary buttonLabel="Reload example">{liveCode}</ErrorBoundary>
     </Root>
   );
 }

--- a/src/website/app/ErrorBoundary.js
+++ b/src/website/app/ErrorBoundary.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2017 CA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+import React, { Component } from 'react';
+import { red } from '../../colors';
+import { createStyledComponent } from '../../styles';
+import { createThemedComponent } from '../../themes';
+import _Button from '../../Button';
+import Heading from './Heading';
+
+type Props = {
+  buttonLabel: string,
+  children?: React$Node,
+  errorMessage: string,
+  onReRender?: () => void
+};
+
+type State = {
+  hasError: boolean
+};
+
+const ErrorBlock = createStyledComponent('div', ({ theme }) => ({
+  backgroundColor: red.red_10,
+  border: `1px solid ${red.red_20}`,
+  color: theme.color_text_danger,
+  lineHeight: theme.lineHeight_prose,
+  padding: theme.space_inset_lg,
+  textAlign: 'center'
+}));
+
+const Button = createThemedComponent(_Button, {
+  borderColor_focus: red.red_60
+});
+
+export default class ErrorBoundary extends Component<Props, State> {
+  static defaultProps = {
+    errorMessage: 'Oops, something went wrong. Check your console for details.',
+    buttonLabel: 'Reload component'
+  };
+
+  state = {
+    hasError: false
+  };
+
+  componentDidCatch(error: Object, info: Object) {
+    this.setState({ hasError: true });
+    console.error(info);
+  }
+
+  render() {
+    const { buttonLabel, children, errorMessage, onReRender } = this.props;
+    if (this.state.hasError) {
+      const headingProps = {
+        as: 'h4',
+        level: 5,
+        css: { color: 'currentColor' }
+      };
+      const buttonProps = {
+        'aria-label': `${errorMessage} ${buttonLabel}`,
+        autoFocus: true,
+        size: 'small',
+        onClick: () => {
+          this.reRender(onReRender);
+        }
+      };
+      return (
+        <ErrorBlock>
+          <Heading {...headingProps}>{errorMessage}</Heading>
+          <Button {...buttonProps}>{buttonLabel}</Button>
+        </ErrorBlock>
+      );
+    }
+    return children;
+  }
+
+  reRender = (action?: () => void) => {
+    if (action) {
+      action();
+    }
+    this.setState({ hasError: false });
+  };
+}

--- a/src/website/app/LiveProvider.js
+++ b/src/website/app/LiveProvider.js
@@ -44,7 +44,12 @@ const styles = {
       : {
           backgroundColor,
           border: `1px solid ${rgba(siteColors.slate, 0.3)}`,
-          padding: theme.space_inset_md
+          fontFamily: 'comic sans ms',
+          padding: theme.space_inset_md,
+
+          '& ::selection': {
+            backgroundColor: 'highlight'
+          }
         };
   },
   liveEditor: ({ theme }) => ({


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
- Add an ErrorBoundary component and wrap it around our examples' previews/editor
- Fix incorrectly-styled description when viewing standalone example
- Reset text highlight to browser default inside example previews
- Assign funky font-family to live previews to make it immediately
obvious if `includeStyleReset` was forgotten

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
It can be frustrating to encounter an error while live-editing an example and have the whole page crash. This prevents that and provides a nice "reload this component" button.

The funky font makes it immediately obvious if a dev has forgotten to `includeStyleReset`. If a component can ever be rendered not inside another (i.e. Card, but not CardTitle), then it should have the reset.

The other minor improvements are just things that have been bugging me for a while and seemed easy enough to do here.

### Screenshots, videos, or demo, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

https://site-example-error-boundaries-and-more--mineral-ui.netlify.com/components/box/

![Error block](https://user-images.githubusercontent.com/486540/36275993-b969da1c-1249-11e8-8336-3833abc2e65c.png)


### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. The easiest way I know of to force an error is to go to [Box's responsive example](https://site-example-error-boundaries-and-more--mineral-ui.netlify.com/components/box/responsive/), place your cursor just before `'wide'` in the `breakpoints` array, and hit backspace until you've deleted "800, ". Make sure the error message is sufficient and that the 'Try again?' button works.
3. Highlight some text in an example. It should use the same highlight color as the browser/OS default, _not_ light green like the rest of the page.
4. Either set `includeStyleReset: false` on a component in the source or just remove the `font-family: 'Open Sans', ...` on a component in a preview via dev tools. You should see a funky font.

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Docs improvements

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->
