### PR TITLE
[website] Improve routing and some relative linking

### DIFF
--- a/src/website/app/App.js
+++ b/src/website/app/App.js
@@ -1,7 +1,6 @@
 /* @flow */
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
-import { Redirect, Route, Switch } from 'react-router-dom';
 import { canUseDOM } from 'exenv';
 import lighten from 'polished/lib/color/lighten';
 import { pxToEm } from '../../styles';
@@ -119,27 +118,13 @@ class App extends Component<Props> {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (canUseDOM && this.props.location !== prevProps.location) {
-      global.window.scrollTo(0, 0);
-    }
-  }
-
   render() {
     const { demoRoutes } = this.props;
 
     return (
       <ThemeProvider theme={siteTheme}>
         <div>
-          <Switch>
-            <Route
-              exact
-              strict
-              path="/:url*"
-              render={props => <Redirect to={`${props.location.pathname}/`} />}
-            />
-            <Route render={() => <Router demoRoutes={demoRoutes} />} />
-          </Switch>
+          <Router demoRoutes={demoRoutes} />
           <BaselineGrid />
         </div>
       </ThemeProvider>

--- a/src/website/app/ComponentDocExample.js
+++ b/src/website/app/ComponentDocExample.js
@@ -22,6 +22,7 @@ type Props = {
   hideSource?: boolean,
   id: string,
   scope?: Object,
+  slug: string,
   source?: string,
   standalone?: boolean,
   title?: React$Node
@@ -107,12 +108,17 @@ export default function ComponentDocExample({
   hideSource,
   id,
   scope,
+  slug,
   source,
   standalone,
   title: propsTitle,
   ...restProps
 }: Props) {
   const rootProps = { ...restProps };
+  const descriptionProps = {
+    scope: { Callout },
+    standalone
+  };
   const liveProviderProps = {
     backgroundColor,
     hideSource: chromeless || hideSource,
@@ -138,14 +144,18 @@ export default function ComponentDocExample({
   ) : (
     <Root {...rootProps}>
       {standalone && (
-        <BackLink to="../">
+        <BackLink to={`/components/${slug}`}>
           <IconArrowBack color="currentColor" size="small" /> {componentName}
         </BackLink>
       )}
       <Title id={!standalone ? id : undefined}>
-        {!standalone ? <Link to={id}>{title}</Link> : title}
+        {!standalone ? (
+          <Link to={`/components/${slug}/${id}`}>{title}</Link>
+        ) : (
+          title
+        )}
       </Title>
-      <Description scope={{ Callout }}>{description || ''}</Description>
+      <Description {...descriptionProps}>{description || ''}</Description>
       <ErrorBoundary buttonLabel="Reload example">{liveCode}</ErrorBoundary>
     </Root>
   );

--- a/src/website/app/Markdown.js
+++ b/src/website/app/Markdown.js
@@ -24,7 +24,8 @@ type Props = {
   className?: string,
   scope?: {
     [string]: React$ComponentType<*>
-  }
+  },
+  standalone?: boolean
 };
 
 type mdCodeProps = {
@@ -306,6 +307,7 @@ export default function Markdown({
   children,
   className,
   scope,
+  standalone,
   ...restProps
 }: Props) {
   const rootProps = {
@@ -317,7 +319,16 @@ export default function Markdown({
     createElement,
     elements: {
       a({ href, children }: mdLinkProps) {
-        const linkProps = isNormalLink(href) ? { href } : { to: href };
+        let linkProps = { to: href };
+        if (isNormalLink(href)) {
+          if (standalone && href.startsWith('#')) {
+            // When viewing a standalone example, convert any same-page anchor
+            // links to routed ones
+            linkProps = { to: href.replace('#', '') };
+          } else {
+            linkProps = { href };
+          }
+        }
         return <Link {...linkProps}>{children}</Link>;
       },
       code({ language = 'jsx', code, children }: mdCodeProps) {

--- a/src/website/app/ScrollToIdOnMount.js
+++ b/src/website/app/ScrollToIdOnMount.js
@@ -1,0 +1,25 @@
+/* @flow */
+import { Component } from 'react';
+import { canUseDOM } from 'exenv';
+
+type Props = {
+  children?: any,
+  id?: string
+};
+
+export default class ScrollToIdOnMount extends Component<Props> {
+  componentDidMount() {
+    const element =
+      canUseDOM &&
+      this.props.id &&
+      global.document.getElementById(this.props.id);
+
+    if (element) {
+      element.scrollIntoView();
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/src/website/app/demos/Avatar/examples/avatar.js
+++ b/src/website/app/demos/Avatar/examples/avatar.js
@@ -7,7 +7,7 @@ export default {
   id: 'basic',
   title: 'Basic Usage',
   description: `Avatar can display an image, a text character, or an
-[Icon](../icon). For accessibility, please provide an \`alt\`/\`title\`
+[Icon](/components/icon). For accessibility, please provide an \`alt\`/\`title\`
 attribute for standalone Avatars.`,
   scope: { Avatar, DemoLayout, IconCloud },
   source: `

--- a/src/website/app/demos/Avatar/examples/colors.js
+++ b/src/website/app/demos/Avatar/examples/colors.js
@@ -6,10 +6,10 @@ export default {
   id: 'colors',
   title: 'Colors',
   description: `Avatar is available in any of the
-[palette's base colors](/color/#guidelines-ramps). By default, it will use your
+[palette's base colors](/color#guidelines-ramps). By default, it will use your
 theme's base color. You may also pass in a custom \`background\` and \`color\`,
 but be sure to use a color combination with an
-[adequate contrast ratio](/color/#guidelines-accessibility-(a11y\)).`, // eslint-disable-line no-useless-escape
+[adequate contrast ratio](/color#guidelines-accessibility-(a11y\)).`, // eslint-disable-line no-useless-escape
   scope: { Avatar, DemoLayout },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Avatar/index.js
+++ b/src/website/app/demos/Avatar/index.js
@@ -13,6 +13,6 @@ export default {
   slug: 'avatar',
   title: 'Avatar',
   whenHowToUse: `Avatar should be used to associate something to an identity.
-For example, add a user's Avatar to a [Card](../card) to connect that Card's
+For example, add a user's Avatar to a [Card](/components/card) to connect that Card's
 content to that user.`
 };

--- a/src/website/app/demos/Box/components/responsiveInstructions.js
+++ b/src/website/app/demos/Box/components/responsiveInstructions.js
@@ -4,7 +4,7 @@ const instructions = `
 media queries used for responsive properties.
 1. Those breakpoint values can either be a number (converted to px) or a key
 from the theme (e.g. the default
-[mineralTheme](/theming/#common-scenarios-theme-structure) has 'narrow',
+[mineralTheme](/theming#common-scenarios-theme-structure) has 'narrow',
 'medium', and 'wide').
 1. For each responsive property, instead of passing a single value, _pass an
 array of values that is one longer than the \`breakpoints\` array_. The first

--- a/src/website/app/demos/Box/examples/spacing.js
+++ b/src/website/app/demos/Box/examples/spacing.js
@@ -6,7 +6,7 @@ export default {
   id: 'spacing',
   title: 'Spacing',
   description: `Values for margin & padding
-can be a [spacing theme variable](/theming/#common-scenarios-theme-structure)
+can be a [spacing theme variable](/theming#common-scenarios-theme-structure)
 or a custom string or number.
 
 In _order of precedence_, Box accepts the following spacing props:

--- a/src/website/app/demos/Button/bestPractices.js
+++ b/src/website/app/demos/Button/bestPractices.js
@@ -6,7 +6,7 @@ export default [
   {
     type: 'do',
     description:
-      'Use the [appropriate variant](/color/#guidelines-variants) for your intent.',
+      'Use the [appropriate variant](/color#guidelines-variants) for your intent.',
     example: (
       <Button variant="success" primary>
         Proceed to Checkout

--- a/src/website/app/demos/Button/examples/iconOnly.js
+++ b/src/website/app/demos/Button/examples/iconOnly.js
@@ -6,7 +6,7 @@ import DemoLayout from '../components/DemoLayout';
 export default {
   id: 'icon-only',
   title: 'Icon-Only Buttons',
-  description: `Buttons that contain only [Icons](../icon) can use either \`iconStart\` or \`iconEnd\` props and must have an \`aria-label\` provided.
+  description: `Buttons that contain only [Icons](/components/icon) can use either \`iconStart\` or \`iconEnd\` props and must have an \`aria-label\` provided.
 
 Use icon-only Buttons sparingly. The meaning of the Button can be diluted without a visual label.`,
   scope: { Button, IconCloud, DemoLayout },

--- a/src/website/app/demos/Button/examples/icons.js
+++ b/src/website/app/demos/Button/examples/icons.js
@@ -6,7 +6,7 @@ import DemoLayout from '../components/DemoLayout';
 export default {
   id: 'icons',
   title: 'Buttons with Icons',
-  description: `Buttons can contain [Icons](../icon) at their start, end, or both.
+  description: `Buttons can contain [Icons](/components/icon) at their start, end, or both.
 
 \`small\` Buttons use small Icons; \`medium\` and \`large\` Buttons use medium Icons; \`jumbo\` Buttons use large Icons.`,
   scope: { Button, IconCloud, DemoLayout },

--- a/src/website/app/demos/Button/examples/rtl.js
+++ b/src/website/app/demos/Button/examples/rtl.js
@@ -8,7 +8,7 @@ export default {
   title: 'Bidirectionality',
   description: `Buttons support right-to-left (RTL) languages.
 Buttons with Icons are reversed when the \`direction\` theme variable is set to \`rtl\`.
-A subset of Icons that [convey directionality](../icon/#rtl) will be reversed.`,
+A subset of Icons that [convey directionality](/components/icon#rtl) will be reversed.`,
   scope: { Button, IconBackspace, ThemeProvider },
   source: `
     <div dir="rtl">

--- a/src/website/app/demos/Card/bestPractices.js
+++ b/src/website/app/demos/Card/bestPractices.js
@@ -53,7 +53,7 @@ representing one data object.`,
     {
       type: 'do',
       backgroundColor,
-      description: `Use the [CardTitle](../card-title) component to add titles
+      description: `Use the [CardTitle](/components/card-title) component to add titles
 to your Cards. Your Card titles and subtitles should use "Title Case".`,
       example: (
         <Card>
@@ -67,7 +67,7 @@ to your Cards. Your Card titles and subtitles should use "Title Case".`,
       backgroundColor,
       description: `Don't use custom heading elements. Regular \`<h1>\`,
 \`<h2>\`, etc. will not be formatted automatically. Use a
-[CardTitle](../card-title) instead.`,
+[CardTitle](/components/card-title) instead.`,
       example: (
         <Card>
           <h1>Heading Element</h1>
@@ -78,7 +78,7 @@ to your Cards. Your Card titles and subtitles should use "Title Case".`,
     {
       type: 'dont',
       backgroundColor,
-      description: `Don't forget to use a [CardBlock](../card-block). Content
+      description: `Don't forget to use a [CardBlock](/components/card-block). Content
 placed into a Card outside the CardBlock will not have formatting or spacing
 applied.`,
       example: (
@@ -97,7 +97,7 @@ applied.`,
       type: 'dont',
       backgroundColor,
       description: `Don't use regular \`<img />\` tags directly inside a Card,
-which will result in unformatted content. Use [CardImage](../card-image)
+which will result in unformatted content. Use [CardImage](/components/card-image)
 instead.`,
       example: (
         <Card>
@@ -149,7 +149,7 @@ single pieces of information is a more efficent design.`,
       type: 'dont',
       backgroundColor,
       description: `Don't use CardActions with a single, obvious action. Use
-[Card's \`onClick\` prop](../card/#clickable) instead.`,
+[Card's \`onClick\` prop](/components/card#clickable) instead.`,
       example: (
         <Card>
           <CardTitle>Card Title</CardTitle>
@@ -164,7 +164,7 @@ single pieces of information is a more efficent design.`,
       type: 'dont',
       backgroundColor,
       description: `Don't place too many actions in CardActions. If you must
-have more than 2–3 actions, use [icon-only Buttons](../button/#icon-only).`,
+have more than 2–3 actions, use [icon-only Buttons](/components/button#icon-only).`,
       example: (
         <Card>
           <CardTitle>Card Title</CardTitle>
@@ -181,7 +181,7 @@ have more than 2–3 actions, use [icon-only Buttons](../button/#icon-only).`,
     {
       type: 'dont',
       backgroundColor,
-      description: `Don't mix [Buttons](../button) and [Links](../link) in
+      description: `Don't mix [Buttons](/components/button) and [Links](/components/link) in
 CardActions. Doing so is confusing for the user.`,
       example: (
         <Card>
@@ -199,7 +199,7 @@ CardActions. Doing so is confusing for the user.`,
     {
       type: 'dont',
       backgroundColor,
-      description: `Don't use CardBlock outside of [Card](../card), for which it
+      description: `Don't use CardBlock outside of [Card](/components/card), for which it
 was designed.`,
       example: <CardBlock>{loremIpsum}</CardBlock>
     }
@@ -208,7 +208,7 @@ was designed.`,
     {
       type: 'dont',
       backgroundColor,
-      description: `Don't use CardDivider to separate [CardTitle](../card-title)
+      description: `Don't use CardDivider to separate [CardTitle](/components/card-title)
 from other content.`,
       example: (
         <Card>
@@ -222,7 +222,7 @@ from other content.`,
       type: 'dont',
       backgroundColor,
       description: `Don't use CardDivider between every section of
-[Card](../card) content, which makes the Card unnecessarily busy. Dividers are
+[Card](/components/card) content, which makes the Card unnecessarily busy. Dividers are
 best used when the Card contains complex content that would be hard to discern
 without the visual separation.`,
       example: (
@@ -373,7 +373,7 @@ if the \`secondaryText\` information is not brief, consider using the
       type: 'do',
       backgroundColor,
       description: `Use \`actions\` to provide non-primary actions for a Card.
-If you need to provide 2–3 primary actions, use [CardActions](../card-actions).`,
+If you need to provide 2–3 primary actions, use [CardActions](/components/card-actions).`,
       example: (
         <Card>
           <CardTitle actions={<CardTitleMenu data={actionMenuData} />}>
@@ -386,7 +386,7 @@ If you need to provide 2–3 primary actions, use [CardActions](../card-actions)
     {
       type: 'dont',
       backgroundColor,
-      description: `Don't use CardTitle outside of [Card](../card), for which it
+      description: `Don't use CardTitle outside of [Card](/components/card), for which it
 was designed.`,
       example: <CardTitle>Out of Place Title</CardTitle>
     }

--- a/src/website/app/demos/Card/examples/Card/arbitraryChildren.js
+++ b/src/website/app/demos/Card/examples/Card/arbitraryChildren.js
@@ -30,7 +30,7 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `A Card will render any children.
 
-For best results, please ensure content matches the top/bottom margin and left/right padding of the other \`<Card*/>\` components, or use [CardBlock](../card-block).`,
+For best results, please ensure content matches the top/bottom margin and left/right padding of the other \`<Card*/>\` components, or use [CardBlock](/components/card-block).`,
   scope: { Button, Card, CardTitle, customContent, DemoLayout },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Card/examples/Card/card.js
+++ b/src/website/app/demos/Card/examples/Card/card.js
@@ -13,9 +13,9 @@ export default {
   description: `Card content should be neither too simple nor too complex. Cards
 are used as a gateway to more detailed content, not merely as a widget container.
 Cards can contain any children, but are best used with
-[CardActions](../card-actions), [CardBlock](../card-block),
-[CardDivider](../card-divider), [CardFooter](../card-footer),
-[CardImage](../card-image), and [CardTitle](../card-title).`,
+[CardActions](/components/card-actions), [CardBlock](/components/card-block),
+[CardDivider](/components/card-divider), [CardFooter](/components/card-footer),
+[CardImage](/components/card-image), and [CardTitle](/components/card-title).`,
   scope: {
     Button,
     Card,

--- a/src/website/app/demos/Card/examples/Card/clickable.js
+++ b/src/website/app/demos/Card/examples/Card/clickable.js
@@ -11,7 +11,7 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `If an \`onClick\` callback is provided, the entire Card becomes clickable and keyboard actionable.
 Use this feature when only one action can be taken per Card.
-This simplifies the interface by not requiring an extra [Button](../button).`,
+This simplifies the interface by not requiring an extra [Button](/components/button).`,
   scope: { Card, CardBlock, CardTitle, loremIpsum, DemoLayout },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Card/examples/Card/orderOfSections.js
+++ b/src/website/app/demos/Card/examples/Card/orderOfSections.js
@@ -25,7 +25,7 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `There is no "one true way" to lay out children in Card; it is
 flexible enough to accept different component arrangements. The one exception is
-[CardFooter](../card-footer), which must be last in Card.`,
+[CardFooter](/components/card-footer), which must be last in Card.`,
   scope: {
     Button,
     Card,

--- a/src/website/app/demos/Card/examples/CardActions/cardActions.js
+++ b/src/website/app/demos/Card/examples/CardActions/cardActions.js
@@ -11,8 +11,8 @@ export default {
   title: 'Basic Usage',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `Use CardActions to add actions, [Buttons](../button) or
-[Links](../link), to your [Card](../card). Buttons will automatically size
+  description: `Use CardActions to add actions, [Buttons](/components/button) or
+[Links](/components/link), to your [Card](/components/card). Buttons will automatically size
 themselves appropriately, and can be any variety (primary, minimal, icon-only,
 etc.)`,
   scope: {

--- a/src/website/app/demos/Card/examples/CardActions/withLinks.js
+++ b/src/website/app/demos/Card/examples/CardActions/withLinks.js
@@ -13,7 +13,7 @@ export default {
   title: 'With Links',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `Place [Links](../links) in CardActions when your Card needs to
+  description: `Place [Links](/components/links) in CardActions when your Card needs to
 point the users to another location.`,
   scope: { Link, Card, CardActions, CardBlock, loremIpsum, DemoLayout },
   source: `

--- a/src/website/app/demos/Card/examples/CardDivider/cardDivider.js
+++ b/src/website/app/demos/Card/examples/CardDivider/cardDivider.js
@@ -13,7 +13,7 @@ export default {
   title: 'Basic Usage',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `Use CardDivider to separate sections of your [Card](../card).`,
+  description: `Use CardDivider to separate sections of your [Card](/components/card).`,
   scope: { Card, CardBlock, CardDivider, CardTitle, loremIpsum, DemoLayout },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Card/examples/CardFooter/cardFooter.js
+++ b/src/website/app/demos/Card/examples/CardFooter/cardFooter.js
@@ -15,8 +15,8 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardFooter is used to add an extension to a Card. It can
-contain any children, but is best used with [CardActions](../card-actions) and
-[CardBlock](../card-block).`,
+contain any children, but is best used with [CardActions](/components/card-actions) and
+[CardBlock](/components/card-block).`,
   scope: {
     Button,
     Card,

--- a/src/website/app/demos/Card/examples/CardStatus/cardStatus.js
+++ b/src/website/app/demos/Card/examples/CardStatus/cardStatus.js
@@ -9,7 +9,7 @@ export default {
   title: 'Basic Usage',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `CardStatus conveys the current status of [Card](../card). It is
+  description: `CardStatus conveys the current status of [Card](/components/card). It is
 available in a few variants.`,
   scope: { Card, CardBlock, CardStatus, CardTitle, loremIpsum, DemoLayout },
   source: `

--- a/src/website/app/demos/Card/examples/CardTitle/actionsMenu.js
+++ b/src/website/app/demos/Card/examples/CardTitle/actionsMenu.js
@@ -14,7 +14,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `To display a menu of actions in CardTitle, pass a CardTitleMenu
-or [Dropdown](../dropdown) to the \`actions\` prop.
+or [Dropdown](/components/dropdown) to the \`actions\` prop.
 
 <Callout title="Note">
   To help with styling and using the correct <a href="../icon" key="0">Icon</a>,

--- a/src/website/app/demos/Card/examples/CardTitle/avatar.js
+++ b/src/website/app/demos/Card/examples/CardTitle/avatar.js
@@ -11,7 +11,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `To help communicate ownership or categorization of a Card, add
-an \`avatar\` to CardTitle. The [Avatar](../avatar) will automatically size
+an \`avatar\` to CardTitle. The [Avatar](/components/avatar) will automatically size
 itself correctly whether a \`subtitle\` is also provided or not.`,
   scope: { Avatar, Card, CardBlock, CardTitle, loremIpsum, DemoLayout },
   source: `

--- a/src/website/app/demos/Card/index.js
+++ b/src/website/app/demos/Card/index.js
@@ -60,11 +60,11 @@ actions, which may or may not be the same for each Card in the set.`
     slug: 'card-block',
     title: 'CardBlock',
     whenHowToUse: `CardBlock is used to help lay out content that's not a
-[title](../card-title) or an [image](../card-image) in the body of the
-[Card](../card).
+[title](/components/card-title) or an [image](/components/card-image) in the body of the
+[Card](/components/card).
 
 Try not to put inline links in your content. Create purposeful calls to action
-with [Buttons](../button) using [CardActions](../card-actions).`
+with [Buttons](/components/button) using [CardActions](/components/card-actions).`
   },
   {
     bestPractices: bestPractices.cardDivider,
@@ -74,7 +74,7 @@ with [Buttons](../button) using [CardActions](../card-actions).`
     slug: 'card-divider',
     title: 'CardDivider',
     whenHowToUse: `CardDivider is used to provide visual separation between
-sections of a [Card](../card) with complex content. It should be used sparingly.`
+sections of a [Card](/components/card) with complex content. It should be used sparingly.`
   },
   {
     bestPractices: bestPractices.cardFooter,
@@ -84,7 +84,7 @@ sections of a [Card](../card) with complex content. It should be used sparingly.
     slug: 'card-footer',
     title: 'CardFooter',
     whenHowToUse: `Use CardFooter to add a visually differentiated section to
-your [Card](../card). It is best used for stateful information or functionality,
+your [Card](/components/card). It is best used for stateful information or functionality,
 particularly when paired with a [\`variant\`](#variants). CardFooter must always
 be the last thing in a Card.`
   },
@@ -95,7 +95,7 @@ be the last thing in a Card.`
     slug: 'card-image',
     title: 'CardImage',
     whenHowToUse: `CardImage is used when you want to reinforce the intent of the Card.
-Images shouldn't be used alone in a Card, but should be paired with a call to action and/or a [CardTitle](../card-title).
+Images shouldn't be used alone in a Card, but should be paired with a call to action and/or a [CardTitle](/components/card-title).
 
 If you are putting text over top of the CardImage, use a solid color or an image with sufficient contrast to the text.`
   },
@@ -107,7 +107,7 @@ If you are putting text over top of the CardImage, use a solid color or an image
     slug: 'card-status',
     title: 'CardStatus',
     whenHowToUse: `CardStatus is used to display a Card's current status. If
-the status information is not likely to change, use [CardTitle's](../card-title)
+the status information is not likely to change, use [CardTitle's](/components/card-title)
 \`secondaryText\` or \`subtitle\` prop, instead.`
   },
   {
@@ -117,7 +117,7 @@ the status information is not likely to change, use [CardTitle's](../card-title)
     examples: cardTitleExamples,
     slug: 'card-title',
     title: 'CardTitle',
-    whenHowToUse: `Use a CardTitle when you need a consistently styled headings for your [Card](../card).
+    whenHowToUse: `Use a CardTitle when you need a consistently styled headings for your [Card](/components/card).
 Use a subtitle to provide supporting information for the data displayed in the Card.`
   }
 ];

--- a/src/website/app/demos/Checkbox/bestPractices.js
+++ b/src/website/app/demos/Checkbox/bestPractices.js
@@ -73,7 +73,7 @@ is a single sentence, word, or fragment.`,
     {
       type: 'dont',
       description: `Don't use when the user should only select a single option.
-Use a [Radio](../radio) instead.`,
+Use a [Radio](/components/radio) instead.`,
       example: (
         <DemoForm>
           <FormField

--- a/src/website/app/demos/Checkbox/examples/CheckboxGroup/formField.js
+++ b/src/website/app/demos/Checkbox/examples/CheckboxGroup/formField.js
@@ -6,7 +6,7 @@ import DemoForm from '../../components/DemoForm';
 export default {
   id: 'form-field',
   title: 'FormField',
-  description: `Use a [FormField](../form-field) to provide an accessible label
+  description: `Use a [FormField](/components/form-field) to provide an accessible label
 and other features as well as a more streamlined API.
 
 _Note: The \`invalid\` and \`required\` props are not automatically forwarded

--- a/src/website/app/demos/Checkbox/index.js
+++ b/src/website/app/demos/Checkbox/index.js
@@ -26,7 +26,7 @@ export default [
     title: 'Checkbox',
     whenHowToUse: `Use Checkboxes to change settings rather than initiate actions.
 
-Checkboxes are often created in [groups](../checkbox-group).    `
+Checkboxes are often created in [groups](/components/checkbox-group).    `
   },
   {
     bestPractices: bestPractices.checkboxGroup,
@@ -43,12 +43,12 @@ Checkboxes are often created in [groups](../checkbox-group).    `
     slug: 'checkbox-group',
     title: 'CheckboxGroup',
     whenHowToUse: `CheckboxGroup is used to provide a simpler API for creating a
-group of [Checkboxes](../checkbox).  It also provides proper row spacing and an
+group of [Checkboxes](/components/checkbox).  It also provides proper row spacing and an
 inline layout option.
 
 Use CheckboxGroup to allow users to select multiple options from a list.
 
-CheckboxGroups should be wrapped in a [FormField](../form-field) to provide an
+CheckboxGroups should be wrapped in a [FormField](/components/form-field) to provide an
 accessible label and other features.  See the [FormField example](#form-field)
 for details.`
   }

--- a/src/website/app/demos/Dropdown/bestPractices.js
+++ b/src/website/app/demos/Dropdown/bestPractices.js
@@ -50,7 +50,7 @@ special case.`,
     type: 'dont',
     description: `Don't use Dropdown for navigation, even on mobile devices.
 Either reduce the amount of navigation in your application, or consider building
-a drawer with the [Menu](../menu).`,
+a drawer with the [Menu](/components/menu).`,
     example: (
       <Dropdown data={navData}>
         <Button iconStart={<IconMenu />} />

--- a/src/website/app/demos/Dropdown/examples/data.js
+++ b/src/website/app/demos/Dropdown/examples/data.js
@@ -9,11 +9,11 @@ export default {
   title: 'Data-Driven',
   description: `Dropdown content is defined by an array of data, with the
 structure shown in the code example below. Object properties will be passed on
-to the [MenuItem](../menu-item).
+to the [MenuItem](/components/menu-item).
 
-[MenuDividers](../menu-divider) are created simply by passing
+[MenuDividers](/components/menu-divider) are created simply by passing
 \`{divider: true}\` as an item. Menu data can also be
-[grouped](../menu/grouped-data).`,
+[grouped](/components/menu#grouped-data).`,
   scope: { Button, CustomRender, Dropdown, IconCloud },
   source: `
     () => {

--- a/src/website/app/demos/Flex/bestPractices.js
+++ b/src/website/app/demos/Flex/bestPractices.js
@@ -9,7 +9,7 @@ export default {
   flex: [
     {
       type: 'do',
-      description: `Use Flex and [FlexItem](../flex-item) to arrange components
+      description: `Use Flex and [FlexItem](/components/flex-item) to arrange components
 next to one another, with a consistent gutter.`,
       example: (
         <Flex justifyContent="end">
@@ -28,7 +28,7 @@ next to one another, with a consistent gutter.`,
     {
       type: 'dont',
       description: `Don't use Flex to align content to the left & right.
-[StartEnd](../start-end) is a more appropriate choice.`,
+[StartEnd](/components/start-end) is a more appropriate choice.`,
       example: (
         <Flex justifyContent="between">
           <FlexItem>
@@ -67,7 +67,7 @@ next to one another, with a consistent gutter.`,
   flexItem: [
     {
       type: 'do',
-      description: `Use FlexItem within [Flex](../flex) to align components
+      description: `Use FlexItem within [Flex](/components/flex) to align components
 relative to one another.`,
       example: (
         <Flex justifyContent="end">

--- a/src/website/app/demos/Flex/examples/Flex/boxProps.js
+++ b/src/website/app/demos/Flex/examples/Flex/boxProps.js
@@ -6,8 +6,8 @@ import Flex from '../../components/Flex';
 export default {
   id: 'box-props',
   title: 'Box Props',
-  description: `Because Flex styles the [Box](../box) component, it accepts any
-of [Box's props](../box/#props).`,
+  description: `Because Flex styles the [Box](/components/box) component, it accepts any
+of [Box's props](/components/box#props).`,
   scope: { Box, Flex, FlexItem },
   source: `
     <div>

--- a/src/website/app/demos/Flex/examples/Flex/flex.js
+++ b/src/website/app/demos/Flex/examples/Flex/flex.js
@@ -5,7 +5,7 @@ import Flex from '../../components/Flex';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  description: `Use Flex and [FlexItem](../flex-item) to lay out components 
+  description: `Use Flex and [FlexItem](/components/flex-item) to lay out components 
 throughout your app. They can be arranged side-by-side, stacked on top of one
 another, centered both horizontally and vertically, and lots more as
 illustrated in the further examples below.`,

--- a/src/website/app/demos/Flex/examples/FlexItem/alignSelf.js
+++ b/src/website/app/demos/Flex/examples/FlexItem/alignSelf.js
@@ -11,7 +11,7 @@ const Flex = createStyledComponent(_Flex, ({ direction }) => ({
 export default {
   id: 'align-self',
   title: 'Align Self',
-  description: `[Flex's](../flex) [\`alignItems\`](../flex/#align-items) prop
+  description: `[Flex's](/components/flex) [\`alignItems\`](/components/flex#align-items) prop
 will align its items along the cross axis. The \`alignSelf\` prop allows an
 override of that value for specific items.`,
   scope: { DemoLayout, Flex, FlexItem },

--- a/src/website/app/demos/Flex/examples/FlexItem/boxProps.js
+++ b/src/website/app/demos/Flex/examples/FlexItem/boxProps.js
@@ -5,8 +5,8 @@ import Flex from '../../components/Flex';
 export default {
   id: 'box-props',
   title: 'Box Props',
-  description: `Because FlexItem styles the [Box](../box) component, it accepts
-any of [Box's props](../box/#props).`,
+  description: `Because FlexItem styles the [Box](/components/box) component, it accepts
+any of [Box's props](/components/box#props).`,
   scope: { Flex, FlexItem },
   source: `
     <Flex>

--- a/src/website/app/demos/Flex/examples/FlexItem/flexItem.js
+++ b/src/website/app/demos/Flex/examples/FlexItem/flexItem.js
@@ -5,7 +5,7 @@ import Flex from '../../components/Flex';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  description: `Use [Flex](../flex) and FlexItem to lay out components
+  description: `Use [Flex](/components/flex) and FlexItem to lay out components
 throughout your app. They can be arranged side-by-side, stacked on top of one
 another, sized proportionally, and lots more as illustrated in the further
 examples below.`,

--- a/src/website/app/demos/Flex/index.js
+++ b/src/website/app/demos/Flex/index.js
@@ -28,7 +28,7 @@ export default [
     ),
     slug: 'flex',
     title: 'Flex',
-    whenHowToUse: `Flex, together with [FlexItem](../flex-item), provides an
+    whenHowToUse: `Flex, together with [FlexItem](/components/flex-item), provides an
 easy way to align components next to or on top of one another. With configurable
 gutters, many alignment options, and optionally responsive properties, it is
 powerful and flexible enough to be the foundation of your app's layout.`
@@ -52,7 +52,7 @@ powerful and flexible enough to be the foundation of your app's layout.`
     ),
     slug: 'flex-item',
     title: 'FlexItem',
-    whenHowToUse: `FlexItem, together with [Flex](../flex), provides an easy
+    whenHowToUse: `FlexItem, together with [Flex](/components/flex), provides an easy
 way to align components next to or on top of one another. With many alignment
 options and optionally responsive properties, it is powerful and flexible enough
 to be the foundation of your app's layout.`

--- a/src/website/app/demos/Form/bestPractices.js
+++ b/src/website/app/demos/Form/bestPractices.js
@@ -38,7 +38,7 @@ export default {
     },
     {
       type: 'do',
-      description: `Use the [appropriate variant](/color/#guidelines-variants)
+      description: `Use the [appropriate variant](/color#guidelines-variants)
 to match your intent.`,
       example: (
         <FormField input={TextInput} label="Promo Code" variant="success" />
@@ -111,7 +111,7 @@ accessible manner when the design requires it.`,
       type: 'do',
       description: `Wrap multiple, related inputs in a FormFieldset and provide
 a brief, descriptive \`legend\`. Note that the labels for the individual fields
-are provided, but [hidden](../form-field/#hide-label) to reduce noise.`,
+are provided, but [hidden](/components/form-field#hide-label) to reduce noise.`,
       example: (
         <FormFieldset legend="Address">
           <DemoLayout>
@@ -153,7 +153,7 @@ are provided, but [hidden](../form-field/#hide-label) to reduce noise.`,
   formFieldDivider: [
     {
       type: 'dont',
-      description: `Don't separate every [FormField](../form-field) with a
+      description: `Don't separate every [FormField](/components/form-field) with a
 FormFieldDivider.`,
       example: (
         <DemoLayout>

--- a/src/website/app/demos/Form/examples/FormFieldDivider/basic.js
+++ b/src/website/app/demos/Form/examples/FormFieldDivider/basic.js
@@ -7,8 +7,8 @@ export default {
   id: 'basic',
   title: 'Basic Usage',
   description: `Use a FormFieldDivider to create implicit groups of
-[FormFields](../form-field). For more semantic grouping, use a
-[FormFieldset](../form-fieldset).`,
+[FormFields](/components/form-field). For more semantic grouping, use a
+[FormFieldset](/components/form-fieldset).`,
   scope: { DemoLayout, FormField, FormFieldDivider, TextInput },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Form/examples/FormFieldset/basic.js
+++ b/src/website/app/demos/Form/examples/FormFieldset/basic.js
@@ -6,7 +6,7 @@ import { FormField, FormFieldset } from '../../../../../../Form';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  description: `Wrap any number of [FormFields](../form-field) in a FormFieldset
+  description: `Wrap any number of [FormFields](/components/form-field) in a FormFieldset
 to semantically group them. A brief, descriptive legend is especially useful for
 users of Assistive Technology (AT), such as a screen reader.`,
   scope: { DemoLayout, FormField, FormFieldset, TextInput },

--- a/src/website/app/demos/Form/index.js
+++ b/src/website/app/demos/Form/index.js
@@ -50,7 +50,7 @@ Error text should be short and concise, telling the user how to fix the problem.
     slug: 'form-fieldset',
     title: 'FormFieldset',
     whenHowToUse: `Wrap groups of related inputs (which themselves should be wrapped
-in [FormFields](../form-field)) in a FormFieldset with a useful legend.
+in [FormFields](/components/form-field)) in a FormFieldset with a useful legend.
 
 Consider using FormFieldset instead of a heading element to improve accessibility.`
   },

--- a/src/website/app/demos/Icon/index.js
+++ b/src/website/app/demos/Icon/index.js
@@ -17,7 +17,7 @@ Use icons in combination with labels to help users more quickly process your UI.
 
 Don't use too many icons or you run the risk of creating visual clutter.
 
-Icons are usually used inside of a [Button](../button) to reinforce the action.
+Icons are usually used inside of a [Button](/components/button) to reinforce the action.
 If used alone, Icon placement should be very clear. For example, a play icon ► could be used instead of writing out the word "Play".
 
 Icons should only be used if they aid communication, not merely for decoration.`

--- a/src/website/app/demos/Link/bestPractices.js
+++ b/src/website/app/demos/Link/bestPractices.js
@@ -38,7 +38,7 @@ export default [
   {
     type: 'dont',
     description: `Don't use a Link to perform a page action. To represent an
-action, use a [Button](../button).`,
+action, use a [Button](/components/button).`,
     example: <Link>Scroll to bottom</Link>
   }
 ];

--- a/src/website/app/demos/Link/examples/button.js
+++ b/src/website/app/demos/Link/examples/button.js
@@ -5,7 +5,7 @@ export default {
   id: 'button',
   title: 'Button',
   description:
-    'Use the [Button](/components/button/#link) component to create a link with Button styling.',
+    'Use the [Button](/components/button#link) component to create a link with Button styling.',
   scope: { Button },
   source: `<Button element="a" href="#button">Link</Button>`
 };

--- a/src/website/app/demos/Menu/bestPractices.js
+++ b/src/website/app/demos/Menu/bestPractices.js
@@ -184,7 +184,7 @@ overwhelming to users and your feature will get buried.`,
     {
       type: 'do',
       backgroundColor,
-      description: `Use the [appropriate variant](/color/#guidelines-variants)
+      description: `Use the [appropriate variant](/color#guidelines-variants)
 to give your users hints about what the potential outcome of an action will be.`,
       example: (
         <DemoLayout>
@@ -214,7 +214,7 @@ to give your users hints about what the potential outcome of an action will be.`
     {
       type: 'do',
       backgroundColor,
-      description: `Clearly label [MenuItem](../menu-item) actions to be
+      description: `Clearly label [MenuItem](/components/menu-item) actions to be
 predictable for frictionless interaction. Labels should be structured:
 \`<verb> <noun>\`.`,
       example: (
@@ -278,7 +278,7 @@ it probably belongs somewhere else.`,
       type: 'dont',
       backgroundColor,
       description: `Don't use disabled MenuItems as section titles. Instead, use
-the \`title\` prop of a [MenuGroup](../menu-group) to show meta information for
+the \`title\` prop of a [MenuGroup](/components/menu-group) to show meta information for
 a group, or place this information elsewhere in the interface.`,
       example: (
         <DemoLayout>

--- a/src/website/app/demos/Menu/examples/Menu/flatData.js
+++ b/src/website/app/demos/Menu/examples/Menu/flatData.js
@@ -12,9 +12,9 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `Menu content can also be defined by an array of data, with the
 structure shown in the code example below. Object properties will be passed on
-to the [MenuItem](../menu-item).
+to the [MenuItem](/components/menu-item).
 
-[MenuDividers](../menu-divider) are created simply by passing
+[MenuDividers](/components/menu-divider) are created simply by passing
 \`{divider: true}\` as an item.`,
   scope: { CustomRender, DemoLayout, IconCloud, Menu },
   source: `

--- a/src/website/app/demos/Menu/examples/Menu/groupedData.js
+++ b/src/website/app/demos/Menu/examples/Menu/groupedData.js
@@ -12,9 +12,9 @@ export default {
   backgroundColor: mineralTheme.color_gray_10,
   description: `Menu items can be grouped by using the structure shown in the
 code example below. Object properties in the \`items\` array(s) will be passed
-on to the [MenuItem](../menu-item).
+on to the [MenuItem](/components/menu-item).
 
-A new [MenuGroup](../menu-group) will be created for each array object that has
+A new [MenuGroup](/components/menu-group) will be created for each array object that has
 an \`items\` property defined.`,
   scope: { CustomRender, DemoLayout, IconCloud, Menu },
   source: `

--- a/src/website/app/demos/Menu/examples/Menu/menu.js
+++ b/src/website/app/demos/Menu/examples/Menu/menu.js
@@ -9,7 +9,7 @@ export default {
   title: 'Basic Usage',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `Menus are composed of [MenuDivider](../menu-divider), [MenuGroup](../menu-group), and [MenuItem](../menu-item).
+  description: `Menus are composed of [MenuDivider](/components/menu-divider), [MenuGroup](/components/menu-group), and [MenuItem](/components/menu-item).
 Menus display a list of actions or navigation options.
 
 <Callout title="Note">

--- a/src/website/app/demos/Menu/examples/MenuDivider/menuDivider.js
+++ b/src/website/app/demos/Menu/examples/MenuDivider/menuDivider.js
@@ -8,7 +8,7 @@ export default {
   title: 'Separating MenuItems',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `[MenuItems](../menu-item) and [MenuGroups](../menu-group) can be separated with a MenuDivider.
+  description: `[MenuItems](/components/menu-item) and [MenuGroups](/components/menu-group) can be separated with a MenuDivider.
 MenuDividers are used to create hierarchy by setting some options apart from others.`,
   scope: { DemoLayout, Menu, MenuDivider, MenuGroup, MenuItem },
   source: `

--- a/src/website/app/demos/Menu/examples/MenuGroup/menuGroup.js
+++ b/src/website/app/demos/Menu/examples/MenuGroup/menuGroup.js
@@ -8,11 +8,11 @@ export default {
   title: 'Grouping MenuItems',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `To group [MenuItems](../menu-item) together, wrap them in a MenuGroup.
+  description: `To group [MenuItems](/components/menu-item) together, wrap them in a MenuGroup.
 Optionally, provide a title to provide context if the grouping is large or not immediately obvious.
 
-Your [Menu](../menu) may not need a MenuGroup title.
-If your Menu is simple, instead consider using a [MenuDivider](../menu-divider), which is quicker to scan for your users.`,
+Your [Menu](/components/menu) may not need a MenuGroup title.
+If your Menu is simple, instead consider using a [MenuDivider](/components/menu-divider), which is quicker to scan for your users.`,
   scope: { DemoLayout, Menu, MenuGroup, MenuItem },
   source: `
     <DemoLayout>

--- a/src/website/app/demos/Menu/examples/MenuItem/customRender.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/customRender.js
@@ -20,7 +20,7 @@ help match the other MenuItems, you have access to its
 might be a helpful template. Some things to keep in mind:
 
 1. Remember to include \`:focus\`, \`:hover\`, and \`:active\` styles.
-  - If this is to be used for a [Dropdown](../dropdown), also apply your
+  - If this is to be used for a [Dropdown](/components/dropdown), also apply your
      focus/hover styles when \`props.isHighlighted === true\`.
 1. Remember to accommodate the disabled state (\`props.disabled === true\`).
 1. If your app supports RTL languages, you can use \`theme.direction\` to

--- a/src/website/app/demos/Menu/examples/MenuItem/icons.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/icons.js
@@ -9,7 +9,7 @@ export default {
   title: 'Menu Items with Icons',
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
-  description: `A MenuItem can display an [Icon](../icon) at its start, end, or both.
+  description: `A MenuItem can display an [Icon](/components/icon) at its start, end, or both.
 If both \`startIcon\` and \`variant\` props are provided, \`startIcon\` will be used.`,
   scope: { DemoLayout, IconCloud, Menu, MenuItem },
   source: `

--- a/src/website/app/demos/Menu/examples/MenuItem/rtl.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/rtl.js
@@ -10,7 +10,7 @@ export default {
   // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `MenuItems with Icons are reversed when the \`direction\` theme variable is set to \`rtl\` (right-to-left).
-A subset of Icons that [convey directionality](../icon/#rtl) will be reversed.`,
+A subset of Icons that [convey directionality](/components/icon#rtl) will be reversed.`,
   scope: { DemoLayout, IconHelp, Menu, MenuItem, ThemeProvider },
   source: `
     <DemoLayout dir="rtl">

--- a/src/website/app/demos/Menu/index.js
+++ b/src/website/app/demos/Menu/index.js
@@ -35,7 +35,7 @@ Labels should have clear messaging in the form of \`<verb> <noun>\`, if possible
     examples: menuDividerExamples,
     slug: 'menu-divider',
     title: 'MenuDivider',
-    whenHowToUse: `MenuDividers are used to visually separate [MenuGroups](../menu-group) or individual [MenuItems](../menu-item) to establish hierarchy in your Menu.
+    whenHowToUse: `MenuDividers are used to visually separate [MenuGroups](/components/menu-group) or individual [MenuItems](/components/menu-item) to establish hierarchy in your Menu.
 They could be used to separate items in a long list if all elements exist on the same conceptual level.
 For example, if your Menu is composed of a long list of songs, a MenuDivider could be placed between songs that start with A, B, C, etc.
 
@@ -51,7 +51,7 @@ Do not use MenuDividers to simply separate options as a decoration, or to provid
     whenHowToUse: `MenuGroups are used to group conceptually related elements, and to hint at other available, related options.
 If the intention of the grouping is not immediately obvious, add a section title via the \`title\` prop to aid in your users' decision-making process.
 
-If there are only a few elements in a couple of groups, and the grouping logic is obvious, consider using a [MenuDivider](../menu-divider) instead.`
+If there are only a few elements in a couple of groups, and the grouping logic is obvious, consider using a [MenuDivider](/components/menu-divider) instead.`
   },
   {
     bestPractices: bestPractices.menuItem,
@@ -61,7 +61,7 @@ If there are only a few elements in a couple of groups, and the grouping logic i
     slug: 'menu-item',
     title: 'MenuItem',
     whenHowToUse: `Use MenuItems to present the user with a choice of actions, and don't use MenuItems to display content that is not actionable.
-For example, don't create a [Menu](../menu) with several options where the last item is an un-clickable status message showing the number of available servers.
+For example, don't create a [Menu](/components/menu) with several options where the last item is an un-clickable status message showing the number of available servers.
 This information is not _actionable_ and perhaps belongs somewhere else in your interface.
 
 Use the secondary text to give hints about extra functionality or provide status.`

--- a/src/website/app/demos/Radio/bestPractices.js
+++ b/src/website/app/demos/Radio/bestPractices.js
@@ -105,7 +105,7 @@ a neutral option.`,
     {
       type: 'dont',
       description: `Don't use when the user should be able to select multiple
-options. Use a [Checkbox](../checkbox) instead.`,
+options. Use a [Checkbox](/components/checkbox) instead.`,
       example: (
         <DemoForm>
           <FormField

--- a/src/website/app/demos/Radio/examples/RadioGroup/formField.js
+++ b/src/website/app/demos/Radio/examples/RadioGroup/formField.js
@@ -6,7 +6,7 @@ import DemoForm from '../../components/DemoForm';
 export default {
   id: 'form-field',
   title: 'FormField',
-  description: `Use a [FormField](../form-field) to provide an accessible label
+  description: `Use a [FormField](/components/form-field) to provide an accessible label
 and other features as well as a more streamlined API.`,
   scope: { DemoForm, FormField, RadioGroup },
   source: `

--- a/src/website/app/demos/Radio/index.js
+++ b/src/website/app/demos/Radio/index.js
@@ -26,7 +26,7 @@ export default [
     title: 'Radio',
     whenHowToUse: `Use Radios to change settings rather than initiate actions.
 
-Radios are usually created in [groups](../radio-group) or two or more.`
+Radios are usually created in [groups](/components/radio-group) or two or more.`
   },
   {
     bestPractices: bestPractices.radioGroup,
@@ -43,7 +43,7 @@ Radios are usually created in [groups](../radio-group) or two or more.`
     slug: 'radio-group',
     title: 'RadioGroup',
     whenHowToUse: `RadioGroup is used to provide a simpler API for creating a
-group of [Radios](../radio).  It also provides proper row spacing and an
+group of [Radios](/components/radio).  It also provides proper row spacing and an
 inline layout option.
 
 Use a RadioGroup to allow users to select a single option from a list.
@@ -62,7 +62,7 @@ users cannot return to once a selection is made.
 * Both of these case can generally be addressed by providing a neutral option.
 If this is insufficient, consider an alternate form control.
 
-RadioGroups should be wrapped in a [FormField](../form-field) to provide an
+RadioGroups should be wrapped in a [FormField](/components/form-field) to provide an
 accessible label and other features.  See the [FormField example](#form-field)
 for details.`
   }

--- a/src/website/app/demos/Select/bestPractices.js
+++ b/src/website/app/demos/Select/bestPractices.js
@@ -19,7 +19,7 @@ export default [
     type: 'dont',
     description: `Don't rely on placeholder text alone to communicate purpose as
 it will disappear once a value is selected. You can easily add a label to Select
-using a [FormField](../FormField).`,
+using a [FormField](/components/form-field).`,
     example: (
       <Select data={foodData} placeholder="Choose your favorite food..." />
     )
@@ -74,7 +74,7 @@ text to prompt the user to make a choice.`,
     type: 'dont',
     description: `Don't use the \`onSelect\` or \`onChange\` handlers to
 initiate actions when an option is selected. Users often change their choices
-multiple times when interacting with Select. Offer a "submit" [Button](../button)
+multiple times when interacting with Select. Offer a "submit" [Button](/components/button)
 at the end of the form instead.`,
     example: (
       <div>

--- a/src/website/app/demos/Select/examples/data.js
+++ b/src/website/app/demos/Select/examples/data.js
@@ -9,11 +9,11 @@ export default {
   title: 'Data-Driven',
   description: `Select options are defined by an array of data, with the
 structure shown in the code example below. Object properties will be passed on
-to the [MenuItem](../menu-item).
+to the [MenuItem](/components/menu-item).
 
-[MenuDividers](../menu-divider) are created simply by passing
+[MenuDividers](/components/menu-divider) are created simply by passing
 \`{divider: true}\` as an item. Menu data can also be
-[grouped](../menu/grouped-data).`,
+[grouped](/components/menu#grouped-data).`,
   scope: { Button, CustomRender, Select, IconCloud },
   source: `
     () => {

--- a/src/website/app/demos/Select/examples/formField.js
+++ b/src/website/app/demos/Select/examples/formField.js
@@ -7,7 +7,7 @@ import { statesData as data } from '../components/selectData';
 export default {
   id: 'form-field',
   title: 'FormField',
-  description: `Use a [FormField](../form-field) to provide an accessible label
+  description: `Use a [FormField](/components/form-field) to provide an accessible label
 and other features as well as a more streamlined API.`,
   scope: { data, DemoLayout, FormField, Select },
   source: `

--- a/src/website/app/demos/Select/examples/invalid.js
+++ b/src/website/app/demos/Select/examples/invalid.js
@@ -7,7 +7,7 @@ export default {
   title: 'Invalid',
   description: `The \`invalid\` prop on a Select does nothing visually on its
 own, but is important for accessibility. See FormField's
-[Validation](../form-field/#validation) example for more info.`,
+[Validation](/components/form-field#validation) example for more info.`,
   scope: { data, Select },
   source: `
     <Select data={data} invalid />

--- a/src/website/app/demos/Select/examples/required.js
+++ b/src/website/app/demos/Select/examples/required.js
@@ -7,7 +7,7 @@ export default {
   title: 'Required',
   description: `The \`required\` prop on a Select does nothing visually on
 its own, but is important for accessibility. See FormField's
-[Required](../form-field/#required) and [Validation](../form-field/#validation)
+[Required](/components/form-field#required) and [Validation](/components/form-field#validation)
 examples for more information.`,
   scope: { data, Select },
   source: `

--- a/src/website/app/demos/Select/examples/variants.js
+++ b/src/website/app/demos/Select/examples/variants.js
@@ -7,7 +7,7 @@ export default {
   id: 'variants',
   title: 'Variants',
   description: `is available in a few variants, mostly for use with
-[validation](../form-field/#validation). Be sure to use the
+[validation](/components/form-field#validation). Be sure to use the
 [appropriate variant](/color#guidelines-variants) for your intent.`,
   scope: { data, DemoLayout, Select },
   source: `

--- a/src/website/app/demos/Select/index.js
+++ b/src/website/app/demos/Select/index.js
@@ -12,7 +12,7 @@ export default {
   slug: 'select',
   title: 'Select',
   whenHowToUse: `Select boxes are best used in forms to allow users to choose
-from a set of 4 to 9 options, where using a [RadioGroup](../radio-group) would
+from a set of 4 to 9 options, where using a [RadioGroup](/components/radio-group) would
 take up too much space.
 
 Select can be used with more than 9 options when the entire set is well
@@ -20,9 +20,9 @@ known to the user. When the user may not know all the options in the set,
 consider allowing the user to type in the option they want.
 
 With fewer than 4 options, consider using a
-[RadioGroup](../radio-group) instead so that users can see all the options at
+[RadioGroup](/components/radio-group) instead so that users can see all the options at
 once.
 
 Don’t use Select to present the user with a list of actions.
-Use a [Dropdown](../dropdown) instead.`
+Use a [Dropdown](/components/dropdown) instead.`
 };

--- a/src/website/app/demos/TextArea/bestPractices.js
+++ b/src/website/app/demos/TextArea/bestPractices.js
@@ -6,7 +6,7 @@ import TextArea from '../../../../TextArea';
 export default [
   {
     type: 'do',
-    description: `Wrap TextArea in a [FormField](../form-field) and provide a
+    description: `Wrap TextArea in a [FormField](/components/form-field) and provide a
 brief, descriptive label.`,
     example: <FormField input={TextArea} label="Name" />
   },

--- a/src/website/app/demos/TextArea/examples/formField.js
+++ b/src/website/app/demos/TextArea/examples/formField.js
@@ -6,7 +6,7 @@ import DemoLayout from '../components/DemoLayout';
 export default {
   id: 'form-field',
   title: 'FormField',
-  description: `Use a [FormField](../form-field) to provide an accessible label
+  description: `Use a [FormField](/components/form-field) to provide an accessible label
 and other features as well as a more streamlined API.`,
   scope: { DemoLayout, FormField, TextArea },
   source: `

--- a/src/website/app/demos/TextArea/examples/invalid.js
+++ b/src/website/app/demos/TextArea/examples/invalid.js
@@ -6,7 +6,7 @@ export default {
   title: 'Invalid',
   description: `The \`invalid\` prop on a TextArea does nothing visually on its
 own, but is important for accessibility. See FormField's
-[Validation](../form-field/#validation) example for more info.`,
+[Validation](/components/form-field#validation) example for more info.`,
   scope: { TextArea },
   source: `
     <TextArea invalid />

--- a/src/website/app/demos/TextArea/examples/required.js
+++ b/src/website/app/demos/TextArea/examples/required.js
@@ -6,7 +6,7 @@ export default {
   title: 'Required',
   description: `The \`required\` prop on a TextArea does nothing visually on
 its own, but is important for accessibility. See FormField's
-[Required](../form-field/#required) and [Validation](../form-field/#validation)
+[Required](/components/form-field#required) and [Validation](/components/form-field#validation)
 examples for more information.`,
   scope: { TextArea },
   source: `

--- a/src/website/app/demos/TextArea/examples/variants.js
+++ b/src/website/app/demos/TextArea/examples/variants.js
@@ -6,7 +6,7 @@ export default {
   id: 'variants',
   title: 'Variants',
   description: `TextArea is available in a few variants, mostly for use with
-[validation](../form-field/#validation). Be sure to use the
+[validation](/components/form-field#validation). Be sure to use the
 [appropriate variant](/color#guidelines-variants) for your intent.`,
   scope: { DemoLayout, TextArea },
   source: `

--- a/src/website/app/demos/TextArea/index.js
+++ b/src/website/app/demos/TextArea/index.js
@@ -25,6 +25,6 @@ export default [
 from a user.
 
 TextAreas should always have an associated label for accessibility and so the
-user knows what information to provide. See [FormField](../form-field).`
+user knows what information to provide. See [FormField](/components/form-field).`
   }
 ];

--- a/src/website/app/demos/TextInput/bestPractices.js
+++ b/src/website/app/demos/TextInput/bestPractices.js
@@ -7,7 +7,7 @@ import DemoLayout from './components/DemoLayout';
 export default [
   {
     type: 'do',
-    description: `Wrap TextInput in a [FormField](../form-field) and provide a
+    description: `Wrap TextInput in a [FormField](/components/form-field) and provide a
 brief, descriptive label.`,
     example: <FormField input={TextInput} label="Name" />
   },

--- a/src/website/app/demos/TextInput/examples/formField.js
+++ b/src/website/app/demos/TextInput/examples/formField.js
@@ -7,7 +7,7 @@ import DemoLayout from '../components/DemoLayout';
 export default {
   id: 'form-field',
   title: 'FormField',
-  description: `Use a [FormField](../form-field) to provide an accessible label
+  description: `Use a [FormField](/components/form-field) to provide an accessible label
 and other features as well as a more streamlined API.`,
   scope: { DemoLayout, FormField, IconAccountBox, TextInput },
   source: `

--- a/src/website/app/demos/TextInput/examples/icons.js
+++ b/src/website/app/demos/TextInput/examples/icons.js
@@ -6,7 +6,7 @@ import DemoLayout from '../components/DemoLayout';
 export default {
   id: 'icons',
   title: 'With Icons',
-  description: `TextInputs can contain [Icons](../icon) at their start, end, or both.`,
+  description: `TextInputs can contain [Icons](/components/icon) at their start, end, or both.`,
   scope: { DemoLayout, IconCloud, TextInput },
   source: `
   () => {

--- a/src/website/app/demos/TextInput/examples/invalid.js
+++ b/src/website/app/demos/TextInput/examples/invalid.js
@@ -6,7 +6,7 @@ export default {
   title: 'Invalid',
   description: `The \`invalid\` prop on a TextInput does nothing visually on its
 own, but is important for accessibility. See FormField's
-[Validation](../form-field/#validation) example for more info.`,
+[Validation](/components/form-field#validation) example for more info.`,
   scope: { TextInput },
   source: `
     <TextInput invalid />

--- a/src/website/app/demos/TextInput/examples/required.js
+++ b/src/website/app/demos/TextInput/examples/required.js
@@ -6,7 +6,7 @@ export default {
   title: 'Required',
   description: `The \`required\` prop on a TextInput does nothing visually on
 its own, but is important for accessibility. See FormField's
-[Required](../form-field/#required) and [Validation](../form-field/#validation)
+[Required](/components/form-field#required) and [Validation](/components/form-field#validation)
 examples for more information.`,
   scope: { TextInput },
   source: `

--- a/src/website/app/demos/TextInput/examples/rtl.js
+++ b/src/website/app/demos/TextInput/examples/rtl.js
@@ -14,7 +14,7 @@ export default {
   title: 'Bidirectionality',
   description: `TextInputs support right-to-left (RTL) languages.
 TextInputs with Icons are reversed when the \`direction\` theme variable is set to \`rtl\`.
-A subset of Icons that [convey directionality](../icon/#rtl) will be reversed.`,
+A subset of Icons that [convey directionality](/components/icon#rtl) will be reversed.`,
   scope: { DemoLayout, IconBackspace, TextInput, ThemeProvider },
   source: `
     <div dir="rtl">

--- a/src/website/app/demos/TextInput/examples/variants.js
+++ b/src/website/app/demos/TextInput/examples/variants.js
@@ -6,7 +6,7 @@ export default {
   id: 'variants',
   title: 'Variants',
   description: `TextInput is available in a few variants, mostly for use with
-[validation](../form-field/#validation). Be sure to use the
+[validation](/components/form-field#validation). Be sure to use the
 [appropriate variant](/color#guidelines-variants) for your intent.`,
   scope: { DemoLayout, TextInput },
   source: `

--- a/src/website/app/demos/TextInput/index.js
+++ b/src/website/app/demos/TextInput/index.js
@@ -24,7 +24,7 @@ export default [
     whenHowToUse: `Use a TextInput to accept brief, free-form input from a user.
 
 TextInputs should always have an associated label for accessibility and so the
-user knows what information to provide. See [FormField](../form-field).
+user knows what information to provide. See [FormField](/components/form-field).
 
 Be specific when choosing the \`type\` for your TextInput. Mobile devices will
 display different keyboards depending on the input type.

--- a/src/website/app/pages/ComponentDoc/DocExamples.js
+++ b/src/website/app/pages/ComponentDoc/DocExamples.js
@@ -16,18 +16,23 @@ type Example = {
 };
 
 type Props = {
-  examples: Array<Example>
+  examples: Array<Example>,
+  slug: string
 };
 
-export default function DocExamples({ examples }: Props) {
+export default function DocExamples({ examples, slug }: Props) {
   if (process.env.NODE_ENV === 'production') {
     examples = examples.filter(example => !example.hideFromProd);
   }
   return (
     <Section>
-      {examples.map((example, index) => (
-        <ComponentDocExample key={index} {...example} />
-      ))}
+      {examples.map((example, index) => {
+        const exampleProps = {
+          slug,
+          ...example
+        };
+        return <ComponentDocExample {...exampleProps} key={index} />;
+      })}
     </Section>
   );
 }

--- a/src/website/app/pages/ComponentDoc/DocThemeVariables.js
+++ b/src/website/app/pages/ComponentDoc/DocThemeVariables.js
@@ -67,8 +67,8 @@ export default function DocThemeVariables({
       <Markdown>
         {`These variables can be used as hooks to override this component's
           style at either a
-          [local](/theming/#common-scenarios-theme-your-entire-app-theme-a-component)
-          or [global](/theming/#theming-common-scenarios-theme-your-entire-app)
+          [local](/theming#common-scenarios-theme-your-entire-app-theme-a-component)
+          or [global](/theming#common-scenarios-theme-your-entire-app)
           level. The \`theme\` referenced below is whatever theme is available
           from props to the instance of this component.`}
       </Markdown>

--- a/src/website/app/pages/ComponentDoc/index.js
+++ b/src/website/app/pages/ComponentDoc/index.js
@@ -28,6 +28,7 @@ type Props = {
     canonicalLink: string
   },
   propsComment?: string | React$Element<*>,
+  slug: string,
   title: string,
   whenHowToUse?: string
 };
@@ -78,8 +79,8 @@ export default function ComponentDoc({
   componentTheme,
   doc,
   examples,
-
   propsComment,
+  slug,
   title,
   whenHowToUse,
   ...restProps
@@ -96,6 +97,7 @@ export default function ComponentDoc({
   };
   delete rootProps.subcomponent;
   delete rootProps.slug;
+  const examplesProps = { examples, slug };
   const propProps = { propDoc, propsComment, title };
   const themeVariablesProps = {
     baseTheme: mineralTheme,
@@ -108,7 +110,7 @@ export default function ComponentDoc({
       {doc.description && <DocIntro>{doc.description}</DocIntro>}
       <DocSubNav {...subNavProps} />
       {examples && <DocHeading id="examples">Examples</DocHeading>}
-      {examples && <DocExamples examples={examples} />}
+      {examples && <DocExamples {...examplesProps} />}
       <DocHeading id="api-and-theme">API & Theme</DocHeading>
       <DocProps {...propProps} />
       {componentTheme && <DocThemeVariables {...themeVariablesProps} />}

--- a/src/website/app/pages/Home/content/themePlayground.md
+++ b/src/website/app/pages/Home/content/themePlayground.md
@@ -4,7 +4,7 @@ It’s easy to match Mineral components to a product experience with themes.
 With just a few lines of code, change the theme for every component or constrain
 the change to only affect a portion of them. Themes are simple enough to quickly
 change the color palette and powerful enough to adjust a
-[whole host of other properties](/theming/#common-scenarios-theme-structure).
+[whole host of other properties](/theming#common-scenarios-theme-structure).
 
 <PlaygroundButton to="/theming">
   Learn About Themes

--- a/src/website/app/pages/Theming/theming.md
+++ b/src/website/app/pages/Theming/theming.md
@@ -42,7 +42,7 @@ ThemeProviders may be nested in order to apply a custom theme to a portion of yo
 
 ### Theme a component
 
-Each component has a set of component-level theme variables that may be overridden to adjust styles on a per component basis.  These are documented on the individual component pages,  e.g. [Button theme variables](/components/button/#theme-variables).
+Each component has a set of component-level theme variables that may be overridden to adjust styles on a per component basis.  These are documented on the individual component pages,  e.g. [Button theme variables](/components/button#theme-variables).
 
 To theme a component, use [createThemedComponent](#common-scenarios-api) as shown below.  It is effectively the same as wrapping your component with a ThemeProvider.
 
@@ -118,7 +118,7 @@ This function is useful when you want to create a new theme that uses a differen
 
 **Parameters**
 
-* `baseColor`: Optional.  Default: 'blue'.  Color used to generate theme color scheme.  Value must be a valid [Mineral UI color](/color/#guidelines-ramps).
+* `baseColor`: Optional.  Default: 'blue'.  Color used to generate theme color scheme.  Value must be a valid [Mineral UI color](/color#guidelines-ramps).
 * `overrides`: Optional.  A shallow object of variables to be spread on to the default theme.  Useful to override default values.
 
 **Returns**

--- a/src/website/app/pages/index.js
+++ b/src/website/app/pages/index.js
@@ -1,8 +1,6 @@
 /* @flow */
-import Loadable from '../Loadable';
-
 type Page = {
-  component: React$ComponentType<*>,
+  component: string,
   description: string,
   id?: string,
   path: string,
@@ -22,27 +20,21 @@ const sections: Array<Section> = [
     heading: 'Guidelines',
     pages: [
       {
-        component: Loadable({
-          loader: () => import('./GettingStarted')
-        }),
+        component: 'GettingStarted',
         description:
           'Mineral UI’s React component library helps you quickly build elegantly accessible apps. Use npm or yarn to install components and themes tested across modern browsers.',
         path: '/getting-started',
         title: 'Getting Started'
       },
       {
-        component: Loadable({
-          loader: () => import('./Color')
-        }),
+        component: 'Color',
         description:
           'Make your apps beautiful and accessibile with Mineral UI color palettes and themes.',
         path: '/color',
         title: 'Color'
       },
       {
-        component: Loadable({
-          loader: () => import('./Typography')
-        }),
+        component: 'Typography',
         description:
           'Mineral UI provides a simple set of typographic elements to easily apply structure to your interface.',
         path: '/typography',
@@ -54,18 +46,14 @@ const sections: Array<Section> = [
     heading: 'What’s New',
     pages: [
       {
-        component: Loadable({
-          loader: () => import('./ComponentStatus')
-        }),
+        component: 'ComponentStatus',
         description:
           'Check back here anytime to see current component status information for Mineral UI. Check our GitHub for issues or to suggest a new feature!',
         path: '/component-status',
         title: 'Component Status'
       },
       {
-        component: Loadable({
-          loader: () => import('./Roadmap')
-        }),
+        component: 'Roadmap',
         description:
           'Mineral UI is committed to stable and predictable releases. Learn more about our plans for the future.',
         path: '/roadmap',
@@ -77,27 +65,21 @@ const sections: Array<Section> = [
     heading: 'Customization',
     pages: [
       {
-        component: Loadable({
-          loader: () => import('./Styling')
-        }),
+        component: 'Styling',
         description:
           'Mineral UI is built on a design system with styles ready to go out of the box. Learn the techniques for customizing styles in your application.',
         path: '/styling',
         title: 'Styling'
       },
       {
-        component: Loadable({
-          loader: () => import('./Theming')
-        }),
+        component: 'Theming',
         description:
           'Theming is a core concept in Mineral UI. Mineral UI makes it simple to implement and maintain theming across your app.',
         path: '/theming',
         title: 'Theming'
       },
       {
-        component: Loadable({
-          loader: () => import('./PaletteDemo')
-        }),
+        component: 'PaletteDemo',
         description:
           'Select from the main theme colors in the picker to see how components are affected. Mineral UI themes are composed of a main color ramp and the base gray ramp.',
         path: '/palette-demo',


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->

- Fix new page (vs. same-page) anchor links via ScrollToIdOnMount
- Remove forced trailing slash from routes
- Add redirect for /components route
- Pass slug to ComponentDocExample and use it to generate relative-to-root links
- Fix broken anchor link in Component Theme table intro
- Convert same-page anchor links to routed ones when viewing standalone examples
- Change all relative links to be relative-to-the-root


### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->

Closes #533, connects #547 (/components route) and fixes a few other niggles.


### Screenshots, videos, or demo, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

https://533-fix-routed-anchors--mineral-ui.netlify.com/getting-started#installation

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. Click the link above
1. Did you scroll to the Installation heading? Good!
1. Navigate to a component's theme variables table and click on either the "global" or "local" link.
1. Did you scroll to the appropriate heading? Good!
1. Navigate to a specific example route for a component that contains a same-page anchor link (like [this one](https://533-fix-routed-anchors--mineral-ui.netlify.com/components/box/width)).
1. Click the would-be anchor link and confirm you instead navigate to the example route
1. Click the back link and then click the same now-still-an-anchor link and confirm you scroll to the example
1. Confirm you can navigate to any given page with and without the trailing slash


### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Just website stuff.


### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![60% of the time, it works everytime](https://media.giphy.com/media/LEKtRCGyA90QM/giphy.gif)
