### PR TITLE
perf(select,dropdown) Use items instance var

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "exenv": "1.2.2",
+    "fast-deep-equal": "1.1.0",
     "fontfaceobserver": "2.0.13",
     "react-popper": "0.7.4",
     "scroll-into-view-if-needed": "1.5.0"

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -18,6 +18,7 @@
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed';
+import deepEqual from 'fast-deep-equal';
 import { composePropsWithGetter, generateId } from '../utils';
 import Root from '../Popover';
 import DropdownContent, {
@@ -120,6 +121,14 @@ export default class Dropdown extends Component<Props, State> {
   highlightedItemId: ?string;
 
   itemMatcher: any;
+
+  items: Items = getItems(this.props.data);
+
+  componentWillReceiveProps(nextProps: Props) {
+    if (!deepEqual(this.props.data, nextProps.data)) {
+      this.items = getItems(nextProps.data);
+    }
+  }
 
   render() {
     const {
@@ -238,14 +247,6 @@ export default class Dropdown extends Component<Props, State> {
     );
   };
 
-  getItems = () => {
-    return getItems(this.props.data);
-  };
-
-  getItemIndex = (item: Item) => {
-    return this.getItems().indexOf(item);
-  };
-
   getHighlightedItemId = () => {
     const highlightedIndex = this.getControllableValue('highlightedIndex');
     return highlightedIndex !== undefined && highlightedIndex !== null
@@ -274,7 +275,7 @@ export default class Dropdown extends Component<Props, State> {
       this.highlightItemAtIndex(0);
     } else if (key === 'End' && isOpen) {
       event.preventDefault();
-      this.highlightItemAtIndex(this.getItems().length - 1);
+      this.highlightItemAtIndex(this.items.length - 1);
     } else if (key === 'Enter' || key === ' ') {
       event.preventDefault();
       isOpen
@@ -290,7 +291,7 @@ export default class Dropdown extends Component<Props, State> {
   findItemMatchingKey = (key: string) => {
     this.itemMatcher = this.itemMatcher || new ItemMatcher();
     return this.itemMatcher.findMatchingItem(
-      this.getItems(),
+      this.items,
       this.getControllableValue('highlightedIndex'),
       key
     );
@@ -298,7 +299,7 @@ export default class Dropdown extends Component<Props, State> {
 
   highlightItemMatchingKey = (key: string) => {
     const matchingItem = this.findItemMatchingKey(key);
-    matchingItem && this.highlightItemAtIndex(this.getItemIndex(matchingItem));
+    matchingItem && this.highlightItemAtIndex(this.items.indexOf(matchingItem));
   };
 
   highlightItemAtIndex = (index: number) => {
@@ -317,7 +318,7 @@ export default class Dropdown extends Component<Props, State> {
           highlightedIndex:
             prevState.highlightedIndex === null ||
             prevState.highlightedIndex === undefined ||
-            prevState.highlightedIndex === this.getItems().length - 1
+            prevState.highlightedIndex === this.items.length - 1
               ? 0
               : prevState.highlightedIndex + 1
         }),
@@ -331,7 +332,7 @@ export default class Dropdown extends Component<Props, State> {
       this.setState(
         prevState => ({
           highlightedIndex: !prevState.highlightedIndex
-            ? this.getItems().length - 1
+            ? this.items.length - 1
             : prevState.highlightedIndex - 1
         }),
         this.scrollHighlightedItemIntoViewIfNeeded

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -18,6 +18,7 @@
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed';
+import deepEqual from 'fast-deep-equal';
 import { composeEventHandlers, generateId } from '../utils';
 import { createStyledComponent } from '../styles';
 import { createThemedComponent, mapComponentThemes } from '../themes';
@@ -192,6 +193,14 @@ export default class Select extends Component<Props, State> {
 
   itemMatcher: any;
 
+  items: Items = getItems(this.props.data);
+
+  componentWillReceiveProps(nextProps: Props) {
+    if (!deepEqual(this.props.data, nextProps.data)) {
+      this.items = getItems(nextProps.data);
+    }
+  }
+
   render() {
     const {
       data,
@@ -298,14 +307,6 @@ export default class Select extends Component<Props, State> {
     };
   };
 
-  getItems = () => {
-    return getItems(this.props.data);
-  };
-
-  getItemIndex = (item: Item) => {
-    return this.getItems().indexOf(item);
-  };
-
   getHighlightedOrSelectedIndex = () => {
     const isOpen = this.getControllableValue('isOpen');
     const selectedItem = this.getControllableValue('selectedItem');
@@ -316,7 +317,7 @@ export default class Select extends Component<Props, State> {
       selectedItem &&
       (highlightedIndex === null || highlightedIndex === undefined)
     ) {
-      return this.getItemIndex(selectedItem);
+      return this.items.indexOf(selectedItem);
     }
 
     return highlightedIndex;
@@ -346,7 +347,7 @@ export default class Select extends Component<Props, State> {
       this.highlightItemAtIndex(0);
     } else if (key === 'End' && isOpen) {
       event.preventDefault();
-      this.highlightItemAtIndex(this.getItems().length - 1);
+      this.highlightItemAtIndex(this.items.length - 1);
     } else if (key === 'Enter' || key === ' ') {
       event.preventDefault();
       isOpen ? this.clickHighlightedItem() : this.open(event);
@@ -358,7 +359,7 @@ export default class Select extends Component<Props, State> {
   findItemMatchingKey = (key: string) => {
     this.itemMatcher = this.itemMatcher || new ItemMatcher();
     return this.itemMatcher.findMatchingItem(
-      this.getItems(),
+      this.items,
       this.getControllableValue('highlightedIndex'),
       key
     );
@@ -366,7 +367,7 @@ export default class Select extends Component<Props, State> {
 
   highlightItemMatchingKey = (key: string) => {
     const matchingItem = this.findItemMatchingKey(key);
-    matchingItem && this.highlightItemAtIndex(this.getItemIndex(matchingItem));
+    matchingItem && this.highlightItemAtIndex(this.items.indexOf(matchingItem));
   };
 
   highlightItemAtIndex = (index: number) => {
@@ -386,9 +387,9 @@ export default class Select extends Component<Props, State> {
             prevState.highlightedIndex === null ||
             prevState.highlightedIndex === undefined
               ? prevState.selectedItem
-                ? this.getItemIndex(prevState.selectedItem)
+                ? this.items.indexOf(prevState.selectedItem)
                 : 0
-              : prevState.highlightedIndex === this.getItems().length - 1
+              : prevState.highlightedIndex === this.items.length - 1
                 ? 0
                 : prevState.highlightedIndex + 1
         }),
@@ -405,10 +406,10 @@ export default class Select extends Component<Props, State> {
             prevState.highlightedIndex === null ||
             prevState.highlightedIndex === undefined
               ? prevState.selectedItem
-                ? this.getItemIndex(prevState.selectedItem)
-                : this.getItems().length - 1
+                ? this.items.indexOf(prevState.selectedItem)
+                : this.items.length - 1
               : prevState.highlightedIndex === 0
-                ? this.getItems().length - 1
+                ? this.items.length - 1
                 : prevState.highlightedIndex - 1
         }),
         this.scrollHighlightedItemIntoViewIfNeeded
@@ -424,7 +425,7 @@ export default class Select extends Component<Props, State> {
           : prevState.selectedItem;
         return {
           highlightedIndex: selectedItem
-            ? this.getItemIndex(selectedItem)
+            ? this.items.indexOf(selectedItem)
             : prevState.highlightedIndex ? prevState.highlightedIndex : 0
         };
       }, this.scrollHighlightedItemIntoViewIfNeeded);
@@ -459,7 +460,7 @@ export default class Select extends Component<Props, State> {
     if (!this.isControlled('highlightedIndex')) {
       stateToSet = {
         ...stateToSet,
-        highlightedIndex: this.getItemIndex(item)
+        highlightedIndex: this.items.indexOf(item)
       };
     }
 


### PR DESCRIPTION
### Description

Update Select and Dropdown to use `items` instance variable instead of calling `getItems()` a bunch of times.

This does introduce the need to do a deep equality check on `data`, which adds an additional project dependency - https://www.npmjs.com/package/fast-deep-equal

### Motivation and context

Performance

We wanted to do this in the original Select PR, but it got bumped out of MVP.

### Screenshots, videos, or demo, if appropriate

http://select-items-instance-var--mineral-ui.netlify.com/

### How to test

1. General testing - ensure that the Select and Dropdown components work as previous in the demo
2. Additional testing, if you desire...
  * start local demo and browse to an individual Select demo example
  * add a `console.count('getItems()');` to `Menu.getItems()`;
  * play with example and compare the number of times that it is called vs. the same using `master`
  * Use `console.time` to compare the time to run `getItems` alone vs. `deepEqual` in `componentWillReceiveProps` and note that `deepEqual` is considerably faster.

### Types of changes

- Other (provide details below)

performance improvement

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - **[n/a]**" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - existing coverage
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
