### PR TITLE
[Avatar]: Remove icon prop from rendering on DOM element

### DIFF
--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -138,6 +138,7 @@ const Root = createStyledComponent(
   },
   {
     displayName: 'Avatar',
+    filterProps: ['icon'],
     includeStyleReset: true
   }
 );

--- a/src/Avatar/__tests__/__snapshots__/Avatar.spec.js.snap
+++ b/src/Avatar/__tests__/__snapshots__/Avatar.spec.js.snap
@@ -217,7 +217,6 @@ exports[`Avatar demo examples basic 1`] = `
                   >
                     <span
                       className="glamor-0"
-                      icon={undefined}
                     >
                       <img
                         alt="Allison"
@@ -235,7 +234,6 @@ exports[`Avatar demo examples basic 1`] = `
                   >
                     <span
                       className="glamor-1"
-                      icon={undefined}
                     >
                       <abbr
                         title="Allison"
@@ -259,12 +257,6 @@ exports[`Avatar demo examples basic 1`] = `
                   >
                     <span
                       className="glamor-3"
-                      icon={
-                        <IconCloud
-                          size="1.5em"
-                          title="cloud"
-                        />
-                      }
                     >
                       <IconCloud
                         size="1.5em"
@@ -1253,7 +1245,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-0"
-                      icon={undefined}
                     >
                       <abbr
                         title="Theme  "
@@ -1275,7 +1266,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-1"
-                      icon={undefined}
                     >
                       <abbr
                         title="Red    "
@@ -1297,7 +1287,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-2"
-                      icon={undefined}
                     >
                       <abbr
                         title="Magenta"
@@ -1319,7 +1308,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-3"
-                      icon={undefined}
                     >
                       <abbr
                         title="Purple "
@@ -1341,7 +1329,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-4"
-                      icon={undefined}
                     >
                       <abbr
                         title="Indigo "
@@ -1363,7 +1350,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-0"
-                      icon={undefined}
                     >
                       <abbr
                         title="Blue   "
@@ -1385,7 +1371,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-6"
-                      icon={undefined}
                     >
                       <abbr
                         title="Sky    "
@@ -1407,7 +1392,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-7"
-                      icon={undefined}
                     >
                       <abbr
                         title="Teal   "
@@ -1429,7 +1413,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-8"
-                      icon={undefined}
                     >
                       <abbr
                         title="Green  "
@@ -1451,7 +1434,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-9"
-                      icon={undefined}
                     >
                       <abbr
                         title="Lime   "
@@ -1473,7 +1455,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-10"
-                      icon={undefined}
                     >
                       <abbr
                         title="Yellow "
@@ -1495,7 +1476,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-11"
-                      icon={undefined}
                     >
                       <abbr
                         title="Orange "
@@ -1517,7 +1497,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-12"
-                      icon={undefined}
                     >
                       <abbr
                         title="Gray   "
@@ -1539,7 +1518,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-13"
-                      icon={undefined}
                     >
                       <abbr
                         title="Slate  "
@@ -1561,7 +1539,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-14"
-                      icon={undefined}
                     >
                       <abbr
                         title="Dusk   "
@@ -1585,7 +1562,6 @@ exports[`Avatar demo examples colors 1`] = `
                   >
                     <span
                       className="glamor-15"
-                      icon={undefined}
                     >
                       <abbr
                         title="Custom"
@@ -1692,7 +1668,6 @@ exports[`Avatar demo examples custom-text-abbr 1`] = `
               >
                 <span
                   className="glamor-0"
-                  icon={undefined}
                 >
                   <abbr
                     title="Dr. Bernard Johnson"
@@ -1925,7 +1900,6 @@ exports[`Avatar demo examples shapes 1`] = `
                   >
                     <span
                       className="glamor-0"
-                      icon={undefined}
                     >
                       <abbr
                         title="Circle"
@@ -1946,7 +1920,6 @@ exports[`Avatar demo examples shapes 1`] = `
                   >
                     <span
                       className="glamor-1"
-                      icon={undefined}
                     >
                       <abbr
                         title="Rounded"
@@ -1967,7 +1940,6 @@ exports[`Avatar demo examples shapes 1`] = `
                   >
                     <span
                       className="glamor-2"
-                      icon={undefined}
                     >
                       <abbr
                         title="Square"
@@ -2730,7 +2702,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-0"
-                      icon={undefined}
                     >
                       <img
                         alt="Sam"
@@ -2750,7 +2721,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-1"
-                      icon={undefined}
                     >
                       <abbr
                         title="Sam"
@@ -2776,12 +2746,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-3"
-                      icon={
-                        <IconCloud
-                          size="medium"
-                          title="cloud"
-                        />
-                      }
                     >
                       <IconCloud
                         size="medium"
@@ -2836,7 +2800,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-4"
-                      icon={undefined}
                     >
                       <img
                         alt="Melissa"
@@ -2856,7 +2819,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-5"
-                      icon={undefined}
                     >
                       <abbr
                         title="Melissa"
@@ -2882,12 +2844,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-7"
-                      icon={
-                        <IconCloud
-                          size="medium"
-                          title="cloud"
-                        />
-                      }
                     >
                       <IconCloud
                         size="medium"
@@ -2940,7 +2896,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-8"
-                      icon={undefined}
                     >
                       <img
                         alt="Larry"
@@ -2958,7 +2913,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-9"
-                      icon={undefined}
                     >
                       <abbr
                         title="Larry"
@@ -2982,12 +2936,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-11"
-                      icon={
-                        <IconCloud
-                          size="1.5em"
-                          title="cloud"
-                        />
-                      }
                     >
                       <IconCloud
                         size="1.5em"
@@ -3042,7 +2990,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-12"
-                      icon={undefined}
                     >
                       <img
                         alt="Jennifer"
@@ -3062,7 +3009,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-13"
-                      icon={undefined}
                     >
                       <abbr
                         title="Jennifer"
@@ -3088,12 +3034,6 @@ exports[`Avatar demo examples sizes 1`] = `
                   >
                     <span
                       className="glamor-15"
-                      icon={
-                        <IconCloud
-                          size="1.5em"
-                          title="cloud"
-                        />
-                      }
                     >
                       <IconCloud
                         size="1.5em"

--- a/src/Card/__tests__/__snapshots__/Card.spec.js.snap
+++ b/src/Card/__tests__/__snapshots__/Card.spec.js.snap
@@ -1059,7 +1059,6 @@ exports[`Card demo examples avatar 1`] = `
                                     >
                                       <span
                                         className="glamor-0"
-                                        icon={undefined}
                                       >
                                         <img
                                           alt="Alt text"
@@ -1159,7 +1158,6 @@ exports[`Card demo examples avatar 1`] = `
                                     >
                                       <span
                                         className="glamor-0"
-                                        icon={undefined}
                                       >
                                         <img
                                           alt="Alt text"
@@ -6872,7 +6870,6 @@ exports[`Card demo examples rtl 3`] = `
                                         >
                                           <span
                                             className="glamor-0"
-                                            icon={undefined}
                                           >
                                             <img
                                               alt="نص بديل"


### PR DESCRIPTION
### Description

Stops the `icon` prop from rendering on the Avatar component DOM element

### Motivation and context

closes #584

### Screenshots, videos, or demo, if appropriate

https://584-avatar--mineral-ui.netlify.com/components/avatar/

### How to test

* View the source of an Avatar component that renders an Icon in the [website](https://584-avatar--mineral-ui.netlify.com/components/avatar/). Note that it no longer contains `icon="[object Object]"`.
* Verify that the `icon` functionality of the Avatar component still works

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
