### PR TITLE
[website] Generate page with prop permutations of multiple components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "pack-ls": "cd dist && tar -tvf $(npm pack) && rm *.tgz",
     "release": "npm run build && npm test && ./scripts/release.js",
     "release:dist": "./scripts/release.js",
+    "sketch": "html-sketchapp --url http://0.0.0.0:8080/kitchen-sink --out-dir dist",
+    "sketch:install": "html-sketchapp install",
     "start": "webpack-dev-server --progress",
     "test": "npm run lint && npm run flow:restart && npm run jest -- --coverage"
   },
@@ -101,6 +103,7 @@
     "glamorous": "4.9.7",
     "glob": "7.1.2",
     "happo.io": "1.0.0-rc1",
+    "html-sketchapp-cli": "0.3.0",
     "html-webpack-plugin": "2.30.1",
     "husky": "0.14.3",
     "inquirer": "3.3.0",

--- a/src/website/app/Router.js
+++ b/src/website/app/Router.js
@@ -25,6 +25,10 @@ const AsyncHome = Loadable({
   loader: () => import('./pages/Home')
 });
 
+const AsyncKitchenSink = Loadable({
+  loader: () => import('./pages/KitchenSink')
+});
+
 const getPageHeader = (heading: string, title: string) => {
   return `${heading}
 
@@ -83,6 +87,7 @@ export default function Router({ demoRoutes }: Props) {
     <Switch>
       <Route path="/" exact component={AsyncHome} />
       {routes}
+      <Route path="/kitchen-sink" component={AsyncKitchenSink} />
       <Route
         path="/components/:componentId/:exampleId"
         render={route => {

--- a/src/website/app/pages/KitchenSink/components/avatar.js
+++ b/src/website/app/pages/KitchenSink/components/avatar.js
@@ -1,0 +1,50 @@
+/* @flow */
+import Avatar from '../../../../../library/Avatar';
+
+export default {
+  Component: Avatar,
+  componentName: 'Avatar',
+  props: [
+    {
+      name: 'size',
+      labels: ['Small', 'Medium', 'Large', 'Jumbo'],
+      values: ['small', 'medium', undefined, 'jumbo']
+    },
+    {
+      name: 'background',
+      labels: [
+        'Red',
+        'Magenta',
+        'Purple',
+        'Indigo',
+        'Blue',
+        'Sky',
+        'Teal',
+        'Green',
+        'Lime',
+        'Yellow',
+        'Orange',
+        'Gray',
+        'Slate',
+        'Dusk'
+      ],
+      values: [
+        'red',
+        'magenta',
+        'purple',
+        'indigo',
+        'blue',
+        'sky',
+        'teal',
+        'green',
+        'lime',
+        'yellow',
+        'orange',
+        'gray',
+        'slate',
+        'dusk'
+      ]
+    }
+  ],
+  commonProps: { children: 'Avatar' }
+};

--- a/src/website/app/pages/KitchenSink/components/button.js
+++ b/src/website/app/pages/KitchenSink/components/button.js
@@ -1,0 +1,25 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+
+export default {
+  Component: Button,
+  componentName: 'Button',
+  props: [
+    {
+      name: undefined,
+      labels: ['Default', 'Primary', 'Minimal'],
+      values: [undefined, 'primary', 'minimal']
+    },
+    {
+      name: 'size',
+      labels: ['Small', 'Medium', 'Large', 'Jumbo'],
+      values: ['small', 'medium', undefined, 'jumbo']
+    },
+    {
+      name: 'variant',
+      labels: ['Regular', 'Danger', 'Success', 'Warning'],
+      values: [undefined, 'danger', 'success', 'warning']
+    }
+  ],
+  commonProps: { children: 'Button Text' }
+};

--- a/src/website/app/pages/KitchenSink/components/index.js
+++ b/src/website/app/pages/KitchenSink/components/index.js
@@ -1,0 +1,5 @@
+/* @flow */
+import avatar from './avatar';
+import button from './button';
+
+export default [avatar, button];

--- a/src/website/app/pages/KitchenSink/index.js
+++ b/src/website/app/pages/KitchenSink/index.js
@@ -1,0 +1,161 @@
+/* @flow */
+import React from 'react';
+import { createStyledComponent } from '../../../../library/styles';
+import { ThemeProvider } from '../../../../library/themes';
+import Flex, { FlexItem } from '../../../../library/Flex';
+import components from './components';
+
+type Args = {
+  Component: React$StatelessFunctionalComponent<*> | React$ComponentType<*>,
+  componentName: string,
+  props?: Array<Prop>,
+  commonProps?: Object
+};
+
+type Prop = {
+  name: ?string,
+  labels: Array<string>,
+  values: Array<any> // TODO: Better flow type?
+};
+
+type PermutationProps = {
+  Component: React$StatelessFunctionalComponent<*> | React$ComponentType<*>,
+  title: string,
+  commonProps?: Object,
+  dynamicProps?: Object
+};
+
+/*
+ * Following two functions are from: https://stackoverflow.com/a/15308220
+ */
+
+// Arbitrary base x number class
+var BaseX = function(initRadix) {
+  this.radix = initRadix ? initRadix : 1;
+  this.value = 0;
+  this.increment = function() {
+    return (this.value = (this.value + 1) % this.radix) === 0;
+  };
+};
+
+function cartesianProduct(input) {
+  var output = [], // Array containing the resulting combinations
+    counters = [], // Array of counters corresponding to our input arrays
+    remainder = false, // Did adding one cause the previous digit to rollover?
+    temp; // Holds one combination to be pushed into the output array
+
+  // Initialize the counters
+  for (var i = input.length - 1; i >= 0; i--) {
+    counters.unshift(new BaseX(input[i].length));
+  }
+
+  // Get all possible combinations
+  // Loop through until the first counter rolls over
+  while (!remainder) {
+    temp = []; // Reset the temporary value collection array
+    remainder = true; // Always increment the last array counter
+
+    // Process each of the arrays
+    for (i = input.length - 1; i >= 0; i--) {
+      temp.unshift(input[i][counters[i].value]); // Add this array's value to the result
+
+      // If the counter to the right rolled over, increment this one.
+      if (remainder) {
+        remainder = counters[i].increment();
+      }
+    }
+    output.push(temp); // Collect the results.
+  }
+
+  return output;
+}
+
+const getProp = (name, value) =>
+  name ? { [name]: value } : value ? { [value]: true } : null;
+
+const getPermutations = ({
+  Component,
+  componentName,
+  props,
+  commonProps
+}: Args) => {
+  const changingProps = props; // See https://github.com/facebook/flow/issues/3299
+  if (changingProps) {
+    const valuePermutations = cartesianProduct(
+      changingProps.map(prop => prop.values)
+    );
+    const labelPermutations = cartesianProduct(
+      changingProps.map(prop => prop.labels)
+    );
+
+    return valuePermutations.map((permutation, index) => {
+      const dynamicProps = permutation.reduce((acc, value, valueIndex) => {
+        return {
+          ...acc,
+          ...getProp(changingProps[valueIndex].name, value)
+        };
+      }, {});
+      const title = permutation
+        .reduce(
+          (acc, title, titleIndex) => {
+            acc.push(`/${labelPermutations[index][titleIndex]}`);
+            return acc;
+          },
+          [componentName]
+        )
+        .join('');
+      const symbolProps = {
+        Component,
+        title,
+        dynamicProps,
+        commonProps
+      };
+      return <Permutation key={index} {...symbolProps} />;
+    });
+  } else {
+    const symbolProps = {
+      Component,
+      title: componentName,
+      commonProps
+    };
+    return <Permutation key={componentName} {...symbolProps} />;
+  }
+};
+
+const PermutationRoot = createStyledComponent(FlexItem, ({ theme }) => ({
+  '& > p': {
+    color: theme.color_caption,
+    fontFamily: theme.fontFamily_system,
+    fontSize: theme.fontSize_ui,
+    margin: `0 0 ${theme.space_stack_sm}`
+  }
+})).withProps({ grow: 1, padding: 'lg', width: '12rem' });
+
+const Permutation = ({
+  Component,
+  title,
+  commonProps,
+  dynamicProps,
+  ...restProps
+}: PermutationProps) => (
+  <PermutationRoot {...restProps}>
+    <p>{title}</p>
+    <span data-sketch-symbol={title}>
+      <Component {...dynamicProps} {...commonProps} />
+    </span>
+  </PermutationRoot>
+);
+
+export default function ComponentPermutations() {
+  return (
+    <ThemeProvider>
+      <div>
+        {components.map((component, index) => (
+          <Flex wrap key={index}>
+            {getPermutations(component)}
+          </Flex>
+        ))}
+      </div>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
<!--
NOTE: We're just getting started. While we appreciate any feedback, we're not yet ready to accept public contributions.

Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: [ComponentName] Clear, brief title using imperative tense
For example: [Button] Add support for type=submit

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
- Add a "kitchen sink" (open to different names) page that displays prop permutations of multiple components
    - This page is primarily to be used to generate a Sketch file which will allow inserting those permutations, but may have other purposes
- Generate that page via simple config per-component
- Add a `sketch` npm script to generate the [almost-Sketch files](https://github.com/brainly/html-sketchapp#how-does-it-work)

Note: This work is more about figuring out the proper approach, which is why only Avatar and Button are included.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Closes #638. I completed the AC in just a couple hours. Then I spent a couple days addressing the other consideration noted there.

### Screenshots, videos, or demo, if appropriate
<!-- To record and share a video: http://recordit.co/ -->

[Explanatory demo video](https://drive.google.com/file/d/1d4IAo46XuhfRWJZjPF092x5fToBYnlcY/view?usp=sharing)

https://638-html-sketchapp--mineral-ui.netlify.com/kitchen-sink

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
1. Navigate to the new [KitchenSink page](https://638-html-sketchapp--mineral-ui.netlify.com/kitchen-sink) (`/kitchen-sink`, purposefully not available in nav) and confirm that Avatar and Button are rendered correctly
1. If you have Sketch installed
    1. `npm run sketch` to generate the necessary files
    1. `npm run sketch:install` to install the corresponding Sketch plugin
    1. Open Sketch, create a new file, Plugins > From \*Almost\* Sketch to Sketch
    1. Select the two generated files in /dist
    1. Confirm that the resulting Sketch file is correct

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Just website stuff

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) [n/a]
* [x] Automated tests written and passing **See below**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered **See below**
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

<!-- If any of the above need further details, you should include those here. -->

**Testing**: All existing tests pass, as expected. But there's a somewhat gnarly function that should probably be unit-tested.

**Performance**: The page itself will eventually render hundreds, if not thousands, of components, so it'll become quite large/slow. I made sure it won't affect the rest of the site by making the route async to split the bundle there.

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Cookie factory](https://media.giphy.com/media/D0StO6ivDc5lC/giphy.gif)
