### PR TITLE
build(test): Avoid posting happo comment when no diffs

### DIFF
--- a/scripts/happo-ci.sh
+++ b/scripts/happo-ci.sh
@@ -68,13 +68,13 @@ run-happo "$CURRENT_SHA"
 
 # Compare reports from the two SHAs.
 COMMIT_SUBJECT="$(git show -s --format=%s)"
-SUMMARY=$(npm run --silent happo compare "$PREVIOUS_SHA" "$CURRENT_SHA" \
-  --link "$PR_URL" --message "$COMMIT_SUBJECT" || true)
+if ! SUMMARY=$(npm run --silent happo compare "$PREVIOUS_SHA" "$CURRENT_SHA" \
+  --link "$PR_URL" --message "$COMMIT_SUBJECT"); then
+  MESSAGE="Message from Happo:
 
-MESSAGE="Message from Happo:
+  $SUMMARY"
 
-$SUMMARY"
+  echo "Attempting to post comment on ${PR_URL}: ${MESSAGE}"
 
-echo "Attempting to post comment on ${PR_URL}: ${MESSAGE}"
-
-node scripts/postCommentOnPR.js "$MESSAGE"
+  node scripts/postCommentOnPR.js "$MESSAGE"
+fi


### PR DESCRIPTION
I've noticed that the comment posted from the happo-ci.sh script can be
noisy, especially for PRs that are pushed to/rebased many times. By
silencing out the comment so that it's only posted when there are one or
more diffs/added/deleted we can avoid noise in many cases.