### PR TITLE
chore(dependencies): Update prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "exenv": "1.2.2",
     "fast-deep-equal": "1.1.0",
     "fontfaceobserver": "2.0.13",
+    "prop-types": "^15.5.7",
     "react-popper": "0.7.4",
     "scroll-into-view-if-needed": "1.5.0"
   },
@@ -115,7 +116,6 @@
     "prepend-file": "1.3.1",
     "prettier": "1.7.4",
     "pretty-bytes": "4.0.2",
-    "prop-types": "15.6.0",
     "raf": "3.4.0",
     "raw-loader": "0.5.1",
     "react": "16.1.1",


### PR DESCRIPTION
### Description

Update prop-types dependency
* Move prop-types package from devDependencies to dependencies
* Use flexible carat version so package can be de-duped in consumer apps 
* Minimum version set to 15.5.7 as previous versions have issues

### Motivation and context

The package has some pretty clear instructions on how to depend on it.  

https://github.com/facebook/prop-types#how-to-depend-on-this-package

closes #621 

### How to test

Not sure there is really anything to test here.  We are now strictly following Facebook guidelines on how to depend on this package.  We could maybe go into CRA and validate that different versions get deduped properly, but honestly I am not sure it is worth the effort at this point in time.

### Types of changes

- Other (provide details below)

Chore, maybe a bugfix, but not one that likely affected anyone yet.

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
