### PR TITLE
chore(scripts): Improve build/release scripts

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -27,7 +27,10 @@ Currently the site is hosted on Netlify. In order to publish the website, one of
 * __How do I publish a prerelease version?__
 
   ```sh
-  npm run release -- --canary
+  npm run clean
+  npm run build:library
+  npm run build:package -- --label=alpha
+  npm run release:dist -- --npm-tag=alpha
   ```
 
 * __Is it okay to publish from a branch?__
@@ -37,6 +40,7 @@ Currently the site is hosted on Netlify. In order to publish the website, one of
 * __This publishing stuff is scary.  Is there any way to experiment without fear of breaking things?__
 
     * There is a confirmation prompt at the end of the `release` script.  You can abort prior to taking any remote actions, then inspect the local changes.
+    * There are also `--skip-git` and `--skip-npm` options.
     * As mentioned above, check the `release` command usage for options.
 
     ```sh

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   "main": "./dist/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
-    "build": "npm run clean && npm run build:package && npm run build:website",
+    "build": "npm run clean && npm run build:library && npm run build:website",
     "build:analyze": "ANALYZE=true npm run start",
     "build:icons": "npm i --prefix ./packages/mineral-ui-icons && npm run build:icons --prefix ./packages/mineral-ui-icons",
+    "build:library": "./scripts/build-library.js",
     "build:package": "./scripts/build-package.js",
     "build:website": "./scripts/build-website.js",
     "clean": "rm -rf dist",

--- a/scripts/build-library.js
+++ b/scripts/build-library.js
@@ -1,0 +1,34 @@
+#! /usr/bin/env node
+/* eslint-disable no-console */
+
+const execSync = require('child_process').execSync;
+
+const { NODE_ENV = 'production' } = process.env;
+
+const exec = (command, env) =>
+  execSync(command, {
+    stdio: 'inherit',
+    env: { ...process.env, ...env }
+  });
+
+// components es modules
+console.log('\n\nBuilding ES modules...');
+exec(
+  'babel ./src/library --out-dir ./dist/es --ignore *.spec.js,*.template.js',
+  {
+    NODE_ENV
+  }
+);
+
+// components cjs modules
+console.log('\n\nBuilding CommonJS modules...');
+exec('babel ./src/library --out-dir ./dist --ignore *.spec.js,*.template.js', {
+  BABEL_ENV: 'cjs',
+  NODE_ENV
+});
+
+// flow definitions - not yet ready for public consumption
+// console.log('\n\nCopying Flow Definitions...');
+// exec(
+//   'flow-copy-source -v -i "**/__tests__/**" -i "**/dist/**" -i "**/lib/**" -i "**/templates/**" ./src/library ./dist'
+// );

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -1,34 +1,125 @@
 #! /usr/bin/env node
 /* eslint-disable no-console */
 
-const execSync = require('child_process').execSync;
+const os = require('os');
+const fs = require('fs-extra');
+const path = require('path');
+const { execSync } = require('child_process');
+const semver = require('semver');
 
-const { NODE_ENV = 'production' } = process.env;
+// Configure the arguments parser and documentation
+const argv = require('yargs')
+  .option('label', {
+    describe: 'Build a pre-release package with a custom version label'
+  })
+  .option('skip-git', {
+    describe: 'Skip git commands. No commits, tags, etc.'
+  })
+  .usage('Usage: $0 [options]')
+  .example('$0', 'Build a standard package.')
+  .example(
+    '$0 --label alpha',
+    'Build a canary/prerelease package with label "alpha".  e.g. 0.1.0-alpha.0'
+  )
+  .example(
+    '$0 --skip-git',
+    'Build a package without committing or tagging anything.'
+  )
+  .help('h')
+  .alias('h', 'help').argv;
 
-const exec = (command, env) =>
+const exec = command =>
   execSync(command, {
-    stdio: 'inherit',
-    env: { ...process.env, ...env }
+    stdio: 'inherit'
   });
 
-// components es modules
-console.log('\n\nBuilding ES modules...');
-exec(
-  'babel ./src/library --out-dir ./dist/es --ignore *.spec.js,*.template.js',
-  {
-    NODE_ENV
-  }
-);
+console.log('\n\nBuilding package...');
+const { label, skipGit } = argv;
 
-// components cjs modules
-console.log('\n\nBuilding CommonJS modules...');
-exec('babel ./src/library --out-dir ./dist --ignore *.spec.js,*.template.js', {
-  BABEL_ENV: 'cjs',
-  NODE_ENV
+// Read root package.json and get current package version
+const packageJsonFile = path.resolve(__dirname, '../package.json');
+const packageJsonData = fs.readJsonSync(packageJsonFile);
+const { version: currentVersion } = packageJsonData;
+
+// Determine next package version
+let nextVersion;
+if (label) {
+  // Adjust pre-release version
+  const bump = semver.prerelease(currentVersion) ? 'prerelease' : 'preminor';
+  nextVersion = semver.inc(currentVersion, bump, label); // e.g. 0.1.0-alpha.0
+} else {
+  // Simply increment minor version until 1.0 milestone
+  // Following the 1.0 milestone, this can be updated with something that
+  // determines the version bump based on commit messages
+  nextVersion = semver.inc(currentVersion, 'minor');
+}
+
+// Create a copy of the original package.json for restoration later
+exec('cp package.json _package.json');
+
+// Bump version in package.json, but do not commit or tag it
+// This is necessary in order to generate a changelog with the appropriate version
+exec(`npm --no-git-tag-version version ${nextVersion}`);
+
+// Generate changelog
+const changelogConfigFile = path.resolve(
+  __dirname,
+  '../utils/changelogConfig.js'
+);
+exec(
+  `conventional-changelog --preset angular --infile CHANGELOG.md --same-file --config ${changelogConfigFile}`
+);
+// Check if a changelog has been generated
+// Note: tmpfile used to get output from git status command
+const gitStatusFile = path.resolve(os.tmpdir(), '.git-status');
+exec(`echo "$(git status --porcelain)" > ${gitStatusFile}`);
+const hasChangelog = fs
+  .readFileSync(gitStatusFile, { encoding: 'utf8' })
+  .includes('CHANGELOG.md');
+fs.removeSync(gitStatusFile);
+// Only commit changelog if it has been updated/generated
+if (hasChangelog && !skipGit) {
+  exec('git add CHANGELOG.md');
+  exec(`git commit -m "docs(changelog): ${nextVersion}"`);
+}
+
+// Restore original package.json
+exec('mv -f _package.json package.json');
+
+// Update version in package.json, commit and tag
+exec(`npm version ${nextVersion} --no-git-tag-version`);
+if (!skipGit) {
+  exec(`git add package.json`);
+  exec(`git commit -m "chore(release): ${nextVersion}"`);
+  exec(`git tag -f v${nextVersion}`);
+}
+
+// Copy additional files to dist to be included in the npm package
+exec('cp {README.md,LICENSE.md,CHANGELOG.md} dist');
+
+// Create simplified package.json in dist
+const updatedPackageJasonData = fs.readJsonSync(packageJsonFile);
+const minimalPackageJsonData = {
+  name: updatedPackageJasonData.name,
+  author: updatedPackageJasonData.author,
+  description: updatedPackageJasonData.description,
+  version: updatedPackageJasonData.version,
+  license: updatedPackageJasonData.license,
+  repository: updatedPackageJasonData.repository,
+  bugs: updatedPackageJasonData.bugs,
+  homepage: updatedPackageJasonData.homepage,
+  main: './index.js',
+  module: './es/index.js',
+  files: ['**', '!website', '!*.tgz'],
+  dependencies: updatedPackageJasonData.dependencies,
+  peerDependencies: updatedPackageJasonData.peerDependencies
+};
+const minimalPackageJsonFile = path.resolve(__dirname, '../dist/package.json');
+fs.writeJsonSync(minimalPackageJsonFile, minimalPackageJsonData, {
+  spaces: 2
 });
 
-// flow definitions - not yet ready for public consumption
-// console.log('\n\nCopying Flow Definitions...');
-// exec(
-//   'flow-copy-source -v -i "**/__tests__/**" -i "**/dist/**" -i "**/lib/**" -i "**/templates/**" ./src/library ./dist'
-// );
+// Create an installable package for local testing
+exec('cd dist && npm pack');
+
+console.log('Package built successfully.');

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,33 +2,29 @@
 /* eslint-disable no-console */
 
 const os = require('os');
-const fse = require('fs-extra');
+const fs = require('fs-extra');
 const path = require('path');
 const { execSync } = require('child_process');
-const semver = require('semver');
 const inquirer = require('inquirer');
 
 // Configure the arguments parser and documentation
 const argv = require('yargs')
-  .option('canary', {
-    describe: 'Publish a pre-release canary version'
-  })
   .option('npm-tag', {
     describe: 'Publish a release using a custom npm dist-tag',
     default: 'latest',
     type: 'string'
   })
+  .option('skip-git', {
+    describe: "Skip git commands. Don't push to GitHub"
+  })
+  .option('skip-npm', {
+    describe: "Skip npm commands. Don't publish to npm"
+  })
   .usage('Usage: $0 [options]')
-  .example('$0', 'perform a standard release')
-  .example(
-    '$0 --canary',
-    'perform a canary/prerelease with label and npm dist-tag "alpha", e.g. 0.1.0-alpha.0'
-  )
-  .example(
-    '$0 --canary=beta --npmTag=beta',
-    'perform a canary/prerelease with label and npm dist-tag "beta", e.g. 0.1.0-beta.0'
-  )
-  .example('$0 --npmTag=next', 'perform a release using npm dist-tag "next"')
+  .example('$0', 'Perform a standard release')
+  .example('$0 --npm-tag=next', 'Perform a release using npm dist-tag "next"')
+  .example('$0 --skip-git', 'Skip push to GitHub.')
+  .example('$0 --skip-npm', 'Skip publish to npm.')
   .help('h')
   .alias('h', 'help').argv;
 
@@ -37,85 +33,32 @@ const exec = command =>
     stdio: 'inherit'
   });
 
-// Read root package.json and get current package version
-const packageJsonFile = path.resolve(__dirname, '../package.json');
-const packageJsonData = fse.readJsonSync(packageJsonFile);
-const { version: currentVersion } = packageJsonData;
+const { npmTag, skipGit, skipNpm } = argv;
 
-// Identify next package version - simply increment minor version until 1.0 milestone
-// Following the 1.0 milestone, this can be updated with something that
-// determines the version bump based on commit messages
-let nextVersion = semver.inc(currentVersion, 'minor');
-
-// Avoid publishing canary under latest npm-tag, default to alpha
-const npmTag = argv.canary && argv.npmTag === 'latest' ? 'alpha' : argv.npmTag;
-
-// Adjust canary version appropriately
-if (argv.canary) {
-  const label = typeof argv.canary === 'string' ? argv.canary : 'alpha';
-  const bump = semver.prerelease(currentVersion) ? 'prerelease' : 'preminor';
-  nextVersion = semver.inc(currentVersion, bump, label); // e.g. - 0.1.0-alpha.0
+// Read dist/package.json and get package version
+const packageJsonFile = path.resolve(__dirname, '../dist/package.json');
+if (!fs.existsSync(packageJsonFile)) {
+  console.log(
+    `Unable to find ${packageJsonFile}. You must build a package first. Release aborted.`
+  );
+  process.exit(0);
 }
+const version = fs.readJsonSync(packageJsonFile).version;
 
-// Create a copy of the original package.json for restoration later
-exec('cp package.json _package.json');
-
-// Bump version in package.json, but do not commit or tag it
-// This is necessary in order to generate a changelog with the appropriate version
-exec(`npm --no-git-tag-version version ${nextVersion}`);
-
-// Generate changelog
-const changelogConfigFile = path.resolve(
-  __dirname,
-  '../utils/changelogConfig.js'
-);
-exec(
-  `conventional-changelog --preset angular --infile CHANGELOG.md --same-file --config ${changelogConfigFile}`
-);
-// Check if a changelog has been generated
-// Note: tmpfile used to get output from git status command
-const gitStatusFile = path.resolve(os.tmpdir(), '.git-status');
-exec(`echo "$(git status --porcelain)" > ${gitStatusFile}`);
-const hasChangelog = fse
-  .readFileSync(gitStatusFile, { encoding: 'utf8' })
-  .includes('CHANGELOG.md');
-fse.removeSync(gitStatusFile);
-// Only commit changelog if it has been updated/generated
-if (hasChangelog) {
-  exec('git add CHANGELOG.md');
-  exec(`git commit -m "docs(changelog): ${nextVersion}"`);
+// Check if version has previously been published
+// Note: tmpfile used to get output from npm command
+const npmVersionsFile = path.resolve(os.tmpdir(), '.npm-versions');
+exec(`echo "$(npm show mineral-ui versions)" > ${npmVersionsFile}`);
+const versionPreviouslyPublished = fs
+  .readFileSync(npmVersionsFile, { encoding: 'utf8' })
+  .includes(version);
+fs.removeSync(npmVersionsFile);
+if (versionPreviouslyPublished) {
+  console.log(
+    `Version ${version} has previously been published. Release aborted.`
+  );
+  process.exit(0);
 }
-
-// Restore original package.json
-exec('mv -f _package.json package.json');
-
-// Update version in package.json, commit and tag
-exec(`npm version ${nextVersion} -f -m "chore(release): ${nextVersion}"`);
-
-// Copy additional files to dist to be included in the npm package
-exec('cp {README.md,LICENSE.md,CHANGELOG.md} dist');
-
-// Create simplified package.json in dist
-const updatedPackageJasonData = fse.readJsonSync(packageJsonFile);
-const minimalPackageJsonData = {
-  name: updatedPackageJasonData.name,
-  author: updatedPackageJasonData.author,
-  description: updatedPackageJasonData.description,
-  version: updatedPackageJasonData.version,
-  license: updatedPackageJasonData.license,
-  repository: updatedPackageJasonData.repository,
-  bugs: updatedPackageJasonData.bugs,
-  homepage: updatedPackageJasonData.homepage,
-  main: './index.js',
-  module: './es/index.js',
-  files: ['**', '!website'],
-  dependencies: updatedPackageJasonData.dependencies,
-  peerDependencies: updatedPackageJasonData.peerDependencies
-};
-const minimalPackageJsonFile = path.resolve(__dirname, '../dist/package.json');
-fse.writeJsonSync(minimalPackageJsonFile, minimalPackageJsonData, {
-  spaces: 2
-});
 
 // Publishing - prompt user for confirmation
 inquirer
@@ -123,18 +66,26 @@ inquirer
     {
       type: 'confirm',
       name: 'confirm',
-      message: `Ready to release ${nextVersion} using npm tag ${npmTag}?`
+      message: `Ready to release ${version} using npm tag ${npmTag}?`
     }
   ])
   .then(({ confirm }) => {
     if (confirm) {
-      // Push commits and tags to GitHub
-      console.log('Pushing to GitHub...');
-      exec('git push -f --follow-tags');
-
       // Publish to npm
-      console.log('Publishing to npm...');
-      exec(`cd dist && npm publish --tag=${npmTag}`);
+      if (skipNpm) {
+        console.log('Skipped publish to npm...');
+      } else {
+        console.log('Publishing to npm...');
+        exec(`cd dist && npm publish --tag=${npmTag}`);
+      }
+
+      // Push commits and tags to GitHub
+      if (skipGit) {
+        console.log('Skipped push to GitHub...');
+      } else {
+        console.log('Pushing to GitHub...');
+        exec('git push -f --follow-tags');
+      }
     } else {
       console.log('Release aborted.');
     }


### PR DESCRIPTION
### Description

Refactor build/release scripts.  Splits apart the release script into different build scripts with individual responsibilities.

Changes:
* `build-library`
  * _New_.
  * This script simply transpiles the library code to dist.
  * Does what `build-package` used to do.  
* `build-package`
  * _Changed_.  The previous logic has been moved to the `build-library` script.  The new logic/functionality has been extracted from the `release` script.
  * This script determines and updates version in package.json, generates changelog, adds a tag and up to 2 commits (changelog and release), creates a minimal dist/package.json, and creates a locally installable package for testing in CRA.
  * The `--label` option is used for generating prerelease packages.  It is used to generate the version and git tag.  e.g. 0.23.0-alpha.0 . It has nothing to do with the npm dist tag, which is handled in the release script.
  * The `--skip-git` option is used to skip git actions, in which case no tags or commits will be created.  _(no more need to reset ~2 and delete tags)_  
  * Run `npm run build:package -- --help` for usage.
* `release`
  *  _Changed_.  The package building logic has been extract to the `build-package` script.
  * This script is now simply responsible for performing actual release behaviors, e.g. pushing to Github and publishing to npm.  It has a couple additional safety checks as well.
  * The `skip-git` and `skip-npm` options can be used individually or in tandem to perform a "dry-run".
  * The `npm-tag` option is useful for publishing pre-releases.
  * Run `npm run release:dist -- --help` for usage.

### Motivation and context

* Make creation of local installable package easier for local testing in CRA.
* Make it easier to publish pre-releases.  Really, it is to make doing so more flexible and explicit.

Closes #624 

### How to test

**Build works as normal**

1. `npm run build`

**Build a package for local testing in CRA**

1. `npm run clean`
2. `npm run build:library`
3. `npm run build:package -- --skip-git`
4. Note the installable package in dist, e.g. mineral-ui-*.tgz.
5. Note that by using the `--skip-git` option, there were no new commits or tags created.  There will be local changes to `package.json` and `CHANGELOG.md` that can be reviewed and later discarded.
6. Go install/try it in CRA if you like.  `npm i ../../dist/mineral-ui-*.tgz && npm start`

**Publish a prerelease version (if you must).**  

_Note that I have recently published `0.23.0-alpha.0` under the `alpha` dist tag, so if you are actually going to publish something while testing this, you'll need to use a different version.  FWIW, there is a safety check in the release script to check for this case anyway._

1. `npm run clean`
2. `npm run build:library`
3. `npm run build:package -- --label=alpha`
4. `npm run release:dist -- --npm-tag=alpha --skip-git`
5. `npm dist-tag ls`
6. Go install/try it in CRA if you like.  `npm i mineral-ui@alpha`

### Types of changes

- Other (provide details below)

Refactor of build/release scripts

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
