### PR TITLE
fix(select): Select calls onChange handler

### DIFF
--- a/src/library/Select/Select.js
+++ b/src/library/Select/Select.js
@@ -435,6 +435,8 @@ export default class Select extends Component<Props, State> {
   };
 
   onSelect = (item: Item, event: SyntheticEvent<>) => {
+    const prevSelectedItem = this.getControllableValue('selectedItem');
+
     let stateToSet;
     if (!this.isControlled('selectedItem')) {
       stateToSet = {
@@ -450,18 +452,21 @@ export default class Select extends Component<Props, State> {
 
     if (stateToSet) {
       this.setState(stateToSet, () => {
-        this.onSelectActions(item, event);
+        this.onSelectActions(item, prevSelectedItem, event);
       });
     } else {
-      this.onSelectActions(item, event);
+      this.onSelectActions(item, prevSelectedItem, event);
     }
   };
 
-  onSelectActions = (item: Item, event: SyntheticEvent<>) => {
-    const selectedItem = this.getControllableValue('selectedItem');
+  onSelectActions = (
+    item: Item,
+    prevSelectedItem: Item,
+    event: SyntheticEvent<>
+  ) => {
     this.props.onSelect && this.props.onSelect(item, event);
 
-    if (selectedItem !== item) {
+    if (prevSelectedItem !== item) {
       this.onChange(item, event);
     }
 

--- a/src/library/Select/__tests__/Select.spec.js
+++ b/src/library/Select/__tests__/Select.spec.js
@@ -13,15 +13,18 @@ import type { Items } from '../../Menu/Menu';
 const data: Items = [
   {
     text: 'A item',
-    value: 'A'
+    value: 'A',
+    onClick: jest.fn()
   },
   {
     text: 'B item',
-    value: 'B'
+    value: 'B',
+    onClick: jest.fn()
   },
   {
     text: 'C item',
-    value: 'C'
+    value: 'C',
+    onClick: jest.fn()
   }
 ];
 
@@ -246,7 +249,9 @@ describe('Select', () => {
         [themeProvider, select] = mountSelect({
           onClose: jest.fn(),
           defaultIsOpen: true,
-          defaultHighlightedIndex: 0
+          defaultHighlightedIndex: 0,
+          onChange: jest.fn(),
+          onSelect: jest.fn()
         });
         trigger = select.find(SelectTrigger);
         triggerRoot = trigger.find('div').first();
@@ -331,6 +336,43 @@ describe('Select', () => {
             triggerRoot.simulate('keydown', { key: 'b' });
 
             assertItemAtIndexIsHighlighted(themeProvider, 1);
+          });
+        });
+      });
+
+      describe('item selection', () => {
+        beforeEach(() => {
+          [themeProvider, select] = mountSelect({
+            defaultIsOpen: true,
+            defaultSelectedItem: data[0],
+            onChange: jest.fn(),
+            onSelect: jest.fn()
+          });
+          trigger = select.find(SelectTrigger);
+          triggerRoot = trigger.find('div').first();
+        });
+
+        describe('when item is same as previous', () => {
+          it('calls appropriate event handlers', () => {
+            const item = themeProvider.find(MenuItem).at(0);
+
+            item.simulate('click');
+
+            expect(data[0].onClick).toHaveBeenCalled();
+            expect(select.props().onSelect).toHaveBeenCalled();
+            expect(select.props().onChange).not.toHaveBeenCalled();
+          });
+        });
+
+        describe('when item is different than previous', () => {
+          it('calls appropriate event handlers', () => {
+            const item = themeProvider.find(MenuItem).at(1);
+
+            item.simulate('click');
+
+            expect(data[1].onClick).toHaveBeenCalled();
+            expect(select.props().onSelect).toHaveBeenCalled();
+            expect(select.props().onChange).toHaveBeenCalled();
           });
         });
       });

--- a/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
@@ -338,7 +338,7 @@ exports[`Select demo examples controlled 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-78"
+                    id="select-88"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -377,7 +377,7 @@ exports[`Select demo examples controlled 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-78"
+                      id="select-88"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -416,7 +416,7 @@ exports[`Select demo examples controlled 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-78"
+                        id="select-88"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -457,7 +457,7 @@ exports[`Select demo examples controlled 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-78"
+                              id="select-88"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -495,7 +495,7 @@ exports[`Select demo examples controlled 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-78-content"
+                                    id="select-88-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -515,7 +515,7 @@ exports[`Select demo examples controlled 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-78"
+                                id="select-88"
                                 isOpen={false}
                                 onChange={[Function]}
                                 onClose={[Function]}
@@ -547,7 +547,7 @@ exports[`Select demo examples controlled 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-78-content"
+                                      id="select-88-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -567,7 +567,7 @@ exports[`Select demo examples controlled 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-78"
+                                  id="select-88"
                                   isOpen={false}
                                   onChange={[Function]}
                                   onClose={[Function]}
@@ -580,23 +580,23 @@ exports[`Select demo examples controlled 1`] = `
                                 >
                                   <Manager
                                     className="glamor-9"
-                                    id="select-78"
+                                    id="select-88"
                                     onChange={[Function]}
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-9"
-                                      id="select-78"
+                                      id="select-88"
                                       onChange={[Function]}
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-78-content"
+                                        aria-describedby="select-88-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-78-content"
+                                        aria-owns="select-88-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -619,12 +619,12 @@ exports[`Select demo examples controlled 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-78-content"
+                                                aria-describedby="select-88-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-78-content"
+                                                aria-owns="select-88-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -662,12 +662,12 @@ exports[`Select demo examples controlled 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-78-content"
+                                                  aria-describedby="select-88-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-78-content"
+                                                  aria-owns="select-88-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -709,12 +709,12 @@ exports[`Select demo examples controlled 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-78-content"
+                                                    aria-describedby="select-88-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-78-content"
+                                                    aria-owns="select-88-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -740,12 +740,12 @@ exports[`Select demo examples controlled 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-78-content"
+                                                      aria-describedby="select-88-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-78-content"
+                                                      aria-owns="select-88-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -763,12 +763,12 @@ exports[`Select demo examples controlled 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-78-content"
+                                                        aria-describedby="select-88-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-78-content"
+                                                        aria-owns="select-88-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -1274,7 +1274,7 @@ exports[`Select demo examples data 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-80"
+                  id="select-90"
                   isOpen={false}
                   modifiers={
                     Object {
@@ -1334,7 +1334,7 @@ exports[`Select demo examples data 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-80"
+                    id="select-90"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -1394,7 +1394,7 @@ exports[`Select demo examples data 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-80"
+                      id="select-90"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -1456,7 +1456,7 @@ exports[`Select demo examples data 1`] = `
                             getMenuProps={[Function]}
                             getTriggerProps={[Function]}
                             highlightedIndex={undefined}
-                            id="select-80"
+                            id="select-90"
                             isOpen={false}
                             modifiers={
                               Object {
@@ -1515,7 +1515,7 @@ exports[`Select demo examples data 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-80-content"
+                                  id="select-90-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -1535,7 +1535,7 @@ exports[`Select demo examples data 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-80"
+                              id="select-90"
                               isOpen={false}
                               onClose={[Function]}
                               onOpen={[Function]}
@@ -1588,7 +1588,7 @@ exports[`Select demo examples data 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-80-content"
+                                    id="select-90-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -1608,7 +1608,7 @@ exports[`Select demo examples data 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-80"
+                                id="select-90"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -1619,21 +1619,21 @@ exports[`Select demo examples data 1`] = `
                               >
                                 <Manager
                                   className="glamor-9"
-                                  id="select-80"
+                                  id="select-90"
                                   tag="span"
                                 >
                                   <span
                                     className="glamor-9"
-                                    id="select-80"
+                                    id="select-90"
                                   >
                                     <PopoverTrigger
                                       aria-activedescendant={undefined}
-                                      aria-describedby="select-80-content"
+                                      aria-describedby="select-90-content"
                                       aria-disabled={undefined}
                                       aria-expanded={false}
                                       aria-haspopup="listbox"
                                       aria-invalid={undefined}
-                                      aria-owns="select-80-content"
+                                      aria-owns="select-90-content"
                                       aria-readonly={undefined}
                                       aria-required={undefined}
                                       disabled={undefined}
@@ -1656,12 +1656,12 @@ exports[`Select demo examples data 1`] = `
                                           >
                                             <SelectTrigger
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-80-content"
+                                              aria-describedby="select-90-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-80-content"
+                                              aria-owns="select-90-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               disabled={undefined}
@@ -1699,12 +1699,12 @@ exports[`Select demo examples data 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-80-content"
+                                                aria-describedby="select-90-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-80-content"
+                                                aria-owns="select-90-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 control={[Function]}
@@ -1746,12 +1746,12 @@ exports[`Select demo examples data 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-80-content"
+                                                  aria-describedby="select-90-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-80-content"
+                                                  aria-owns="select-90-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   className="glamor-5"
@@ -1777,12 +1777,12 @@ exports[`Select demo examples data 1`] = `
                                                 >
                                                   <FauxControl
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-80-content"
+                                                    aria-describedby="select-90-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-80-content"
+                                                    aria-owns="select-90-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -1800,12 +1800,12 @@ exports[`Select demo examples data 1`] = `
                                                   >
                                                     <div
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-80-content"
+                                                      aria-describedby="select-90-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-80-content"
+                                                      aria-owns="select-90-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-4"
@@ -2260,7 +2260,7 @@ exports[`Select demo examples disabled 1`] = `
                 getMenuProps={[Function]}
                 getTriggerProps={[Function]}
                 highlightedIndex={undefined}
-                id="select-84"
+                id="select-94"
                 isOpen={false}
                 modifiers={
                   Object {
@@ -2297,7 +2297,7 @@ exports[`Select demo examples disabled 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-84"
+                  id="select-94"
                   isOpen={false}
                   modifiers={
                     Object {
@@ -2334,7 +2334,7 @@ exports[`Select demo examples disabled 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-84"
+                    id="select-94"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -2373,7 +2373,7 @@ exports[`Select demo examples disabled 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-84"
+                          id="select-94"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -2409,7 +2409,7 @@ exports[`Select demo examples disabled 1`] = `
                                 }
                                 getItemProps={[Function]}
                                 getMenuProps={[Function]}
-                                id="select-84-content"
+                                id="select-94-content"
                                 modifiers={
                                   Object {
                                     "contentWidth": Object {
@@ -2429,7 +2429,7 @@ exports[`Select demo examples disabled 1`] = `
                             getTriggerProps={[Function]}
                             hasArrow={true}
                             highlightedIndex={undefined}
-                            id="select-84"
+                            id="select-94"
                             isOpen={false}
                             onClose={[Function]}
                             onOpen={[Function]}
@@ -2459,7 +2459,7 @@ exports[`Select demo examples disabled 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-84-content"
+                                  id="select-94-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -2479,7 +2479,7 @@ exports[`Select demo examples disabled 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-84"
+                              id="select-94"
                               isOpen={false}
                               onClose={[Function]}
                               onOpen={[Function]}
@@ -2490,21 +2490,21 @@ exports[`Select demo examples disabled 1`] = `
                             >
                               <Manager
                                 className="glamor-9"
-                                id="select-84"
+                                id="select-94"
                                 tag="span"
                               >
                                 <span
                                   className="glamor-9"
-                                  id="select-84"
+                                  id="select-94"
                                 >
                                   <PopoverTrigger
                                     aria-activedescendant={undefined}
-                                    aria-describedby="select-84-content"
+                                    aria-describedby="select-94-content"
                                     aria-disabled={true}
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={undefined}
-                                    aria-owns="select-84-content"
+                                    aria-owns="select-94-content"
                                     aria-readonly={undefined}
                                     aria-required={undefined}
                                     disabled={true}
@@ -2527,12 +2527,12 @@ exports[`Select demo examples disabled 1`] = `
                                         >
                                           <SelectTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-84-content"
+                                            aria-describedby="select-94-content"
                                             aria-disabled={true}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={undefined}
-                                            aria-owns="select-84-content"
+                                            aria-owns="select-94-content"
                                             aria-readonly={undefined}
                                             aria-required={undefined}
                                             disabled={true}
@@ -2570,12 +2570,12 @@ exports[`Select demo examples disabled 1`] = `
                                                 ]
                                               }
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-84-content"
+                                              aria-describedby="select-94-content"
                                               aria-disabled={true}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-84-content"
+                                              aria-owns="select-94-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               control={[Function]}
@@ -2617,12 +2617,12 @@ exports[`Select demo examples disabled 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-84-content"
+                                                aria-describedby="select-94-content"
                                                 aria-disabled={true}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-84-content"
+                                                aria-owns="select-94-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 className="glamor-5"
@@ -2648,12 +2648,12 @@ exports[`Select demo examples disabled 1`] = `
                                               >
                                                 <FauxControl
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-84-content"
+                                                  aria-describedby="select-94-content"
                                                   aria-disabled={true}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-84-content"
+                                                  aria-owns="select-94-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   className="glamor-5"
@@ -2671,12 +2671,12 @@ exports[`Select demo examples disabled 1`] = `
                                                 >
                                                   <div
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-84-content"
+                                                    aria-describedby="select-94-content"
                                                     aria-disabled={true}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-84-content"
+                                                    aria-owns="select-94-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-4"
@@ -3574,13 +3574,13 @@ exports[`Select demo examples form-field 1`] = `
                       <label>
                         <glamorous(div)
                           hideLabel={undefined}
-                          key="formField-124-textWrapper"
+                          key="formField-134-textWrapper"
                         >
                           <div
                             className="glamor-1"
                           >
                             <span
-                              id="formField-124-labelText"
+                              id="formField-134-labelText"
                             >
                               State
                             </span>
@@ -3596,7 +3596,7 @@ exports[`Select demo examples form-field 1`] = `
                           </div>
                         </glamorous(div)>
                         <Select
-                          aria-describedby="formField-124-caption"
+                          aria-describedby="formField-134-caption"
                           data={
                             Array [
                               Object {
@@ -3801,7 +3801,7 @@ exports[`Select demo examples form-field 1`] = `
                               },
                             ]
                           }
-                          key="formField-124-control"
+                          key="formField-134-control"
                           name="state"
                           placeholder="Choose a state..."
                           placement="bottom-start"
@@ -3811,7 +3811,7 @@ exports[`Select demo examples form-field 1`] = `
                           variant={undefined}
                         >
                           <Select
-                            aria-describedby="formField-124-caption"
+                            aria-describedby="formField-134-caption"
                             data={
                               Array [
                                 Object {
@@ -4021,7 +4021,7 @@ exports[`Select demo examples form-field 1`] = `
                             getMenuProps={[Function]}
                             getTriggerProps={[Function]}
                             highlightedIndex={undefined}
-                            id="select-125"
+                            id="select-135"
                             isOpen={false}
                             modifiers={
                               Object {
@@ -4038,7 +4038,7 @@ exports[`Select demo examples form-field 1`] = `
                             rootProps={undefined}
                           >
                             <ThemedComponent
-                              aria-describedby="formField-124-caption"
+                              aria-describedby="formField-134-caption"
                               className="glamor-13"
                               data={
                                 Array [
@@ -4249,7 +4249,7 @@ exports[`Select demo examples form-field 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-125"
+                              id="select-135"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -4266,7 +4266,7 @@ exports[`Select demo examples form-field 1`] = `
                               rootProps={undefined}
                             >
                               <Themed(Dropdown)
-                                aria-describedby="formField-124-caption"
+                                aria-describedby="formField-134-caption"
                                 className="glamor-13"
                                 data={
                                   Array [
@@ -4477,7 +4477,7 @@ exports[`Select demo examples form-field 1`] = `
                                 getMenuProps={[Function]}
                                 getTriggerProps={[Function]}
                                 highlightedIndex={undefined}
-                                id="select-125"
+                                id="select-135"
                                 isOpen={false}
                                 modifiers={
                                   Object {
@@ -4496,7 +4496,7 @@ exports[`Select demo examples form-field 1`] = `
                                 <ThemeProvider>
                                   <ThemeProvider>
                                     <Dropdown
-                                      aria-describedby="formField-124-caption"
+                                      aria-describedby="formField-134-caption"
                                       className="glamor-13"
                                       data={
                                         Array [
@@ -4707,7 +4707,7 @@ exports[`Select demo examples form-field 1`] = `
                                       getMenuProps={[Function]}
                                       getTriggerProps={[Function]}
                                       highlightedIndex={undefined}
-                                      id="select-125"
+                                      id="select-135"
                                       isOpen={false}
                                       modifiers={
                                         Object {
@@ -4724,7 +4724,7 @@ exports[`Select demo examples form-field 1`] = `
                                       rootProps={undefined}
                                     >
                                       <Popover
-                                        aria-describedby="formField-124-caption"
+                                        aria-describedby="formField-134-caption"
                                         className="glamor-13"
                                         content={
                                           <DropdownContent
@@ -4934,7 +4934,7 @@ exports[`Select demo examples form-field 1`] = `
                                             }
                                             getItemProps={[Function]}
                                             getMenuProps={[Function]}
-                                            id="select-125-content"
+                                            id="select-135-content"
                                             modifiers={
                                               Object {
                                                 "contentWidth": Object {
@@ -4954,7 +4954,7 @@ exports[`Select demo examples form-field 1`] = `
                                         getTriggerProps={[Function]}
                                         hasArrow={true}
                                         highlightedIndex={undefined}
-                                        id="select-125"
+                                        id="select-135"
                                         isOpen={false}
                                         onClose={[Function]}
                                         onOpen={[Function]}
@@ -4965,7 +4965,7 @@ exports[`Select demo examples form-field 1`] = `
                                         wrapContent={false}
                                       >
                                         <Popover
-                                          aria-describedby="formField-124-caption"
+                                          aria-describedby="formField-134-caption"
                                           className="glamor-13"
                                           content={
                                             <DropdownContent
@@ -5175,7 +5175,7 @@ exports[`Select demo examples form-field 1`] = `
                                               }
                                               getItemProps={[Function]}
                                               getMenuProps={[Function]}
-                                              id="select-125-content"
+                                              id="select-135-content"
                                               modifiers={
                                                 Object {
                                                   "contentWidth": Object {
@@ -5195,7 +5195,7 @@ exports[`Select demo examples form-field 1`] = `
                                           getTriggerProps={[Function]}
                                           hasArrow={true}
                                           highlightedIndex={undefined}
-                                          id="select-125"
+                                          id="select-135"
                                           isOpen={false}
                                           onClose={[Function]}
                                           onOpen={[Function]}
@@ -5207,24 +5207,24 @@ exports[`Select demo examples form-field 1`] = `
                                           wrapContent={false}
                                         >
                                           <Manager
-                                            aria-describedby="formField-124-caption"
+                                            aria-describedby="formField-134-caption"
                                             className="glamor-11"
-                                            id="select-125"
+                                            id="select-135"
                                             tag="span"
                                           >
                                             <span
-                                              aria-describedby="formField-124-caption"
+                                              aria-describedby="formField-134-caption"
                                               className="glamor-11"
-                                              id="select-125"
+                                              id="select-135"
                                             >
                                               <PopoverTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-125-content"
+                                                aria-describedby="select-135-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-125-content"
+                                                aria-owns="select-135-content"
                                                 aria-readonly={undefined}
                                                 aria-required={true}
                                                 disabled={undefined}
@@ -5247,12 +5247,12 @@ exports[`Select demo examples form-field 1`] = `
                                                     >
                                                       <SelectTrigger
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-125-content"
+                                                        aria-describedby="select-135-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-125-content"
+                                                        aria-owns="select-135-content"
                                                         aria-readonly={undefined}
                                                         aria-required={true}
                                                         disabled={undefined}
@@ -5290,12 +5290,12 @@ exports[`Select demo examples form-field 1`] = `
                                                             ]
                                                           }
                                                           aria-activedescendant={undefined}
-                                                          aria-describedby="select-125-content"
+                                                          aria-describedby="select-135-content"
                                                           aria-disabled={undefined}
                                                           aria-expanded={false}
                                                           aria-haspopup="listbox"
                                                           aria-invalid={undefined}
-                                                          aria-owns="select-125-content"
+                                                          aria-owns="select-135-content"
                                                           aria-readonly={undefined}
                                                           aria-required={true}
                                                           control={[Function]}
@@ -5337,12 +5337,12 @@ exports[`Select demo examples form-field 1`] = `
                                                               ]
                                                             }
                                                             aria-activedescendant={undefined}
-                                                            aria-describedby="select-125-content"
+                                                            aria-describedby="select-135-content"
                                                             aria-disabled={undefined}
                                                             aria-expanded={false}
                                                             aria-haspopup="listbox"
                                                             aria-invalid={undefined}
-                                                            aria-owns="select-125-content"
+                                                            aria-owns="select-135-content"
                                                             aria-readonly={undefined}
                                                             aria-required={true}
                                                             className="glamor-7"
@@ -5368,12 +5368,12 @@ exports[`Select demo examples form-field 1`] = `
                                                           >
                                                             <FauxControl
                                                               aria-activedescendant={undefined}
-                                                              aria-describedby="select-125-content"
+                                                              aria-describedby="select-135-content"
                                                               aria-disabled={undefined}
                                                               aria-expanded={false}
                                                               aria-haspopup="listbox"
                                                               aria-invalid={undefined}
-                                                              aria-owns="select-125-content"
+                                                              aria-owns="select-135-content"
                                                               aria-readonly={undefined}
                                                               aria-required={true}
                                                               className="glamor-7"
@@ -5391,12 +5391,12 @@ exports[`Select demo examples form-field 1`] = `
                                                             >
                                                               <div
                                                                 aria-activedescendant={undefined}
-                                                                aria-describedby="select-125-content"
+                                                                aria-describedby="select-135-content"
                                                                 aria-disabled={undefined}
                                                                 aria-expanded={false}
                                                                 aria-haspopup="listbox"
                                                                 aria-invalid={undefined}
-                                                                aria-owns="select-125-content"
+                                                                aria-owns="select-135-content"
                                                                 aria-readonly={undefined}
                                                                 aria-required={true}
                                                                 className="glamor-6"
@@ -5526,13 +5526,13 @@ exports[`Select demo examples form-field 1`] = `
                       </label>
                       <glamorous(div)
                         caption="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-                        id="formField-124-caption"
+                        id="formField-134-caption"
                         isGroup={false}
                         variant={undefined}
                       >
                         <div
                           className="glamor-18"
-                          id="formField-124-caption"
+                          id="formField-134-caption"
                         >
                           Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                         </div>
@@ -5884,7 +5884,7 @@ exports[`Select demo examples invalid 1`] = `
                 getMenuProps={[Function]}
                 getTriggerProps={[Function]}
                 highlightedIndex={undefined}
-                id="select-90"
+                id="select-100"
                 invalid={true}
                 isOpen={false}
                 modifiers={
@@ -5922,7 +5922,7 @@ exports[`Select demo examples invalid 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-90"
+                  id="select-100"
                   invalid={true}
                   isOpen={false}
                   modifiers={
@@ -5960,7 +5960,7 @@ exports[`Select demo examples invalid 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-90"
+                    id="select-100"
                     invalid={true}
                     isOpen={false}
                     modifiers={
@@ -6000,7 +6000,7 @@ exports[`Select demo examples invalid 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-90"
+                          id="select-100"
                           invalid={true}
                           isOpen={false}
                           modifiers={
@@ -6037,7 +6037,7 @@ exports[`Select demo examples invalid 1`] = `
                                 }
                                 getItemProps={[Function]}
                                 getMenuProps={[Function]}
-                                id="select-90-content"
+                                id="select-100-content"
                                 modifiers={
                                   Object {
                                     "contentWidth": Object {
@@ -6057,7 +6057,7 @@ exports[`Select demo examples invalid 1`] = `
                             getTriggerProps={[Function]}
                             hasArrow={true}
                             highlightedIndex={undefined}
-                            id="select-90"
+                            id="select-100"
                             invalid={true}
                             isOpen={false}
                             onClose={[Function]}
@@ -6088,7 +6088,7 @@ exports[`Select demo examples invalid 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-90-content"
+                                  id="select-100-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -6108,7 +6108,7 @@ exports[`Select demo examples invalid 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-90"
+                              id="select-100"
                               invalid={true}
                               isOpen={false}
                               onClose={[Function]}
@@ -6120,21 +6120,21 @@ exports[`Select demo examples invalid 1`] = `
                             >
                               <Manager
                                 className="glamor-9"
-                                id="select-90"
+                                id="select-100"
                                 tag="span"
                               >
                                 <span
                                   className="glamor-9"
-                                  id="select-90"
+                                  id="select-100"
                                 >
                                   <PopoverTrigger
                                     aria-activedescendant={undefined}
-                                    aria-describedby="select-90-content"
+                                    aria-describedby="select-100-content"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={true}
-                                    aria-owns="select-90-content"
+                                    aria-owns="select-100-content"
                                     aria-readonly={undefined}
                                     aria-required={undefined}
                                     disabled={undefined}
@@ -6157,12 +6157,12 @@ exports[`Select demo examples invalid 1`] = `
                                         >
                                           <SelectTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-90-content"
+                                            aria-describedby="select-100-content"
                                             aria-disabled={undefined}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={true}
-                                            aria-owns="select-90-content"
+                                            aria-owns="select-100-content"
                                             aria-readonly={undefined}
                                             aria-required={undefined}
                                             disabled={undefined}
@@ -6200,12 +6200,12 @@ exports[`Select demo examples invalid 1`] = `
                                                 ]
                                               }
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-90-content"
+                                              aria-describedby="select-100-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={true}
-                                              aria-owns="select-90-content"
+                                              aria-owns="select-100-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               control={[Function]}
@@ -6247,12 +6247,12 @@ exports[`Select demo examples invalid 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-90-content"
+                                                aria-describedby="select-100-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={true}
-                                                aria-owns="select-90-content"
+                                                aria-owns="select-100-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 className="glamor-5"
@@ -6278,12 +6278,12 @@ exports[`Select demo examples invalid 1`] = `
                                               >
                                                 <FauxControl
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-90-content"
+                                                  aria-describedby="select-100-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={true}
-                                                  aria-owns="select-90-content"
+                                                  aria-owns="select-100-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   className="glamor-5"
@@ -6301,12 +6301,12 @@ exports[`Select demo examples invalid 1`] = `
                                                 >
                                                   <div
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-90-content"
+                                                    aria-describedby="select-100-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={true}
-                                                    aria-owns="select-90-content"
+                                                    aria-owns="select-100-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-4"
@@ -6957,7 +6957,7 @@ exports[`Select demo examples overflow 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-111"
+                    id="select-121"
                     isOpen={true}
                     modifiers={
                       Object {
@@ -6994,7 +6994,7 @@ exports[`Select demo examples overflow 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-111"
+                      id="select-121"
                       isOpen={true}
                       modifiers={
                         Object {
@@ -7031,7 +7031,7 @@ exports[`Select demo examples overflow 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-111"
+                        id="select-121"
                         isOpen={true}
                         modifiers={
                           Object {
@@ -7070,7 +7070,7 @@ exports[`Select demo examples overflow 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-111"
+                              id="select-121"
                               isOpen={true}
                               modifiers={
                                 Object {
@@ -7106,7 +7106,7 @@ exports[`Select demo examples overflow 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-111-content"
+                                    id="select-121-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -7126,7 +7126,7 @@ exports[`Select demo examples overflow 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-111"
+                                id="select-121"
                                 isOpen={true}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -7156,7 +7156,7 @@ exports[`Select demo examples overflow 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-111-content"
+                                      id="select-121-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -7176,7 +7176,7 @@ exports[`Select demo examples overflow 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-111"
+                                  id="select-121"
                                   isOpen={true}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -7187,21 +7187,21 @@ exports[`Select demo examples overflow 1`] = `
                                 >
                                   <Manager
                                     className="glamor-30"
-                                    id="select-111"
+                                    id="select-121"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-30"
-                                      id="select-111"
+                                      id="select-121"
                                     >
                                       <PopoverTrigger
-                                        aria-activedescendant="select-111-menu"
-                                        aria-describedby="select-111-content"
+                                        aria-activedescendant="select-121-menu"
+                                        aria-describedby="select-121-content"
                                         aria-disabled={undefined}
                                         aria-expanded={true}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-111-content"
+                                        aria-owns="select-121-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -7223,13 +7223,13 @@ exports[`Select demo examples overflow 1`] = `
                                               className="glamor-7"
                                             >
                                               <SelectTrigger
-                                                aria-activedescendant="select-111-menu"
-                                                aria-describedby="select-111-content"
+                                                aria-activedescendant="select-121-menu"
+                                                aria-describedby="select-121-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={true}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-111-content"
+                                                aria-owns="select-121-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -7266,13 +7266,13 @@ exports[`Select demo examples overflow 1`] = `
                                                       />,
                                                     ]
                                                   }
-                                                  aria-activedescendant="select-111-menu"
-                                                  aria-describedby="select-111-content"
+                                                  aria-activedescendant="select-121-menu"
+                                                  aria-describedby="select-121-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={true}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-111-content"
+                                                  aria-owns="select-121-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -7313,13 +7313,13 @@ exports[`Select demo examples overflow 1`] = `
                                                         />,
                                                       ]
                                                     }
-                                                    aria-activedescendant="select-111-menu"
-                                                    aria-describedby="select-111-content"
+                                                    aria-activedescendant="select-121-menu"
+                                                    aria-describedby="select-121-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={true}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-111-content"
+                                                    aria-owns="select-121-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -7344,13 +7344,13 @@ exports[`Select demo examples overflow 1`] = `
                                                     variant={undefined}
                                                   >
                                                     <FauxControl
-                                                      aria-activedescendant="select-111-menu"
-                                                      aria-describedby="select-111-content"
+                                                      aria-activedescendant="select-121-menu"
+                                                      aria-describedby="select-121-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={true}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-111-content"
+                                                      aria-owns="select-121-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -7367,13 +7367,13 @@ exports[`Select demo examples overflow 1`] = `
                                                       variant={undefined}
                                                     >
                                                       <div
-                                                        aria-activedescendant="select-111-menu"
-                                                        aria-describedby="select-111-content"
+                                                        aria-activedescendant="select-121-menu"
+                                                        aria-describedby="select-121-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={true}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-111-content"
+                                                        aria-owns="select-121-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -7508,7 +7508,7 @@ exports[`Select demo examples overflow 1`] = `
                                         }
                                         getItemProps={[Function]}
                                         getMenuProps={[Function]}
-                                        id="select-111-content"
+                                        id="select-121-content"
                                         modifiers={
                                           Object {
                                             "contentWidth": Object {
@@ -7521,7 +7521,7 @@ exports[`Select demo examples overflow 1`] = `
                                         wide={undefined}
                                       >
                                         <DropdownContent
-                                          id="select-111-content"
+                                          id="select-121-content"
                                           modifiers={
                                             Object {
                                               "contentWidth": Object {
@@ -7535,7 +7535,7 @@ exports[`Select demo examples overflow 1`] = `
                                         >
                                           <ThemedComponent
                                             className="glamor-26"
-                                            id="select-111-content"
+                                            id="select-121-content"
                                             modifiers={
                                               Object {
                                                 "contentWidth": Object {
@@ -7548,7 +7548,7 @@ exports[`Select demo examples overflow 1`] = `
                                           >
                                             <RtlPopper
                                               className="glamor-26"
-                                              id="select-111-content"
+                                              id="select-121-content"
                                               modifiers={
                                                 Object {
                                                   "contentWidth": Object {
@@ -7735,7 +7735,7 @@ exports[`Select demo examples overflow 1`] = `
                                                 className="glamor-26"
                                                 component="div"
                                                 eventsEnabled={true}
-                                                id="select-111-content"
+                                                id="select-121-content"
                                                 modifiers={
                                                   Object {
                                                     "contentWidth": Object {
@@ -7750,7 +7750,7 @@ exports[`Select demo examples overflow 1`] = `
                                                   className="glamor-26"
                                                   data-placement={undefined}
                                                   data-x-out-of-boundaries={undefined}
-                                                  id="select-111-content"
+                                                  id="select-121-content"
                                                   style={
                                                     Object {
                                                       "opacity": 0,
@@ -7777,16 +7777,16 @@ exports[`Select demo examples overflow 1`] = `
                                                       ]
                                                     }
                                                     getItemProps={[Function]}
-                                                    id="select-111-menu"
+                                                    id="select-121-menu"
                                                     role="listbox"
                                                   >
                                                     <Menu
-                                                      id="select-111-menu"
+                                                      id="select-121-menu"
                                                       role="listbox"
                                                     >
                                                       <div
                                                         className="glamor-25"
-                                                        id="select-111-menu"
+                                                        id="select-121-menu"
                                                         role="listbox"
                                                       >
                                                         <MenuGroup
@@ -7800,7 +7800,7 @@ exports[`Select demo examples overflow 1`] = `
                                                               <MenuItem
                                                                 aria-disabled={undefined}
                                                                 aria-selected={false}
-                                                                id="select-111-item-0"
+                                                                id="select-121-item-0"
                                                                 isHighlighted={false}
                                                                 item={
                                                                   Object {
@@ -7818,7 +7818,7 @@ exports[`Select demo examples overflow 1`] = `
                                                                   aria-disabled={undefined}
                                                                   aria-selected={false}
                                                                   disabled={undefined}
-                                                                  id="select-111-item-0"
+                                                                  id="select-121-item-0"
                                                                   isHighlighted={false}
                                                                   item={
                                                                     Object {
@@ -7837,7 +7837,7 @@ exports[`Select demo examples overflow 1`] = `
                                                                     aria-disabled={undefined}
                                                                     aria-selected={false}
                                                                     className="glamor-13"
-                                                                    id="select-111-item-0"
+                                                                    id="select-121-item-0"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     role="option"
@@ -7873,7 +7873,7 @@ exports[`Select demo examples overflow 1`] = `
                                                               <MenuItem
                                                                 aria-disabled={undefined}
                                                                 aria-selected={false}
-                                                                id="select-111-item-1"
+                                                                id="select-121-item-1"
                                                                 isHighlighted={false}
                                                                 item={
                                                                   Object {
@@ -7891,7 +7891,7 @@ exports[`Select demo examples overflow 1`] = `
                                                                   aria-disabled={undefined}
                                                                   aria-selected={false}
                                                                   disabled={undefined}
-                                                                  id="select-111-item-1"
+                                                                  id="select-121-item-1"
                                                                   isHighlighted={false}
                                                                   item={
                                                                     Object {
@@ -7910,7 +7910,7 @@ exports[`Select demo examples overflow 1`] = `
                                                                     aria-disabled={undefined}
                                                                     aria-selected={false}
                                                                     className="glamor-13"
-                                                                    id="select-111-item-1"
+                                                                    id="select-121-item-1"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     role="option"
@@ -7946,7 +7946,7 @@ exports[`Select demo examples overflow 1`] = `
                                                               <MenuItem
                                                                 aria-disabled={undefined}
                                                                 aria-selected={false}
-                                                                id="select-111-item-2"
+                                                                id="select-121-item-2"
                                                                 isHighlighted={false}
                                                                 item={
                                                                   Object {
@@ -7964,7 +7964,7 @@ exports[`Select demo examples overflow 1`] = `
                                                                   aria-disabled={undefined}
                                                                   aria-selected={false}
                                                                   disabled={undefined}
-                                                                  id="select-111-item-2"
+                                                                  id="select-121-item-2"
                                                                   isHighlighted={false}
                                                                   item={
                                                                     Object {
@@ -7983,7 +7983,7 @@ exports[`Select demo examples overflow 1`] = `
                                                                     aria-disabled={undefined}
                                                                     aria-selected={false}
                                                                     className="glamor-13"
-                                                                    id="select-111-item-2"
+                                                                    id="select-121-item-2"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     role="option"
@@ -8964,7 +8964,7 @@ exports[`Select demo examples placeholder 1`] = `
                 getMenuProps={[Function]}
                 getTriggerProps={[Function]}
                 highlightedIndex={undefined}
-                id="select-82"
+                id="select-92"
                 isOpen={false}
                 modifiers={
                   Object {
@@ -9189,7 +9189,7 @@ exports[`Select demo examples placeholder 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-82"
+                  id="select-92"
                   isOpen={false}
                   modifiers={
                     Object {
@@ -9414,7 +9414,7 @@ exports[`Select demo examples placeholder 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-82"
+                    id="select-92"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -9641,7 +9641,7 @@ exports[`Select demo examples placeholder 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-82"
+                          id="select-92"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -9865,7 +9865,7 @@ exports[`Select demo examples placeholder 1`] = `
                                 }
                                 getItemProps={[Function]}
                                 getMenuProps={[Function]}
-                                id="select-82-content"
+                                id="select-92-content"
                                 modifiers={
                                   Object {
                                     "contentWidth": Object {
@@ -9885,7 +9885,7 @@ exports[`Select demo examples placeholder 1`] = `
                             getTriggerProps={[Function]}
                             hasArrow={true}
                             highlightedIndex={undefined}
-                            id="select-82"
+                            id="select-92"
                             isOpen={false}
                             onClose={[Function]}
                             onOpen={[Function]}
@@ -10103,7 +10103,7 @@ exports[`Select demo examples placeholder 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-82-content"
+                                  id="select-92-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -10123,7 +10123,7 @@ exports[`Select demo examples placeholder 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-82"
+                              id="select-92"
                               isOpen={false}
                               onClose={[Function]}
                               onOpen={[Function]}
@@ -10134,21 +10134,21 @@ exports[`Select demo examples placeholder 1`] = `
                             >
                               <Manager
                                 className="glamor-9"
-                                id="select-82"
+                                id="select-92"
                                 tag="span"
                               >
                                 <span
                                   className="glamor-9"
-                                  id="select-82"
+                                  id="select-92"
                                 >
                                   <PopoverTrigger
                                     aria-activedescendant={undefined}
-                                    aria-describedby="select-82-content"
+                                    aria-describedby="select-92-content"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={undefined}
-                                    aria-owns="select-82-content"
+                                    aria-owns="select-92-content"
                                     aria-readonly={undefined}
                                     aria-required={undefined}
                                     disabled={undefined}
@@ -10171,12 +10171,12 @@ exports[`Select demo examples placeholder 1`] = `
                                         >
                                           <SelectTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-82-content"
+                                            aria-describedby="select-92-content"
                                             aria-disabled={undefined}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={undefined}
-                                            aria-owns="select-82-content"
+                                            aria-owns="select-92-content"
                                             aria-readonly={undefined}
                                             aria-required={undefined}
                                             disabled={undefined}
@@ -10214,12 +10214,12 @@ exports[`Select demo examples placeholder 1`] = `
                                                 ]
                                               }
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-82-content"
+                                              aria-describedby="select-92-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-82-content"
+                                              aria-owns="select-92-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               control={[Function]}
@@ -10261,12 +10261,12 @@ exports[`Select demo examples placeholder 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-82-content"
+                                                aria-describedby="select-92-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-82-content"
+                                                aria-owns="select-92-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 className="glamor-5"
@@ -10292,12 +10292,12 @@ exports[`Select demo examples placeholder 1`] = `
                                               >
                                                 <FauxControl
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-82-content"
+                                                  aria-describedby="select-92-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-82-content"
+                                                  aria-owns="select-92-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   className="glamor-5"
@@ -10315,12 +10315,12 @@ exports[`Select demo examples placeholder 1`] = `
                                                 >
                                                   <div
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-82-content"
+                                                    aria-describedby="select-92-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-82-content"
+                                                    aria-owns="select-92-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-4"
@@ -10979,7 +10979,7 @@ exports[`Select demo examples placement 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-109"
+                    id="select-119"
                     isOpen={true}
                     modifiers={
                       Object {
@@ -11016,7 +11016,7 @@ exports[`Select demo examples placement 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-109"
+                      id="select-119"
                       isOpen={true}
                       modifiers={
                         Object {
@@ -11053,7 +11053,7 @@ exports[`Select demo examples placement 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-109"
+                        id="select-119"
                         isOpen={true}
                         modifiers={
                           Object {
@@ -11092,7 +11092,7 @@ exports[`Select demo examples placement 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-109"
+                              id="select-119"
                               isOpen={true}
                               modifiers={
                                 Object {
@@ -11128,7 +11128,7 @@ exports[`Select demo examples placement 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-109-content"
+                                    id="select-119-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -11148,7 +11148,7 @@ exports[`Select demo examples placement 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-109"
+                                id="select-119"
                                 isOpen={true}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -11178,7 +11178,7 @@ exports[`Select demo examples placement 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-109-content"
+                                      id="select-119-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -11198,7 +11198,7 @@ exports[`Select demo examples placement 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-109"
+                                  id="select-119"
                                   isOpen={true}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -11209,21 +11209,21 @@ exports[`Select demo examples placement 1`] = `
                                 >
                                   <Manager
                                     className="glamor-30"
-                                    id="select-109"
+                                    id="select-119"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-30"
-                                      id="select-109"
+                                      id="select-119"
                                     >
                                       <PopoverTrigger
-                                        aria-activedescendant="select-109-menu"
-                                        aria-describedby="select-109-content"
+                                        aria-activedescendant="select-119-menu"
+                                        aria-describedby="select-119-content"
                                         aria-disabled={undefined}
                                         aria-expanded={true}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-109-content"
+                                        aria-owns="select-119-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -11245,13 +11245,13 @@ exports[`Select demo examples placement 1`] = `
                                               className="glamor-7"
                                             >
                                               <SelectTrigger
-                                                aria-activedescendant="select-109-menu"
-                                                aria-describedby="select-109-content"
+                                                aria-activedescendant="select-119-menu"
+                                                aria-describedby="select-119-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={true}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-109-content"
+                                                aria-owns="select-119-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -11288,13 +11288,13 @@ exports[`Select demo examples placement 1`] = `
                                                       />,
                                                     ]
                                                   }
-                                                  aria-activedescendant="select-109-menu"
-                                                  aria-describedby="select-109-content"
+                                                  aria-activedescendant="select-119-menu"
+                                                  aria-describedby="select-119-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={true}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-109-content"
+                                                  aria-owns="select-119-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -11335,13 +11335,13 @@ exports[`Select demo examples placement 1`] = `
                                                         />,
                                                       ]
                                                     }
-                                                    aria-activedescendant="select-109-menu"
-                                                    aria-describedby="select-109-content"
+                                                    aria-activedescendant="select-119-menu"
+                                                    aria-describedby="select-119-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={true}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-109-content"
+                                                    aria-owns="select-119-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -11366,13 +11366,13 @@ exports[`Select demo examples placement 1`] = `
                                                     variant={undefined}
                                                   >
                                                     <FauxControl
-                                                      aria-activedescendant="select-109-menu"
-                                                      aria-describedby="select-109-content"
+                                                      aria-activedescendant="select-119-menu"
+                                                      aria-describedby="select-119-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={true}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-109-content"
+                                                      aria-owns="select-119-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -11389,13 +11389,13 @@ exports[`Select demo examples placement 1`] = `
                                                       variant={undefined}
                                                     >
                                                       <div
-                                                        aria-activedescendant="select-109-menu"
-                                                        aria-describedby="select-109-content"
+                                                        aria-activedescendant="select-119-menu"
+                                                        aria-describedby="select-119-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={true}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-109-content"
+                                                        aria-owns="select-119-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -11530,7 +11530,7 @@ exports[`Select demo examples placement 1`] = `
                                         }
                                         getItemProps={[Function]}
                                         getMenuProps={[Function]}
-                                        id="select-109-content"
+                                        id="select-119-content"
                                         modifiers={
                                           Object {
                                             "contentWidth": Object {
@@ -11543,7 +11543,7 @@ exports[`Select demo examples placement 1`] = `
                                         wide={undefined}
                                       >
                                         <DropdownContent
-                                          id="select-109-content"
+                                          id="select-119-content"
                                           modifiers={
                                             Object {
                                               "contentWidth": Object {
@@ -11557,7 +11557,7 @@ exports[`Select demo examples placement 1`] = `
                                         >
                                           <ThemedComponent
                                             className="glamor-26"
-                                            id="select-109-content"
+                                            id="select-119-content"
                                             modifiers={
                                               Object {
                                                 "contentWidth": Object {
@@ -11570,7 +11570,7 @@ exports[`Select demo examples placement 1`] = `
                                           >
                                             <RtlPopper
                                               className="glamor-26"
-                                              id="select-109-content"
+                                              id="select-119-content"
                                               modifiers={
                                                 Object {
                                                   "contentWidth": Object {
@@ -11757,7 +11757,7 @@ exports[`Select demo examples placement 1`] = `
                                                 className="glamor-26"
                                                 component="div"
                                                 eventsEnabled={true}
-                                                id="select-109-content"
+                                                id="select-119-content"
                                                 modifiers={
                                                   Object {
                                                     "contentWidth": Object {
@@ -11772,7 +11772,7 @@ exports[`Select demo examples placement 1`] = `
                                                   className="glamor-26"
                                                   data-placement={undefined}
                                                   data-x-out-of-boundaries={undefined}
-                                                  id="select-109-content"
+                                                  id="select-119-content"
                                                   style={
                                                     Object {
                                                       "opacity": 0,
@@ -11799,16 +11799,16 @@ exports[`Select demo examples placement 1`] = `
                                                       ]
                                                     }
                                                     getItemProps={[Function]}
-                                                    id="select-109-menu"
+                                                    id="select-119-menu"
                                                     role="listbox"
                                                   >
                                                     <Menu
-                                                      id="select-109-menu"
+                                                      id="select-119-menu"
                                                       role="listbox"
                                                     >
                                                       <div
                                                         className="glamor-25"
-                                                        id="select-109-menu"
+                                                        id="select-119-menu"
                                                         role="listbox"
                                                       >
                                                         <MenuGroup
@@ -11822,7 +11822,7 @@ exports[`Select demo examples placement 1`] = `
                                                               <MenuItem
                                                                 aria-disabled={undefined}
                                                                 aria-selected={false}
-                                                                id="select-109-item-0"
+                                                                id="select-119-item-0"
                                                                 isHighlighted={false}
                                                                 item={
                                                                   Object {
@@ -11840,7 +11840,7 @@ exports[`Select demo examples placement 1`] = `
                                                                   aria-disabled={undefined}
                                                                   aria-selected={false}
                                                                   disabled={undefined}
-                                                                  id="select-109-item-0"
+                                                                  id="select-119-item-0"
                                                                   isHighlighted={false}
                                                                   item={
                                                                     Object {
@@ -11859,7 +11859,7 @@ exports[`Select demo examples placement 1`] = `
                                                                     aria-disabled={undefined}
                                                                     aria-selected={false}
                                                                     className="glamor-13"
-                                                                    id="select-109-item-0"
+                                                                    id="select-119-item-0"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     role="option"
@@ -11895,7 +11895,7 @@ exports[`Select demo examples placement 1`] = `
                                                               <MenuItem
                                                                 aria-disabled={undefined}
                                                                 aria-selected={false}
-                                                                id="select-109-item-1"
+                                                                id="select-119-item-1"
                                                                 isHighlighted={false}
                                                                 item={
                                                                   Object {
@@ -11913,7 +11913,7 @@ exports[`Select demo examples placement 1`] = `
                                                                   aria-disabled={undefined}
                                                                   aria-selected={false}
                                                                   disabled={undefined}
-                                                                  id="select-109-item-1"
+                                                                  id="select-119-item-1"
                                                                   isHighlighted={false}
                                                                   item={
                                                                     Object {
@@ -11932,7 +11932,7 @@ exports[`Select demo examples placement 1`] = `
                                                                     aria-disabled={undefined}
                                                                     aria-selected={false}
                                                                     className="glamor-13"
-                                                                    id="select-109-item-1"
+                                                                    id="select-119-item-1"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     role="option"
@@ -11968,7 +11968,7 @@ exports[`Select demo examples placement 1`] = `
                                                               <MenuItem
                                                                 aria-disabled={undefined}
                                                                 aria-selected={false}
-                                                                id="select-109-item-2"
+                                                                id="select-119-item-2"
                                                                 isHighlighted={false}
                                                                 item={
                                                                   Object {
@@ -11986,7 +11986,7 @@ exports[`Select demo examples placement 1`] = `
                                                                   aria-disabled={undefined}
                                                                   aria-selected={false}
                                                                   disabled={undefined}
-                                                                  id="select-109-item-2"
+                                                                  id="select-119-item-2"
                                                                   isHighlighted={false}
                                                                   item={
                                                                     Object {
@@ -12005,7 +12005,7 @@ exports[`Select demo examples placement 1`] = `
                                                                     aria-disabled={undefined}
                                                                     aria-selected={false}
                                                                     className="glamor-13"
-                                                                    id="select-109-item-2"
+                                                                    id="select-119-item-2"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     role="option"
@@ -12645,7 +12645,7 @@ exports[`Select demo examples portal 1`] = `
                                   getMenuProps={[Function]}
                                   getTriggerProps={[Function]}
                                   highlightedIndex={undefined}
-                                  id="select-115"
+                                  id="select-125"
                                   isOpen={true}
                                   modifiers={
                                     Object {
@@ -12686,7 +12686,7 @@ exports[`Select demo examples portal 1`] = `
                                     getMenuProps={[Function]}
                                     getTriggerProps={[Function]}
                                     highlightedIndex={undefined}
-                                    id="select-115"
+                                    id="select-125"
                                     isOpen={true}
                                     modifiers={
                                       Object {
@@ -12727,7 +12727,7 @@ exports[`Select demo examples portal 1`] = `
                                       getMenuProps={[Function]}
                                       getTriggerProps={[Function]}
                                       highlightedIndex={undefined}
-                                      id="select-115"
+                                      id="select-125"
                                       isOpen={true}
                                       modifiers={
                                         Object {
@@ -12770,7 +12770,7 @@ exports[`Select demo examples portal 1`] = `
                                             getMenuProps={[Function]}
                                             getTriggerProps={[Function]}
                                             highlightedIndex={undefined}
-                                            id="select-115"
+                                            id="select-125"
                                             isOpen={true}
                                             modifiers={
                                               Object {
@@ -12810,7 +12810,7 @@ exports[`Select demo examples portal 1`] = `
                                                   }
                                                   getItemProps={[Function]}
                                                   getMenuProps={[Function]}
-                                                  id="select-115-content"
+                                                  id="select-125-content"
                                                   modifiers={
                                                     Object {
                                                       "contentWidth": Object {
@@ -12833,7 +12833,7 @@ exports[`Select demo examples portal 1`] = `
                                               getTriggerProps={[Function]}
                                               hasArrow={true}
                                               highlightedIndex={undefined}
-                                              id="select-115"
+                                              id="select-125"
                                               isOpen={true}
                                               onClose={[Function]}
                                               onOpen={[Function]}
@@ -12864,7 +12864,7 @@ exports[`Select demo examples portal 1`] = `
                                                     }
                                                     getItemProps={[Function]}
                                                     getMenuProps={[Function]}
-                                                    id="select-115-content"
+                                                    id="select-125-content"
                                                     modifiers={
                                                       Object {
                                                         "contentWidth": Object {
@@ -12887,7 +12887,7 @@ exports[`Select demo examples portal 1`] = `
                                                 getTriggerProps={[Function]}
                                                 hasArrow={true}
                                                 highlightedIndex={undefined}
-                                                id="select-115"
+                                                id="select-125"
                                                 isOpen={true}
                                                 onClose={[Function]}
                                                 onOpen={[Function]}
@@ -12899,21 +12899,21 @@ exports[`Select demo examples portal 1`] = `
                                               >
                                                 <Manager
                                                   className="glamor-9"
-                                                  id="select-115"
+                                                  id="select-125"
                                                   tag="span"
                                                 >
                                                   <span
                                                     className="glamor-9"
-                                                    id="select-115"
+                                                    id="select-125"
                                                   >
                                                     <PopoverTrigger
-                                                      aria-activedescendant="select-115-menu"
-                                                      aria-describedby="select-115-content"
+                                                      aria-activedescendant="select-125-menu"
+                                                      aria-describedby="select-125-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={true}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-115-content"
+                                                      aria-owns="select-125-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       disabled={undefined}
@@ -12935,13 +12935,13 @@ exports[`Select demo examples portal 1`] = `
                                                             className="glamor-7"
                                                           >
                                                             <SelectTrigger
-                                                              aria-activedescendant="select-115-menu"
-                                                              aria-describedby="select-115-content"
+                                                              aria-activedescendant="select-125-menu"
+                                                              aria-describedby="select-125-content"
                                                               aria-disabled={undefined}
                                                               aria-expanded={true}
                                                               aria-haspopup="listbox"
                                                               aria-invalid={undefined}
-                                                              aria-owns="select-115-content"
+                                                              aria-owns="select-125-content"
                                                               aria-readonly={undefined}
                                                               aria-required={undefined}
                                                               disabled={undefined}
@@ -12978,13 +12978,13 @@ exports[`Select demo examples portal 1`] = `
                                                                     />,
                                                                   ]
                                                                 }
-                                                                aria-activedescendant="select-115-menu"
-                                                                aria-describedby="select-115-content"
+                                                                aria-activedescendant="select-125-menu"
+                                                                aria-describedby="select-125-content"
                                                                 aria-disabled={undefined}
                                                                 aria-expanded={true}
                                                                 aria-haspopup="listbox"
                                                                 aria-invalid={undefined}
-                                                                aria-owns="select-115-content"
+                                                                aria-owns="select-125-content"
                                                                 aria-readonly={undefined}
                                                                 aria-required={undefined}
                                                                 control={[Function]}
@@ -13025,13 +13025,13 @@ exports[`Select demo examples portal 1`] = `
                                                                       />,
                                                                     ]
                                                                   }
-                                                                  aria-activedescendant="select-115-menu"
-                                                                  aria-describedby="select-115-content"
+                                                                  aria-activedescendant="select-125-menu"
+                                                                  aria-describedby="select-125-content"
                                                                   aria-disabled={undefined}
                                                                   aria-expanded={true}
                                                                   aria-haspopup="listbox"
                                                                   aria-invalid={undefined}
-                                                                  aria-owns="select-115-content"
+                                                                  aria-owns="select-125-content"
                                                                   aria-readonly={undefined}
                                                                   aria-required={undefined}
                                                                   className="glamor-5"
@@ -13056,13 +13056,13 @@ exports[`Select demo examples portal 1`] = `
                                                                   variant={undefined}
                                                                 >
                                                                   <FauxControl
-                                                                    aria-activedescendant="select-115-menu"
-                                                                    aria-describedby="select-115-content"
+                                                                    aria-activedescendant="select-125-menu"
+                                                                    aria-describedby="select-125-content"
                                                                     aria-disabled={undefined}
                                                                     aria-expanded={true}
                                                                     aria-haspopup="listbox"
                                                                     aria-invalid={undefined}
-                                                                    aria-owns="select-115-content"
+                                                                    aria-owns="select-125-content"
                                                                     aria-readonly={undefined}
                                                                     aria-required={undefined}
                                                                     className="glamor-5"
@@ -13079,13 +13079,13 @@ exports[`Select demo examples portal 1`] = `
                                                                     variant={undefined}
                                                                   >
                                                                     <div
-                                                                      aria-activedescendant="select-115-menu"
-                                                                      aria-describedby="select-115-content"
+                                                                      aria-activedescendant="select-125-menu"
+                                                                      aria-describedby="select-125-content"
                                                                       aria-disabled={undefined}
                                                                       aria-expanded={true}
                                                                       aria-haspopup="listbox"
                                                                       aria-invalid={undefined}
-                                                                      aria-owns="select-115-content"
+                                                                      aria-owns="select-125-content"
                                                                       aria-readonly={undefined}
                                                                       aria-required={undefined}
                                                                       className="glamor-4"
@@ -13635,7 +13635,7 @@ exports[`Select demo examples read-only 1`] = `
                 getMenuProps={[Function]}
                 getTriggerProps={[Function]}
                 highlightedIndex={undefined}
-                id="select-86"
+                id="select-96"
                 isOpen={false}
                 modifiers={
                   Object {
@@ -13678,7 +13678,7 @@ exports[`Select demo examples read-only 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-86"
+                  id="select-96"
                   isOpen={false}
                   modifiers={
                     Object {
@@ -13721,7 +13721,7 @@ exports[`Select demo examples read-only 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-86"
+                    id="select-96"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -13766,7 +13766,7 @@ exports[`Select demo examples read-only 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-86"
+                          id="select-96"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -13808,7 +13808,7 @@ exports[`Select demo examples read-only 1`] = `
                                 }
                                 getItemProps={[Function]}
                                 getMenuProps={[Function]}
-                                id="select-86-content"
+                                id="select-96-content"
                                 modifiers={
                                   Object {
                                     "contentWidth": Object {
@@ -13828,7 +13828,7 @@ exports[`Select demo examples read-only 1`] = `
                             getTriggerProps={[Function]}
                             hasArrow={true}
                             highlightedIndex={undefined}
-                            id="select-86"
+                            id="select-96"
                             isOpen={false}
                             onClose={[Function]}
                             onOpen={[Function]}
@@ -13864,7 +13864,7 @@ exports[`Select demo examples read-only 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-86-content"
+                                  id="select-96-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -13884,7 +13884,7 @@ exports[`Select demo examples read-only 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-86"
+                              id="select-96"
                               isOpen={false}
                               onClose={[Function]}
                               onOpen={[Function]}
@@ -13901,21 +13901,21 @@ exports[`Select demo examples read-only 1`] = `
                             >
                               <Manager
                                 className="glamor-9"
-                                id="select-86"
+                                id="select-96"
                                 tag="span"
                               >
                                 <span
                                   className="glamor-9"
-                                  id="select-86"
+                                  id="select-96"
                                 >
                                   <PopoverTrigger
                                     aria-activedescendant={undefined}
-                                    aria-describedby="select-86-content"
+                                    aria-describedby="select-96-content"
                                     aria-disabled={true}
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={undefined}
-                                    aria-owns="select-86-content"
+                                    aria-owns="select-96-content"
                                     aria-readonly={true}
                                     aria-required={undefined}
                                     disabled={undefined}
@@ -13938,12 +13938,12 @@ exports[`Select demo examples read-only 1`] = `
                                         >
                                           <SelectTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-86-content"
+                                            aria-describedby="select-96-content"
                                             aria-disabled={true}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={undefined}
-                                            aria-owns="select-86-content"
+                                            aria-owns="select-96-content"
                                             aria-readonly={true}
                                             aria-required={undefined}
                                             disabled={undefined}
@@ -13986,12 +13986,12 @@ exports[`Select demo examples read-only 1`] = `
                                                 ]
                                               }
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-86-content"
+                                              aria-describedby="select-96-content"
                                               aria-disabled={true}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-86-content"
+                                              aria-owns="select-96-content"
                                               aria-readonly={true}
                                               aria-required={undefined}
                                               control={[Function]}
@@ -14041,12 +14041,12 @@ exports[`Select demo examples read-only 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-86-content"
+                                                aria-describedby="select-96-content"
                                                 aria-disabled={true}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-86-content"
+                                                aria-owns="select-96-content"
                                                 aria-readonly={true}
                                                 aria-required={undefined}
                                                 className="glamor-5"
@@ -14080,12 +14080,12 @@ exports[`Select demo examples read-only 1`] = `
                                               >
                                                 <FauxControl
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-86-content"
+                                                  aria-describedby="select-96-content"
                                                   aria-disabled={true}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-86-content"
+                                                  aria-owns="select-96-content"
                                                   aria-readonly={true}
                                                   aria-required={undefined}
                                                   className="glamor-5"
@@ -14109,12 +14109,12 @@ exports[`Select demo examples read-only 1`] = `
                                                 >
                                                   <div
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-86-content"
+                                                    aria-describedby="select-96-content"
                                                     aria-disabled={true}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-86-content"
+                                                    aria-owns="select-96-content"
                                                     aria-readonly={true}
                                                     aria-required={undefined}
                                                     className="glamor-4"
@@ -14583,7 +14583,7 @@ exports[`Select demo examples required 1`] = `
                 getMenuProps={[Function]}
                 getTriggerProps={[Function]}
                 highlightedIndex={undefined}
-                id="select-88"
+                id="select-98"
                 isOpen={false}
                 modifiers={
                   Object {
@@ -14621,7 +14621,7 @@ exports[`Select demo examples required 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-88"
+                  id="select-98"
                   isOpen={false}
                   modifiers={
                     Object {
@@ -14659,7 +14659,7 @@ exports[`Select demo examples required 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-88"
+                    id="select-98"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -14699,7 +14699,7 @@ exports[`Select demo examples required 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-88"
+                          id="select-98"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -14736,7 +14736,7 @@ exports[`Select demo examples required 1`] = `
                                 }
                                 getItemProps={[Function]}
                                 getMenuProps={[Function]}
-                                id="select-88-content"
+                                id="select-98-content"
                                 modifiers={
                                   Object {
                                     "contentWidth": Object {
@@ -14756,7 +14756,7 @@ exports[`Select demo examples required 1`] = `
                             getTriggerProps={[Function]}
                             hasArrow={true}
                             highlightedIndex={undefined}
-                            id="select-88"
+                            id="select-98"
                             isOpen={false}
                             onClose={[Function]}
                             onOpen={[Function]}
@@ -14787,7 +14787,7 @@ exports[`Select demo examples required 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-88-content"
+                                  id="select-98-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -14807,7 +14807,7 @@ exports[`Select demo examples required 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-88"
+                              id="select-98"
                               isOpen={false}
                               onClose={[Function]}
                               onOpen={[Function]}
@@ -14819,21 +14819,21 @@ exports[`Select demo examples required 1`] = `
                             >
                               <Manager
                                 className="glamor-9"
-                                id="select-88"
+                                id="select-98"
                                 tag="span"
                               >
                                 <span
                                   className="glamor-9"
-                                  id="select-88"
+                                  id="select-98"
                                 >
                                   <PopoverTrigger
                                     aria-activedescendant={undefined}
-                                    aria-describedby="select-88-content"
+                                    aria-describedby="select-98-content"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={undefined}
-                                    aria-owns="select-88-content"
+                                    aria-owns="select-98-content"
                                     aria-readonly={undefined}
                                     aria-required={true}
                                     disabled={undefined}
@@ -14856,12 +14856,12 @@ exports[`Select demo examples required 1`] = `
                                         >
                                           <SelectTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-88-content"
+                                            aria-describedby="select-98-content"
                                             aria-disabled={undefined}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={undefined}
-                                            aria-owns="select-88-content"
+                                            aria-owns="select-98-content"
                                             aria-readonly={undefined}
                                             aria-required={true}
                                             disabled={undefined}
@@ -14899,12 +14899,12 @@ exports[`Select demo examples required 1`] = `
                                                 ]
                                               }
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-88-content"
+                                              aria-describedby="select-98-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-88-content"
+                                              aria-owns="select-98-content"
                                               aria-readonly={undefined}
                                               aria-required={true}
                                               control={[Function]}
@@ -14946,12 +14946,12 @@ exports[`Select demo examples required 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-88-content"
+                                                aria-describedby="select-98-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-88-content"
+                                                aria-owns="select-98-content"
                                                 aria-readonly={undefined}
                                                 aria-required={true}
                                                 className="glamor-5"
@@ -14977,12 +14977,12 @@ exports[`Select demo examples required 1`] = `
                                               >
                                                 <FauxControl
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-88-content"
+                                                  aria-describedby="select-98-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-88-content"
+                                                  aria-owns="select-98-content"
                                                   aria-readonly={undefined}
                                                   aria-required={true}
                                                   className="glamor-5"
@@ -15000,12 +15000,12 @@ exports[`Select demo examples required 1`] = `
                                                 >
                                                   <div
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-88-content"
+                                                    aria-describedby="select-98-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-88-content"
+                                                    aria-owns="select-98-content"
                                                     aria-readonly={undefined}
                                                     aria-required={true}
                                                     className="glamor-4"
@@ -15686,7 +15686,7 @@ exports[`Select demo examples rtl 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-119"
+                          id="select-129"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -15723,7 +15723,7 @@ exports[`Select demo examples rtl 1`] = `
                             getMenuProps={[Function]}
                             getTriggerProps={[Function]}
                             highlightedIndex={undefined}
-                            id="select-119"
+                            id="select-129"
                             isOpen={false}
                             modifiers={
                               Object {
@@ -15760,7 +15760,7 @@ exports[`Select demo examples rtl 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-119"
+                              id="select-129"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -15799,7 +15799,7 @@ exports[`Select demo examples rtl 1`] = `
                                     getMenuProps={[Function]}
                                     getTriggerProps={[Function]}
                                     highlightedIndex={undefined}
-                                    id="select-119"
+                                    id="select-129"
                                     isOpen={false}
                                     modifiers={
                                       Object {
@@ -15835,7 +15835,7 @@ exports[`Select demo examples rtl 1`] = `
                                           }
                                           getItemProps={[Function]}
                                           getMenuProps={[Function]}
-                                          id="select-119-content"
+                                          id="select-129-content"
                                           modifiers={
                                             Object {
                                               "contentWidth": Object {
@@ -15855,7 +15855,7 @@ exports[`Select demo examples rtl 1`] = `
                                       getTriggerProps={[Function]}
                                       hasArrow={true}
                                       highlightedIndex={undefined}
-                                      id="select-119"
+                                      id="select-129"
                                       isOpen={false}
                                       onClose={[Function]}
                                       onOpen={[Function]}
@@ -15885,7 +15885,7 @@ exports[`Select demo examples rtl 1`] = `
                                             }
                                             getItemProps={[Function]}
                                             getMenuProps={[Function]}
-                                            id="select-119-content"
+                                            id="select-129-content"
                                             modifiers={
                                               Object {
                                                 "contentWidth": Object {
@@ -15905,7 +15905,7 @@ exports[`Select demo examples rtl 1`] = `
                                         getTriggerProps={[Function]}
                                         hasArrow={true}
                                         highlightedIndex={undefined}
-                                        id="select-119"
+                                        id="select-129"
                                         isOpen={false}
                                         onClose={[Function]}
                                         onOpen={[Function]}
@@ -15916,21 +15916,21 @@ exports[`Select demo examples rtl 1`] = `
                                       >
                                         <Manager
                                           className="glamor-9"
-                                          id="select-119"
+                                          id="select-129"
                                           tag="span"
                                         >
                                           <span
                                             className="glamor-9"
-                                            id="select-119"
+                                            id="select-129"
                                           >
                                             <PopoverTrigger
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-119-content"
+                                              aria-describedby="select-129-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-119-content"
+                                              aria-owns="select-129-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               disabled={undefined}
@@ -15953,12 +15953,12 @@ exports[`Select demo examples rtl 1`] = `
                                                   >
                                                     <SelectTrigger
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-119-content"
+                                                      aria-describedby="select-129-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-119-content"
+                                                      aria-owns="select-129-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       disabled={undefined}
@@ -15996,12 +15996,12 @@ exports[`Select demo examples rtl 1`] = `
                                                           ]
                                                         }
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-119-content"
+                                                        aria-describedby="select-129-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-119-content"
+                                                        aria-owns="select-129-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         control={[Function]}
@@ -16043,12 +16043,12 @@ exports[`Select demo examples rtl 1`] = `
                                                             ]
                                                           }
                                                           aria-activedescendant={undefined}
-                                                          aria-describedby="select-119-content"
+                                                          aria-describedby="select-129-content"
                                                           aria-disabled={undefined}
                                                           aria-expanded={false}
                                                           aria-haspopup="listbox"
                                                           aria-invalid={undefined}
-                                                          aria-owns="select-119-content"
+                                                          aria-owns="select-129-content"
                                                           aria-readonly={undefined}
                                                           aria-required={undefined}
                                                           className="glamor-5"
@@ -16074,12 +16074,12 @@ exports[`Select demo examples rtl 1`] = `
                                                         >
                                                           <FauxControl
                                                             aria-activedescendant={undefined}
-                                                            aria-describedby="select-119-content"
+                                                            aria-describedby="select-129-content"
                                                             aria-disabled={undefined}
                                                             aria-expanded={false}
                                                             aria-haspopup="listbox"
                                                             aria-invalid={undefined}
-                                                            aria-owns="select-119-content"
+                                                            aria-owns="select-129-content"
                                                             aria-readonly={undefined}
                                                             aria-required={undefined}
                                                             className="glamor-5"
@@ -16097,12 +16097,12 @@ exports[`Select demo examples rtl 1`] = `
                                                           >
                                                             <div
                                                               aria-activedescendant={undefined}
-                                                              aria-describedby="select-119-content"
+                                                              aria-describedby="select-129-content"
                                                               aria-disabled={undefined}
                                                               aria-expanded={false}
                                                               aria-haspopup="listbox"
                                                               aria-invalid={undefined}
-                                                              aria-owns="select-119-content"
+                                                              aria-owns="select-129-content"
                                                               aria-readonly={undefined}
                                                               aria-required={undefined}
                                                               className="glamor-4"
@@ -16273,7 +16273,7 @@ exports[`Select demo examples rtl 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-121"
+                          id="select-131"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -16310,7 +16310,7 @@ exports[`Select demo examples rtl 1`] = `
                             getMenuProps={[Function]}
                             getTriggerProps={[Function]}
                             highlightedIndex={undefined}
-                            id="select-121"
+                            id="select-131"
                             isOpen={false}
                             modifiers={
                               Object {
@@ -16347,7 +16347,7 @@ exports[`Select demo examples rtl 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-121"
+                              id="select-131"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -16386,7 +16386,7 @@ exports[`Select demo examples rtl 1`] = `
                                     getMenuProps={[Function]}
                                     getTriggerProps={[Function]}
                                     highlightedIndex={undefined}
-                                    id="select-121"
+                                    id="select-131"
                                     isOpen={false}
                                     modifiers={
                                       Object {
@@ -16422,7 +16422,7 @@ exports[`Select demo examples rtl 1`] = `
                                           }
                                           getItemProps={[Function]}
                                           getMenuProps={[Function]}
-                                          id="select-121-content"
+                                          id="select-131-content"
                                           modifiers={
                                             Object {
                                               "contentWidth": Object {
@@ -16442,7 +16442,7 @@ exports[`Select demo examples rtl 1`] = `
                                       getTriggerProps={[Function]}
                                       hasArrow={true}
                                       highlightedIndex={undefined}
-                                      id="select-121"
+                                      id="select-131"
                                       isOpen={false}
                                       onClose={[Function]}
                                       onOpen={[Function]}
@@ -16472,7 +16472,7 @@ exports[`Select demo examples rtl 1`] = `
                                             }
                                             getItemProps={[Function]}
                                             getMenuProps={[Function]}
-                                            id="select-121-content"
+                                            id="select-131-content"
                                             modifiers={
                                               Object {
                                                 "contentWidth": Object {
@@ -16492,7 +16492,7 @@ exports[`Select demo examples rtl 1`] = `
                                         getTriggerProps={[Function]}
                                         hasArrow={true}
                                         highlightedIndex={undefined}
-                                        id="select-121"
+                                        id="select-131"
                                         isOpen={false}
                                         onClose={[Function]}
                                         onOpen={[Function]}
@@ -16503,21 +16503,21 @@ exports[`Select demo examples rtl 1`] = `
                                       >
                                         <Manager
                                           className="glamor-9"
-                                          id="select-121"
+                                          id="select-131"
                                           tag="span"
                                         >
                                           <span
                                             className="glamor-9"
-                                            id="select-121"
+                                            id="select-131"
                                           >
                                             <PopoverTrigger
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-121-content"
+                                              aria-describedby="select-131-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-121-content"
+                                              aria-owns="select-131-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               disabled={undefined}
@@ -16540,12 +16540,12 @@ exports[`Select demo examples rtl 1`] = `
                                                   >
                                                     <SelectTrigger
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-121-content"
+                                                      aria-describedby="select-131-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-121-content"
+                                                      aria-owns="select-131-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       disabled={undefined}
@@ -16583,12 +16583,12 @@ exports[`Select demo examples rtl 1`] = `
                                                           ]
                                                         }
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-121-content"
+                                                        aria-describedby="select-131-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-121-content"
+                                                        aria-owns="select-131-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         control={[Function]}
@@ -16630,12 +16630,12 @@ exports[`Select demo examples rtl 1`] = `
                                                             ]
                                                           }
                                                           aria-activedescendant={undefined}
-                                                          aria-describedby="select-121-content"
+                                                          aria-describedby="select-131-content"
                                                           aria-disabled={undefined}
                                                           aria-expanded={false}
                                                           aria-haspopup="listbox"
                                                           aria-invalid={undefined}
-                                                          aria-owns="select-121-content"
+                                                          aria-owns="select-131-content"
                                                           aria-readonly={undefined}
                                                           aria-required={undefined}
                                                           className="glamor-22"
@@ -16661,12 +16661,12 @@ exports[`Select demo examples rtl 1`] = `
                                                         >
                                                           <FauxControl
                                                             aria-activedescendant={undefined}
-                                                            aria-describedby="select-121-content"
+                                                            aria-describedby="select-131-content"
                                                             aria-disabled={undefined}
                                                             aria-expanded={false}
                                                             aria-haspopup="listbox"
                                                             aria-invalid={undefined}
-                                                            aria-owns="select-121-content"
+                                                            aria-owns="select-131-content"
                                                             aria-readonly={undefined}
                                                             aria-required={undefined}
                                                             className="glamor-22"
@@ -16684,12 +16684,12 @@ exports[`Select demo examples rtl 1`] = `
                                                           >
                                                             <div
                                                               aria-activedescendant={undefined}
-                                                              aria-describedby="select-121-content"
+                                                              aria-describedby="select-131-content"
                                                               aria-disabled={undefined}
                                                               aria-expanded={false}
                                                               aria-haspopup="listbox"
                                                               aria-invalid={undefined}
-                                                              aria-owns="select-121-content"
+                                                              aria-owns="select-131-content"
                                                               aria-readonly={undefined}
                                                               aria-required={undefined}
                                                               className="glamor-21"
@@ -17570,7 +17570,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                   getMenuProps={[Function]}
                                   getTriggerProps={[Function]}
                                   highlightedIndex={undefined}
-                                  id="select-113"
+                                  id="select-123"
                                   isOpen={true}
                                   modifiers={
                                     Object {
@@ -17607,7 +17607,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                     getMenuProps={[Function]}
                                     getTriggerProps={[Function]}
                                     highlightedIndex={undefined}
-                                    id="select-113"
+                                    id="select-123"
                                     isOpen={true}
                                     modifiers={
                                       Object {
@@ -17644,7 +17644,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                       getMenuProps={[Function]}
                                       getTriggerProps={[Function]}
                                       highlightedIndex={undefined}
-                                      id="select-113"
+                                      id="select-123"
                                       isOpen={true}
                                       modifiers={
                                         Object {
@@ -17683,7 +17683,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                             getMenuProps={[Function]}
                                             getTriggerProps={[Function]}
                                             highlightedIndex={undefined}
-                                            id="select-113"
+                                            id="select-123"
                                             isOpen={true}
                                             modifiers={
                                               Object {
@@ -17719,7 +17719,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                   }
                                                   getItemProps={[Function]}
                                                   getMenuProps={[Function]}
-                                                  id="select-113-content"
+                                                  id="select-123-content"
                                                   modifiers={
                                                     Object {
                                                       "contentWidth": Object {
@@ -17739,7 +17739,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                               getTriggerProps={[Function]}
                                               hasArrow={true}
                                               highlightedIndex={undefined}
-                                              id="select-113"
+                                              id="select-123"
                                               isOpen={true}
                                               onClose={[Function]}
                                               onOpen={[Function]}
@@ -17769,7 +17769,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                     }
                                                     getItemProps={[Function]}
                                                     getMenuProps={[Function]}
-                                                    id="select-113-content"
+                                                    id="select-123-content"
                                                     modifiers={
                                                       Object {
                                                         "contentWidth": Object {
@@ -17789,7 +17789,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                 getTriggerProps={[Function]}
                                                 hasArrow={true}
                                                 highlightedIndex={undefined}
-                                                id="select-113"
+                                                id="select-123"
                                                 isOpen={true}
                                                 onClose={[Function]}
                                                 onOpen={[Function]}
@@ -17800,21 +17800,21 @@ exports[`Select demo examples scrolling-container 1`] = `
                                               >
                                                 <Manager
                                                   className="glamor-30"
-                                                  id="select-113"
+                                                  id="select-123"
                                                   tag="span"
                                                 >
                                                   <span
                                                     className="glamor-30"
-                                                    id="select-113"
+                                                    id="select-123"
                                                   >
                                                     <PopoverTrigger
-                                                      aria-activedescendant="select-113-menu"
-                                                      aria-describedby="select-113-content"
+                                                      aria-activedescendant="select-123-menu"
+                                                      aria-describedby="select-123-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={true}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-113-content"
+                                                      aria-owns="select-123-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       disabled={undefined}
@@ -17836,13 +17836,13 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                             className="glamor-7"
                                                           >
                                                             <SelectTrigger
-                                                              aria-activedescendant="select-113-menu"
-                                                              aria-describedby="select-113-content"
+                                                              aria-activedescendant="select-123-menu"
+                                                              aria-describedby="select-123-content"
                                                               aria-disabled={undefined}
                                                               aria-expanded={true}
                                                               aria-haspopup="listbox"
                                                               aria-invalid={undefined}
-                                                              aria-owns="select-113-content"
+                                                              aria-owns="select-123-content"
                                                               aria-readonly={undefined}
                                                               aria-required={undefined}
                                                               disabled={undefined}
@@ -17879,13 +17879,13 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                     />,
                                                                   ]
                                                                 }
-                                                                aria-activedescendant="select-113-menu"
-                                                                aria-describedby="select-113-content"
+                                                                aria-activedescendant="select-123-menu"
+                                                                aria-describedby="select-123-content"
                                                                 aria-disabled={undefined}
                                                                 aria-expanded={true}
                                                                 aria-haspopup="listbox"
                                                                 aria-invalid={undefined}
-                                                                aria-owns="select-113-content"
+                                                                aria-owns="select-123-content"
                                                                 aria-readonly={undefined}
                                                                 aria-required={undefined}
                                                                 control={[Function]}
@@ -17926,13 +17926,13 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                       />,
                                                                     ]
                                                                   }
-                                                                  aria-activedescendant="select-113-menu"
-                                                                  aria-describedby="select-113-content"
+                                                                  aria-activedescendant="select-123-menu"
+                                                                  aria-describedby="select-123-content"
                                                                   aria-disabled={undefined}
                                                                   aria-expanded={true}
                                                                   aria-haspopup="listbox"
                                                                   aria-invalid={undefined}
-                                                                  aria-owns="select-113-content"
+                                                                  aria-owns="select-123-content"
                                                                   aria-readonly={undefined}
                                                                   aria-required={undefined}
                                                                   className="glamor-5"
@@ -17957,13 +17957,13 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                   variant={undefined}
                                                                 >
                                                                   <FauxControl
-                                                                    aria-activedescendant="select-113-menu"
-                                                                    aria-describedby="select-113-content"
+                                                                    aria-activedescendant="select-123-menu"
+                                                                    aria-describedby="select-123-content"
                                                                     aria-disabled={undefined}
                                                                     aria-expanded={true}
                                                                     aria-haspopup="listbox"
                                                                     aria-invalid={undefined}
-                                                                    aria-owns="select-113-content"
+                                                                    aria-owns="select-123-content"
                                                                     aria-readonly={undefined}
                                                                     aria-required={undefined}
                                                                     className="glamor-5"
@@ -17980,13 +17980,13 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                     variant={undefined}
                                                                   >
                                                                     <div
-                                                                      aria-activedescendant="select-113-menu"
-                                                                      aria-describedby="select-113-content"
+                                                                      aria-activedescendant="select-123-menu"
+                                                                      aria-describedby="select-123-content"
                                                                       aria-disabled={undefined}
                                                                       aria-expanded={true}
                                                                       aria-haspopup="listbox"
                                                                       aria-invalid={undefined}
-                                                                      aria-owns="select-113-content"
+                                                                      aria-owns="select-123-content"
                                                                       aria-readonly={undefined}
                                                                       aria-required={undefined}
                                                                       className="glamor-4"
@@ -18121,7 +18121,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                       }
                                                       getItemProps={[Function]}
                                                       getMenuProps={[Function]}
-                                                      id="select-113-content"
+                                                      id="select-123-content"
                                                       modifiers={
                                                         Object {
                                                           "contentWidth": Object {
@@ -18134,7 +18134,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                       wide={undefined}
                                                     >
                                                       <DropdownContent
-                                                        id="select-113-content"
+                                                        id="select-123-content"
                                                         modifiers={
                                                           Object {
                                                             "contentWidth": Object {
@@ -18148,7 +18148,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                       >
                                                         <ThemedComponent
                                                           className="glamor-26"
-                                                          id="select-113-content"
+                                                          id="select-123-content"
                                                           modifiers={
                                                             Object {
                                                               "contentWidth": Object {
@@ -18161,7 +18161,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                         >
                                                           <RtlPopper
                                                             className="glamor-26"
-                                                            id="select-113-content"
+                                                            id="select-123-content"
                                                             modifiers={
                                                               Object {
                                                                 "contentWidth": Object {
@@ -18348,7 +18348,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                               className="glamor-26"
                                                               component="div"
                                                               eventsEnabled={true}
-                                                              id="select-113-content"
+                                                              id="select-123-content"
                                                               modifiers={
                                                                 Object {
                                                                   "contentWidth": Object {
@@ -18363,7 +18363,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                 className="glamor-26"
                                                                 data-placement={undefined}
                                                                 data-x-out-of-boundaries={undefined}
-                                                                id="select-113-content"
+                                                                id="select-123-content"
                                                                 style={
                                                                   Object {
                                                                     "opacity": 0,
@@ -18390,16 +18390,16 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                     ]
                                                                   }
                                                                   getItemProps={[Function]}
-                                                                  id="select-113-menu"
+                                                                  id="select-123-menu"
                                                                   role="listbox"
                                                                 >
                                                                   <Menu
-                                                                    id="select-113-menu"
+                                                                    id="select-123-menu"
                                                                     role="listbox"
                                                                   >
                                                                     <div
                                                                       className="glamor-25"
-                                                                      id="select-113-menu"
+                                                                      id="select-123-menu"
                                                                       role="listbox"
                                                                     >
                                                                       <MenuGroup
@@ -18413,7 +18413,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                             <MenuItem
                                                                               aria-disabled={undefined}
                                                                               aria-selected={false}
-                                                                              id="select-113-item-0"
+                                                                              id="select-123-item-0"
                                                                               isHighlighted={false}
                                                                               item={
                                                                                 Object {
@@ -18431,7 +18431,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                                 aria-disabled={undefined}
                                                                                 aria-selected={false}
                                                                                 disabled={undefined}
-                                                                                id="select-113-item-0"
+                                                                                id="select-123-item-0"
                                                                                 isHighlighted={false}
                                                                                 item={
                                                                                   Object {
@@ -18450,7 +18450,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                                   aria-disabled={undefined}
                                                                                   aria-selected={false}
                                                                                   className="glamor-13"
-                                                                                  id="select-113-item-0"
+                                                                                  id="select-123-item-0"
                                                                                   onClick={[Function]}
                                                                                   onKeyDown={[Function]}
                                                                                   role="option"
@@ -18486,7 +18486,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                             <MenuItem
                                                                               aria-disabled={undefined}
                                                                               aria-selected={false}
-                                                                              id="select-113-item-1"
+                                                                              id="select-123-item-1"
                                                                               isHighlighted={false}
                                                                               item={
                                                                                 Object {
@@ -18504,7 +18504,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                                 aria-disabled={undefined}
                                                                                 aria-selected={false}
                                                                                 disabled={undefined}
-                                                                                id="select-113-item-1"
+                                                                                id="select-123-item-1"
                                                                                 isHighlighted={false}
                                                                                 item={
                                                                                   Object {
@@ -18523,7 +18523,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                                   aria-disabled={undefined}
                                                                                   aria-selected={false}
                                                                                   className="glamor-13"
-                                                                                  id="select-113-item-1"
+                                                                                  id="select-123-item-1"
                                                                                   onClick={[Function]}
                                                                                   onKeyDown={[Function]}
                                                                                   role="option"
@@ -18559,7 +18559,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                             <MenuItem
                                                                               aria-disabled={undefined}
                                                                               aria-selected={false}
-                                                                              id="select-113-item-2"
+                                                                              id="select-123-item-2"
                                                                               isHighlighted={false}
                                                                               item={
                                                                                 Object {
@@ -18577,7 +18577,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                                 aria-disabled={undefined}
                                                                                 aria-selected={false}
                                                                                 disabled={undefined}
-                                                                                id="select-113-item-2"
+                                                                                id="select-123-item-2"
                                                                                 isHighlighted={false}
                                                                                 item={
                                                                                   Object {
@@ -18596,7 +18596,7 @@ exports[`Select demo examples scrolling-container 1`] = `
                                                                                   aria-disabled={undefined}
                                                                                   aria-selected={false}
                                                                                   className="glamor-13"
-                                                                                  id="select-113-item-2"
+                                                                                  id="select-123-item-2"
                                                                                   onClick={[Function]}
                                                                                   onKeyDown={[Function]}
                                                                                   role="option"
@@ -19283,7 +19283,7 @@ exports[`Select demo examples size 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-92"
+                    id="select-102"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -19320,7 +19320,7 @@ exports[`Select demo examples size 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-92"
+                      id="select-102"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -19357,7 +19357,7 @@ exports[`Select demo examples size 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-92"
+                        id="select-102"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -19396,7 +19396,7 @@ exports[`Select demo examples size 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-92"
+                              id="select-102"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -19432,7 +19432,7 @@ exports[`Select demo examples size 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-92-content"
+                                    id="select-102-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -19452,7 +19452,7 @@ exports[`Select demo examples size 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-92"
+                                id="select-102"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -19482,7 +19482,7 @@ exports[`Select demo examples size 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-92-content"
+                                      id="select-102-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -19502,7 +19502,7 @@ exports[`Select demo examples size 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-92"
+                                  id="select-102"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -19513,21 +19513,21 @@ exports[`Select demo examples size 1`] = `
                                 >
                                   <Manager
                                     className="glamor-9"
-                                    id="select-92"
+                                    id="select-102"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-9"
-                                      id="select-92"
+                                      id="select-102"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-92-content"
+                                        aria-describedby="select-102-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-92-content"
+                                        aria-owns="select-102-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -19550,12 +19550,12 @@ exports[`Select demo examples size 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-92-content"
+                                                aria-describedby="select-102-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-92-content"
+                                                aria-owns="select-102-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -19593,12 +19593,12 @@ exports[`Select demo examples size 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-92-content"
+                                                  aria-describedby="select-102-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-92-content"
+                                                  aria-owns="select-102-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -19640,12 +19640,12 @@ exports[`Select demo examples size 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-92-content"
+                                                    aria-describedby="select-102-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-92-content"
+                                                    aria-owns="select-102-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -19671,12 +19671,12 @@ exports[`Select demo examples size 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-92-content"
+                                                      aria-describedby="select-102-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-92-content"
+                                                      aria-owns="select-102-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -19694,12 +19694,12 @@ exports[`Select demo examples size 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-92-content"
+                                                        aria-describedby="select-102-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-92-content"
+                                                        aria-owns="select-102-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -19869,7 +19869,7 @@ exports[`Select demo examples size 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-94"
+                    id="select-104"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -19906,7 +19906,7 @@ exports[`Select demo examples size 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-94"
+                      id="select-104"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -19943,7 +19943,7 @@ exports[`Select demo examples size 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-94"
+                        id="select-104"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -19982,7 +19982,7 @@ exports[`Select demo examples size 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-94"
+                              id="select-104"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -20018,7 +20018,7 @@ exports[`Select demo examples size 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-94-content"
+                                    id="select-104-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -20038,7 +20038,7 @@ exports[`Select demo examples size 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-94"
+                                id="select-104"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -20068,7 +20068,7 @@ exports[`Select demo examples size 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-94-content"
+                                      id="select-104-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -20088,7 +20088,7 @@ exports[`Select demo examples size 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-94"
+                                  id="select-104"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -20099,21 +20099,21 @@ exports[`Select demo examples size 1`] = `
                                 >
                                   <Manager
                                     className="glamor-9"
-                                    id="select-94"
+                                    id="select-104"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-9"
-                                      id="select-94"
+                                      id="select-104"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-94-content"
+                                        aria-describedby="select-104-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-94-content"
+                                        aria-owns="select-104-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -20136,12 +20136,12 @@ exports[`Select demo examples size 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-94-content"
+                                                aria-describedby="select-104-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-94-content"
+                                                aria-owns="select-104-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -20179,12 +20179,12 @@ exports[`Select demo examples size 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-94-content"
+                                                  aria-describedby="select-104-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-94-content"
+                                                  aria-owns="select-104-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -20226,12 +20226,12 @@ exports[`Select demo examples size 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-94-content"
+                                                    aria-describedby="select-104-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-94-content"
+                                                    aria-owns="select-104-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -20257,12 +20257,12 @@ exports[`Select demo examples size 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-94-content"
+                                                      aria-describedby="select-104-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-94-content"
+                                                      aria-owns="select-104-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -20280,12 +20280,12 @@ exports[`Select demo examples size 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-94-content"
+                                                        aria-describedby="select-104-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-94-content"
+                                                        aria-owns="select-104-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -20455,7 +20455,7 @@ exports[`Select demo examples size 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-96"
+                    id="select-106"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -20492,7 +20492,7 @@ exports[`Select demo examples size 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-96"
+                      id="select-106"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -20529,7 +20529,7 @@ exports[`Select demo examples size 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-96"
+                        id="select-106"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -20568,7 +20568,7 @@ exports[`Select demo examples size 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-96"
+                              id="select-106"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -20604,7 +20604,7 @@ exports[`Select demo examples size 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-96-content"
+                                    id="select-106-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -20624,7 +20624,7 @@ exports[`Select demo examples size 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-96"
+                                id="select-106"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -20654,7 +20654,7 @@ exports[`Select demo examples size 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-96-content"
+                                      id="select-106-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -20674,7 +20674,7 @@ exports[`Select demo examples size 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-96"
+                                  id="select-106"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -20685,21 +20685,21 @@ exports[`Select demo examples size 1`] = `
                                 >
                                   <Manager
                                     className="glamor-9"
-                                    id="select-96"
+                                    id="select-106"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-9"
-                                      id="select-96"
+                                      id="select-106"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-96-content"
+                                        aria-describedby="select-106-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-96-content"
+                                        aria-owns="select-106-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -20722,12 +20722,12 @@ exports[`Select demo examples size 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-96-content"
+                                                aria-describedby="select-106-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-96-content"
+                                                aria-owns="select-106-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -20765,12 +20765,12 @@ exports[`Select demo examples size 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-96-content"
+                                                  aria-describedby="select-106-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-96-content"
+                                                  aria-owns="select-106-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -20812,12 +20812,12 @@ exports[`Select demo examples size 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-96-content"
+                                                    aria-describedby="select-106-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-96-content"
+                                                    aria-owns="select-106-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -20843,12 +20843,12 @@ exports[`Select demo examples size 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-96-content"
+                                                      aria-describedby="select-106-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-96-content"
+                                                      aria-owns="select-106-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -20866,12 +20866,12 @@ exports[`Select demo examples size 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-96-content"
+                                                        aria-describedby="select-106-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-96-content"
+                                                        aria-owns="select-106-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -21041,7 +21041,7 @@ exports[`Select demo examples size 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-98"
+                    id="select-108"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -21078,7 +21078,7 @@ exports[`Select demo examples size 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-98"
+                      id="select-108"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -21115,7 +21115,7 @@ exports[`Select demo examples size 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-98"
+                        id="select-108"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -21154,7 +21154,7 @@ exports[`Select demo examples size 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-98"
+                              id="select-108"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -21190,7 +21190,7 @@ exports[`Select demo examples size 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-98-content"
+                                    id="select-108-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -21210,7 +21210,7 @@ exports[`Select demo examples size 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-98"
+                                id="select-108"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -21240,7 +21240,7 @@ exports[`Select demo examples size 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-98-content"
+                                      id="select-108-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -21260,7 +21260,7 @@ exports[`Select demo examples size 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-98"
+                                  id="select-108"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -21271,21 +21271,21 @@ exports[`Select demo examples size 1`] = `
                                 >
                                   <Manager
                                     className="glamor-9"
-                                    id="select-98"
+                                    id="select-108"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-9"
-                                      id="select-98"
+                                      id="select-108"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-98-content"
+                                        aria-describedby="select-108-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-98-content"
+                                        aria-owns="select-108-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -21308,12 +21308,12 @@ exports[`Select demo examples size 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-98-content"
+                                                aria-describedby="select-108-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-98-content"
+                                                aria-owns="select-108-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -21351,12 +21351,12 @@ exports[`Select demo examples size 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-98-content"
+                                                  aria-describedby="select-108-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-98-content"
+                                                  aria-owns="select-108-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -21398,12 +21398,12 @@ exports[`Select demo examples size 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-98-content"
+                                                    aria-describedby="select-108-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-98-content"
+                                                    aria-owns="select-108-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-5"
@@ -21429,12 +21429,12 @@ exports[`Select demo examples size 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-98-content"
+                                                      aria-describedby="select-108-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-98-content"
+                                                      aria-owns="select-108-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-5"
@@ -21452,12 +21452,12 @@ exports[`Select demo examples size 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-98-content"
+                                                        aria-describedby="select-108-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-98-content"
+                                                        aria-owns="select-108-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-4"
@@ -22071,7 +22071,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-117"
+                        id="select-127"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -22108,7 +22108,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-117"
+                          id="select-127"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -22145,7 +22145,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                             getMenuProps={[Function]}
                             getTriggerProps={[Function]}
                             highlightedIndex={undefined}
-                            id="select-117"
+                            id="select-127"
                             isOpen={false}
                             modifiers={
                               Object {
@@ -22184,7 +22184,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                                   getMenuProps={[Function]}
                                   getTriggerProps={[Function]}
                                   highlightedIndex={undefined}
-                                  id="select-117"
+                                  id="select-127"
                                   isOpen={false}
                                   modifiers={
                                     Object {
@@ -22220,7 +22220,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                                         }
                                         getItemProps={[Function]}
                                         getMenuProps={[Function]}
-                                        id="select-117-content"
+                                        id="select-127-content"
                                         modifiers={
                                           Object {
                                             "contentWidth": Object {
@@ -22240,7 +22240,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                                     getTriggerProps={[Function]}
                                     hasArrow={true}
                                     highlightedIndex={undefined}
-                                    id="select-117"
+                                    id="select-127"
                                     isOpen={false}
                                     onClose={[Function]}
                                     onOpen={[Function]}
@@ -22270,7 +22270,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                                           }
                                           getItemProps={[Function]}
                                           getMenuProps={[Function]}
-                                          id="select-117-content"
+                                          id="select-127-content"
                                           modifiers={
                                             Object {
                                               "contentWidth": Object {
@@ -22290,7 +22290,7 @@ exports[`Select demo examples trigger-ref 1`] = `
                                       getTriggerProps={[Function]}
                                       hasArrow={true}
                                       highlightedIndex={undefined}
-                                      id="select-117"
+                                      id="select-127"
                                       isOpen={false}
                                       onClose={[Function]}
                                       onOpen={[Function]}
@@ -22301,21 +22301,21 @@ exports[`Select demo examples trigger-ref 1`] = `
                                     >
                                       <Manager
                                         className="glamor-9"
-                                        id="select-117"
+                                        id="select-127"
                                         tag="span"
                                       >
                                         <span
                                           className="glamor-9"
-                                          id="select-117"
+                                          id="select-127"
                                         >
                                           <PopoverTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-117-content"
+                                            aria-describedby="select-127-content"
                                             aria-disabled={undefined}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={undefined}
-                                            aria-owns="select-117-content"
+                                            aria-owns="select-127-content"
                                             aria-readonly={undefined}
                                             aria-required={undefined}
                                             disabled={undefined}
@@ -22338,12 +22338,12 @@ exports[`Select demo examples trigger-ref 1`] = `
                                                 >
                                                   <SelectTrigger
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-117-content"
+                                                    aria-describedby="select-127-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-117-content"
+                                                    aria-owns="select-127-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     disabled={undefined}
@@ -22381,12 +22381,12 @@ exports[`Select demo examples trigger-ref 1`] = `
                                                         ]
                                                       }
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-117-content"
+                                                      aria-describedby="select-127-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-117-content"
+                                                      aria-owns="select-127-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       control={[Function]}
@@ -22428,12 +22428,12 @@ exports[`Select demo examples trigger-ref 1`] = `
                                                           ]
                                                         }
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-117-content"
+                                                        aria-describedby="select-127-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-117-content"
+                                                        aria-owns="select-127-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-5"
@@ -22459,12 +22459,12 @@ exports[`Select demo examples trigger-ref 1`] = `
                                                       >
                                                         <FauxControl
                                                           aria-activedescendant={undefined}
-                                                          aria-describedby="select-117-content"
+                                                          aria-describedby="select-127-content"
                                                           aria-disabled={undefined}
                                                           aria-expanded={false}
                                                           aria-haspopup="listbox"
                                                           aria-invalid={undefined}
-                                                          aria-owns="select-117-content"
+                                                          aria-owns="select-127-content"
                                                           aria-readonly={undefined}
                                                           aria-required={undefined}
                                                           className="glamor-5"
@@ -22482,12 +22482,12 @@ exports[`Select demo examples trigger-ref 1`] = `
                                                         >
                                                           <div
                                                             aria-activedescendant={undefined}
-                                                            aria-describedby="select-117-content"
+                                                            aria-describedby="select-127-content"
                                                             aria-disabled={undefined}
                                                             aria-expanded={false}
                                                             aria-haspopup="listbox"
                                                             aria-invalid={undefined}
-                                                            aria-owns="select-117-content"
+                                                            aria-owns="select-127-content"
                                                             aria-readonly={undefined}
                                                             aria-required={undefined}
                                                             className="glamor-4"
@@ -23573,7 +23573,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                 getMenuProps={[Function]}
                 getTriggerProps={[Function]}
                 highlightedIndex={undefined}
-                id="select-76"
+                id="select-86"
                 isOpen={false}
                 modifiers={
                   Object {
@@ -23804,7 +23804,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                   getMenuProps={[Function]}
                   getTriggerProps={[Function]}
                   highlightedIndex={undefined}
-                  id="select-76"
+                  id="select-86"
                   isOpen={false}
                   modifiers={
                     Object {
@@ -24035,7 +24035,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-76"
+                    id="select-86"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -24268,7 +24268,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                           getMenuProps={[Function]}
                           getTriggerProps={[Function]}
                           highlightedIndex={undefined}
-                          id="select-76"
+                          id="select-86"
                           isOpen={false}
                           modifiers={
                             Object {
@@ -24492,7 +24492,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                                 }
                                 getItemProps={[Function]}
                                 getMenuProps={[Function]}
-                                id="select-76-content"
+                                id="select-86-content"
                                 modifiers={
                                   Object {
                                     "contentWidth": Object {
@@ -24518,7 +24518,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                             getTriggerProps={[Function]}
                             hasArrow={true}
                             highlightedIndex={undefined}
-                            id="select-76"
+                            id="select-86"
                             isOpen={false}
                             onClose={[Function]}
                             onOpen={[Function]}
@@ -24736,7 +24736,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                                   }
                                   getItemProps={[Function]}
                                   getMenuProps={[Function]}
-                                  id="select-76-content"
+                                  id="select-86-content"
                                   modifiers={
                                     Object {
                                       "contentWidth": Object {
@@ -24762,7 +24762,7 @@ exports[`Select demo examples uncontrolled 1`] = `
                               getTriggerProps={[Function]}
                               hasArrow={true}
                               highlightedIndex={undefined}
-                              id="select-76"
+                              id="select-86"
                               isOpen={false}
                               onClose={[Function]}
                               onOpen={[Function]}
@@ -24773,21 +24773,21 @@ exports[`Select demo examples uncontrolled 1`] = `
                             >
                               <Manager
                                 className="glamor-9"
-                                id="select-76"
+                                id="select-86"
                                 tag="span"
                               >
                                 <span
                                   className="glamor-9"
-                                  id="select-76"
+                                  id="select-86"
                                 >
                                   <PopoverTrigger
                                     aria-activedescendant={undefined}
-                                    aria-describedby="select-76-content"
+                                    aria-describedby="select-86-content"
                                     aria-disabled={undefined}
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={undefined}
-                                    aria-owns="select-76-content"
+                                    aria-owns="select-86-content"
                                     aria-readonly={undefined}
                                     aria-required={undefined}
                                     disabled={undefined}
@@ -24810,12 +24810,12 @@ exports[`Select demo examples uncontrolled 1`] = `
                                         >
                                           <SelectTrigger
                                             aria-activedescendant={undefined}
-                                            aria-describedby="select-76-content"
+                                            aria-describedby="select-86-content"
                                             aria-disabled={undefined}
                                             aria-expanded={false}
                                             aria-haspopup="listbox"
                                             aria-invalid={undefined}
-                                            aria-owns="select-76-content"
+                                            aria-owns="select-86-content"
                                             aria-readonly={undefined}
                                             aria-required={undefined}
                                             disabled={undefined}
@@ -24858,12 +24858,12 @@ exports[`Select demo examples uncontrolled 1`] = `
                                                 ]
                                               }
                                               aria-activedescendant={undefined}
-                                              aria-describedby="select-76-content"
+                                              aria-describedby="select-86-content"
                                               aria-disabled={undefined}
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-invalid={undefined}
-                                              aria-owns="select-76-content"
+                                              aria-owns="select-86-content"
                                               aria-readonly={undefined}
                                               aria-required={undefined}
                                               control={[Function]}
@@ -24913,12 +24913,12 @@ exports[`Select demo examples uncontrolled 1`] = `
                                                   ]
                                                 }
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-76-content"
+                                                aria-describedby="select-86-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-76-content"
+                                                aria-owns="select-86-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 className="glamor-5"
@@ -24952,12 +24952,12 @@ exports[`Select demo examples uncontrolled 1`] = `
                                               >
                                                 <FauxControl
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-76-content"
+                                                  aria-describedby="select-86-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-76-content"
+                                                  aria-owns="select-86-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   className="glamor-5"
@@ -24981,12 +24981,12 @@ exports[`Select demo examples uncontrolled 1`] = `
                                                 >
                                                   <div
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-76-content"
+                                                    aria-describedby="select-86-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-76-content"
+                                                    aria-owns="select-86-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-4"
@@ -25856,7 +25856,7 @@ exports[`Select demo examples variants 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-100"
+                    id="select-110"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -25893,7 +25893,7 @@ exports[`Select demo examples variants 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-100"
+                      id="select-110"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -25930,7 +25930,7 @@ exports[`Select demo examples variants 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-100"
+                        id="select-110"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -25969,7 +25969,7 @@ exports[`Select demo examples variants 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-100"
+                              id="select-110"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -26005,7 +26005,7 @@ exports[`Select demo examples variants 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-100-content"
+                                    id="select-110-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -26025,7 +26025,7 @@ exports[`Select demo examples variants 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-100"
+                                id="select-110"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -26055,7 +26055,7 @@ exports[`Select demo examples variants 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-100-content"
+                                      id="select-110-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -26075,7 +26075,7 @@ exports[`Select demo examples variants 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-100"
+                                  id="select-110"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -26086,21 +26086,21 @@ exports[`Select demo examples variants 1`] = `
                                 >
                                   <Manager
                                     className="glamor-10"
-                                    id="select-100"
+                                    id="select-110"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-10"
-                                      id="select-100"
+                                      id="select-110"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-100-content"
+                                        aria-describedby="select-110-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-100-content"
+                                        aria-owns="select-110-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -26123,12 +26123,12 @@ exports[`Select demo examples variants 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-100-content"
+                                                aria-describedby="select-110-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-100-content"
+                                                aria-owns="select-110-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -26166,12 +26166,12 @@ exports[`Select demo examples variants 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-100-content"
+                                                  aria-describedby="select-110-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-100-content"
+                                                  aria-owns="select-110-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -26213,12 +26213,12 @@ exports[`Select demo examples variants 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-100-content"
+                                                    aria-describedby="select-110-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-100-content"
+                                                    aria-owns="select-110-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-6"
@@ -26244,12 +26244,12 @@ exports[`Select demo examples variants 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-100-content"
+                                                      aria-describedby="select-110-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-100-content"
+                                                      aria-owns="select-110-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-6"
@@ -26267,12 +26267,12 @@ exports[`Select demo examples variants 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-100-content"
+                                                        aria-describedby="select-110-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-100-content"
+                                                        aria-owns="select-110-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-5"
@@ -26475,7 +26475,7 @@ exports[`Select demo examples variants 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-103"
+                    id="select-113"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -26512,7 +26512,7 @@ exports[`Select demo examples variants 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-103"
+                      id="select-113"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -26549,7 +26549,7 @@ exports[`Select demo examples variants 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-103"
+                        id="select-113"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -26588,7 +26588,7 @@ exports[`Select demo examples variants 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-103"
+                              id="select-113"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -26624,7 +26624,7 @@ exports[`Select demo examples variants 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-103-content"
+                                    id="select-113-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -26644,7 +26644,7 @@ exports[`Select demo examples variants 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-103"
+                                id="select-113"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -26674,7 +26674,7 @@ exports[`Select demo examples variants 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-103-content"
+                                      id="select-113-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -26694,7 +26694,7 @@ exports[`Select demo examples variants 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-103"
+                                  id="select-113"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -26705,21 +26705,21 @@ exports[`Select demo examples variants 1`] = `
                                 >
                                   <Manager
                                     className="glamor-10"
-                                    id="select-103"
+                                    id="select-113"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-10"
-                                      id="select-103"
+                                      id="select-113"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-103-content"
+                                        aria-describedby="select-113-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-103-content"
+                                        aria-owns="select-113-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -26742,12 +26742,12 @@ exports[`Select demo examples variants 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-103-content"
+                                                aria-describedby="select-113-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-103-content"
+                                                aria-owns="select-113-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -26785,12 +26785,12 @@ exports[`Select demo examples variants 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-103-content"
+                                                  aria-describedby="select-113-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-103-content"
+                                                  aria-owns="select-113-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -26832,12 +26832,12 @@ exports[`Select demo examples variants 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-103-content"
+                                                    aria-describedby="select-113-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-103-content"
+                                                    aria-owns="select-113-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-23"
@@ -26863,12 +26863,12 @@ exports[`Select demo examples variants 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-103-content"
+                                                      aria-describedby="select-113-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-103-content"
+                                                      aria-owns="select-113-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-23"
@@ -26886,12 +26886,12 @@ exports[`Select demo examples variants 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-103-content"
+                                                        aria-describedby="select-113-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-103-content"
+                                                        aria-owns="select-113-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-22"
@@ -27094,7 +27094,7 @@ exports[`Select demo examples variants 1`] = `
                     getMenuProps={[Function]}
                     getTriggerProps={[Function]}
                     highlightedIndex={undefined}
-                    id="select-106"
+                    id="select-116"
                     isOpen={false}
                     modifiers={
                       Object {
@@ -27131,7 +27131,7 @@ exports[`Select demo examples variants 1`] = `
                       getMenuProps={[Function]}
                       getTriggerProps={[Function]}
                       highlightedIndex={undefined}
-                      id="select-106"
+                      id="select-116"
                       isOpen={false}
                       modifiers={
                         Object {
@@ -27168,7 +27168,7 @@ exports[`Select demo examples variants 1`] = `
                         getMenuProps={[Function]}
                         getTriggerProps={[Function]}
                         highlightedIndex={undefined}
-                        id="select-106"
+                        id="select-116"
                         isOpen={false}
                         modifiers={
                           Object {
@@ -27207,7 +27207,7 @@ exports[`Select demo examples variants 1`] = `
                               getMenuProps={[Function]}
                               getTriggerProps={[Function]}
                               highlightedIndex={undefined}
-                              id="select-106"
+                              id="select-116"
                               isOpen={false}
                               modifiers={
                                 Object {
@@ -27243,7 +27243,7 @@ exports[`Select demo examples variants 1`] = `
                                     }
                                     getItemProps={[Function]}
                                     getMenuProps={[Function]}
-                                    id="select-106-content"
+                                    id="select-116-content"
                                     modifiers={
                                       Object {
                                         "contentWidth": Object {
@@ -27263,7 +27263,7 @@ exports[`Select demo examples variants 1`] = `
                                 getTriggerProps={[Function]}
                                 hasArrow={true}
                                 highlightedIndex={undefined}
-                                id="select-106"
+                                id="select-116"
                                 isOpen={false}
                                 onClose={[Function]}
                                 onOpen={[Function]}
@@ -27293,7 +27293,7 @@ exports[`Select demo examples variants 1`] = `
                                       }
                                       getItemProps={[Function]}
                                       getMenuProps={[Function]}
-                                      id="select-106-content"
+                                      id="select-116-content"
                                       modifiers={
                                         Object {
                                           "contentWidth": Object {
@@ -27313,7 +27313,7 @@ exports[`Select demo examples variants 1`] = `
                                   getTriggerProps={[Function]}
                                   hasArrow={true}
                                   highlightedIndex={undefined}
-                                  id="select-106"
+                                  id="select-116"
                                   isOpen={false}
                                   onClose={[Function]}
                                   onOpen={[Function]}
@@ -27324,21 +27324,21 @@ exports[`Select demo examples variants 1`] = `
                                 >
                                   <Manager
                                     className="glamor-10"
-                                    id="select-106"
+                                    id="select-116"
                                     tag="span"
                                   >
                                     <span
                                       className="glamor-10"
-                                      id="select-106"
+                                      id="select-116"
                                     >
                                       <PopoverTrigger
                                         aria-activedescendant={undefined}
-                                        aria-describedby="select-106-content"
+                                        aria-describedby="select-116-content"
                                         aria-disabled={undefined}
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-invalid={undefined}
-                                        aria-owns="select-106-content"
+                                        aria-owns="select-116-content"
                                         aria-readonly={undefined}
                                         aria-required={undefined}
                                         disabled={undefined}
@@ -27361,12 +27361,12 @@ exports[`Select demo examples variants 1`] = `
                                             >
                                               <SelectTrigger
                                                 aria-activedescendant={undefined}
-                                                aria-describedby="select-106-content"
+                                                aria-describedby="select-116-content"
                                                 aria-disabled={undefined}
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-invalid={undefined}
-                                                aria-owns="select-106-content"
+                                                aria-owns="select-116-content"
                                                 aria-readonly={undefined}
                                                 aria-required={undefined}
                                                 disabled={undefined}
@@ -27404,12 +27404,12 @@ exports[`Select demo examples variants 1`] = `
                                                     ]
                                                   }
                                                   aria-activedescendant={undefined}
-                                                  aria-describedby="select-106-content"
+                                                  aria-describedby="select-116-content"
                                                   aria-disabled={undefined}
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
                                                   aria-invalid={undefined}
-                                                  aria-owns="select-106-content"
+                                                  aria-owns="select-116-content"
                                                   aria-readonly={undefined}
                                                   aria-required={undefined}
                                                   control={[Function]}
@@ -27451,12 +27451,12 @@ exports[`Select demo examples variants 1`] = `
                                                       ]
                                                     }
                                                     aria-activedescendant={undefined}
-                                                    aria-describedby="select-106-content"
+                                                    aria-describedby="select-116-content"
                                                     aria-disabled={undefined}
                                                     aria-expanded={false}
                                                     aria-haspopup="listbox"
                                                     aria-invalid={undefined}
-                                                    aria-owns="select-106-content"
+                                                    aria-owns="select-116-content"
                                                     aria-readonly={undefined}
                                                     aria-required={undefined}
                                                     className="glamor-40"
@@ -27482,12 +27482,12 @@ exports[`Select demo examples variants 1`] = `
                                                   >
                                                     <FauxControl
                                                       aria-activedescendant={undefined}
-                                                      aria-describedby="select-106-content"
+                                                      aria-describedby="select-116-content"
                                                       aria-disabled={undefined}
                                                       aria-expanded={false}
                                                       aria-haspopup="listbox"
                                                       aria-invalid={undefined}
-                                                      aria-owns="select-106-content"
+                                                      aria-owns="select-116-content"
                                                       aria-readonly={undefined}
                                                       aria-required={undefined}
                                                       className="glamor-40"
@@ -27505,12 +27505,12 @@ exports[`Select demo examples variants 1`] = `
                                                     >
                                                       <div
                                                         aria-activedescendant={undefined}
-                                                        aria-describedby="select-106-content"
+                                                        aria-describedby="select-116-content"
                                                         aria-disabled={undefined}
                                                         aria-expanded={false}
                                                         aria-haspopup="listbox"
                                                         aria-invalid={undefined}
-                                                        aria-owns="select-106-content"
+                                                        aria-owns="select-116-content"
                                                         aria-readonly={undefined}
                                                         aria-required={undefined}
                                                         className="glamor-39"


### PR DESCRIPTION
### Description

Fix Select component to properly call onChange handler when selected item changes.  The comparison was not properly checking the previous selected item.

### Motivation and context

Connects #645 

### Screenshots, videos, or demo, if appropriate

You can see the incorrect behavior in the following demo.  Note that the onChange handler is never logged. It uses `mineral-ui@0.22.0`. https://codesandbox.io/s/6wlpo392qr

You can see the corrected behavior in the following demo. Note that the onChange handler is logged.  It uses `mineral-ui@0.23.0-next.0`. 
https://codesandbox.io/s/6z5qk1vz5r

This is the standard mineral website demo using this branch.
https://645-select--mineral-ui.netlify.com/

### How to test

1. Run the test suite.  There are new unit tests to cover this case.
2. Try out the aforementioned demos.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
