### PR TITLE
Remove a bunch of no longer needed $FlowFixMe’s

### DIFF
--- a/src/library/Choice/ChoiceGroup.js
+++ b/src/library/Choice/ChoiceGroup.js
@@ -139,7 +139,6 @@ export default function ChoiceGroup({
   if (data && input) {
     inputs = data.map((inputData, index) => {
       return createElement(
-        // $FlowFixMe
         input,
         inputProps(inputData.value, index, inputData)
       );

--- a/src/website/app/Router.js
+++ b/src/website/app/Router.js
@@ -87,7 +87,6 @@ export default function Router({ demoRoutes }: Props) {
         path="/components/:componentId/:exampleId"
         render={(route) => {
           const { componentId, exampleId } = route.match.params;
-          // $FlowFixMe
           const selectedDemo = keyedDemoRoutes[componentId || firstDemoSlug];
           const chromeless = route.location.search === '?chromeless';
           const pageProps = {
@@ -143,7 +142,6 @@ export default function Router({ demoRoutes }: Props) {
             return <Redirect to={`/components/${firstDemoSlug}`} />;
           }
 
-          // $FlowFixMe
           const selectedDemo = keyedDemoRoutes[componentId];
 
           if (selectedDemo.redirect) {

--- a/src/website/app/demos/Card/examples/Card/arbitraryChildren.js
+++ b/src/website/app/demos/Card/examples/Card/arbitraryChildren.js
@@ -26,7 +26,6 @@ const customContent = (
 export default {
   id: 'children',
   title: 'Arbitrary Children',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `A Card will render any children.
 

--- a/src/website/app/demos/Card/examples/Card/card.js
+++ b/src/website/app/demos/Card/examples/Card/card.js
@@ -12,7 +12,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Card content should be neither too simple nor too complex. Cards
 are used as a gateway to more detailed content, not merely as a widget container.

--- a/src/website/app/demos/Card/examples/Card/clickable.js
+++ b/src/website/app/demos/Card/examples/Card/clickable.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'clickable',
   title: 'Clickable',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `If an \`onClick\` callback is provided, the entire Card becomes clickable and keyboard actionable.
 Use this feature when only one action can be taken per Card.

--- a/src/website/app/demos/Card/examples/Card/orderOfSections.js
+++ b/src/website/app/demos/Card/examples/Card/orderOfSections.js
@@ -21,7 +21,6 @@ const DemoLayout = createStyledComponent(_DemoLayout, {
 export default {
   id: 'order',
   title: 'Order of Sections',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `There is no "one true way" to lay out children in Card; it is
 flexible enough to accept different component arrangements. The one exception is

--- a/src/website/app/demos/Card/examples/CardActions/cardActions.js
+++ b/src/website/app/demos/Card/examples/CardActions/cardActions.js
@@ -9,7 +9,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Use CardActions to add actions, [Buttons](/components/button) or
 [Links](/components/link), to your [Card](/components/card). Buttons will automatically size

--- a/src/website/app/demos/Card/examples/CardActions/rtl.js
+++ b/src/website/app/demos/Card/examples/CardActions/rtl.js
@@ -9,7 +9,6 @@ import loremIpsum from '../../components/loremIpsumRtl';
 export default {
   id: 'rtl',
   title: 'Bidirectionality',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardActions reverses its alignment when the \`direction\` theme
 variable is set to \`rtl\` (right-to-left).`,

--- a/src/website/app/demos/Card/examples/CardActions/withLinks.js
+++ b/src/website/app/demos/Card/examples/CardActions/withLinks.js
@@ -11,7 +11,6 @@ const Link = (props: {}) => <_Link target="_blank" {...props} />;
 export default {
   id: 'with-links',
   title: 'With Links',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Place [Links](/components/links) in CardActions when your Card needs to
 point the users to another location.`,

--- a/src/website/app/demos/Card/examples/CardBlock/arbitraryChildren.js
+++ b/src/website/app/demos/Card/examples/CardBlock/arbitraryChildren.js
@@ -20,7 +20,6 @@ const customContent = (
 export default {
   id: 'children',
   title: 'Arbitrary Children',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `A CardBlock will render any children.`,
   scope: { Button, Card, CardBlock, CardTitle, customContent, DemoLayout },

--- a/src/website/app/demos/Card/examples/CardBlock/cardBlock.js
+++ b/src/website/app/demos/Card/examples/CardBlock/cardBlock.js
@@ -29,7 +29,6 @@ const CardBlock = createStyledComponent(_CardBlock, ({ theme }) => ({
 export default {
   id: 'consistent-spacing',
   title: 'Provide Consistent Spacing',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardBlock provides uniform spacing (highlighted here in light
 blue), relative to the other Card components, around its content.`,

--- a/src/website/app/demos/Card/examples/CardDivider/cardDivider.js
+++ b/src/website/app/demos/Card/examples/CardDivider/cardDivider.js
@@ -11,7 +11,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Use CardDivider to separate sections of your [Card](/components/card).`,
   scope: { Card, CardBlock, CardDivider, CardTitle, loremIpsum, DemoLayout },

--- a/src/website/app/demos/Card/examples/CardFooter/cardFooter.js
+++ b/src/website/app/demos/Card/examples/CardFooter/cardFooter.js
@@ -12,7 +12,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardFooter is used to add an extension to a Card. It can
 contain any children, but is best used with [CardActions](/components/card-actions) and

--- a/src/website/app/demos/Card/examples/CardFooter/expandable.js
+++ b/src/website/app/demos/Card/examples/CardFooter/expandable.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'expandable',
   title: 'Expandable Footer',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Set \`expandable\` to true to allow the user to expand/collapse
 CardFooter. Note that a \`title\` must be provided to expandable CardFooters.`,

--- a/src/website/app/demos/Card/examples/CardFooter/rtl.js
+++ b/src/website/app/demos/Card/examples/CardFooter/rtl.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsumRtl';
 export default {
   id: 'rtl',
   title: 'Bidirectionality',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardFooter reverses its alignment when the \`direction\` theme
 variable is set to \`rtl\` (right-to-left).`,

--- a/src/website/app/demos/Card/examples/CardFooter/variants.js
+++ b/src/website/app/demos/Card/examples/CardFooter/variants.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'variants',
   title: 'Available Variants',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardFooter is available in a few variants. Be sure to use the
 [appropriate variant](/color#guidelines-variants) for your intent.`,

--- a/src/website/app/demos/Card/examples/CardImage/withImage.js
+++ b/src/website/app/demos/Card/examples/CardImage/withImage.js
@@ -11,7 +11,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'with-image',
   title: 'Displaying an Image in a Card',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: 'CardImages should provide an `alt` attribute.',
   scope: { Card, CardBlock, CardImage, CardTitle, loremIpsum, DemoLayout },

--- a/src/website/app/demos/Card/examples/CardStatus/cardStatus.js
+++ b/src/website/app/demos/Card/examples/CardStatus/cardStatus.js
@@ -11,7 +11,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardStatus conveys the current status of [Card](/components/card). It is
 available in a few variants.`,

--- a/src/website/app/demos/Card/examples/CardStatus/rtl.js
+++ b/src/website/app/demos/Card/examples/CardStatus/rtl.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsumRtl';
 export default {
   id: 'rtl',
   title: 'Bidirectionality',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardStatus reverses its alignment when the \`direction\` theme
 variable is set to \`rtl\` (right-to-left).`,

--- a/src/website/app/demos/Card/examples/CardTitle/actionsMenu.js
+++ b/src/website/app/demos/Card/examples/CardTitle/actionsMenu.js
@@ -11,7 +11,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'actions-menu',
   title: 'With an Actions Menu',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `To display a menu of actions in CardTitle, pass a CardTitleMenu
 or [Dropdown](/components/dropdown) to the \`actions\` prop.

--- a/src/website/app/demos/Card/examples/CardTitle/avatar.js
+++ b/src/website/app/demos/Card/examples/CardTitle/avatar.js
@@ -8,7 +8,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'avatar',
   title: 'With an Avatar',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `To help communicate ownership or categorization of a Card, add
 an \`avatar\` to CardTitle. The [Avatar](/components/avatar) will automatically size

--- a/src/website/app/demos/Card/examples/CardTitle/cardTitle.js
+++ b/src/website/app/demos/Card/examples/CardTitle/cardTitle.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'titles',
   title: 'Displaying Titles',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: 'In addition to a title, a Card can display a subtitle.',
   scope: { Card, CardBlock, CardTitle, loremIpsum, DemoLayout },

--- a/src/website/app/demos/Card/examples/CardTitle/rtl.js
+++ b/src/website/app/demos/Card/examples/CardTitle/rtl.js
@@ -8,7 +8,6 @@ import loremIpsum from '../../components/loremIpsumRtl';
 export default {
   id: 'rtl',
   title: 'Bidirectionality',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardTitle reverses its alignment when the \`direction\` theme
 variable is set to \`rtl\` (right-to-left).`,

--- a/src/website/app/demos/Card/examples/CardTitle/secondaryText.js
+++ b/src/website/app/demos/Card/examples/CardTitle/secondaryText.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'secondary-text',
   title: 'With Secondary Text',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `When you must provide information that doesn't belong to every
 Card in a set, supply it as \`secondaryText\` information. The information will

--- a/src/website/app/demos/Card/examples/CardTitle/variants.js
+++ b/src/website/app/demos/Card/examples/CardTitle/variants.js
@@ -7,7 +7,6 @@ import loremIpsum from '../../components/loremIpsum';
 export default {
   id: 'variants',
   title: 'Variants',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `CardTitle is available in a few variants. Be sure to use the
 [appropriate variant](/color#guidelines-variants) for your intent.`,

--- a/src/website/app/demos/Menu/examples/Menu/flatData.js
+++ b/src/website/app/demos/Menu/examples/Menu/flatData.js
@@ -8,7 +8,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'data',
   title: 'Flat Data',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Menu content can also be defined by an array of data, with the
 structure shown in the code example below. Object properties will be passed on

--- a/src/website/app/demos/Menu/examples/Menu/groupedData.js
+++ b/src/website/app/demos/Menu/examples/Menu/groupedData.js
@@ -8,7 +8,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'grouped-data',
   title: 'Grouped Data',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Menu items can be grouped by using the structure shown in the
 code example below. Object properties in the \`items\` array(s) will be passed

--- a/src/website/app/demos/Menu/examples/Menu/menu.js
+++ b/src/website/app/demos/Menu/examples/Menu/menu.js
@@ -11,7 +11,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Menus are composed of [MenuDivider](/components/menu-divider), [MenuGroup](/components/menu-group), and [MenuItem](/components/menu-item).
 Menus display a list of actions or navigation options.

--- a/src/website/app/demos/Menu/examples/MenuDivider/menuDivider.js
+++ b/src/website/app/demos/Menu/examples/MenuDivider/menuDivider.js
@@ -10,7 +10,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'separating-items',
   title: 'Separating MenuItems',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `[MenuItems](/components/menu-item) and [MenuGroups](/components/menu-group) can be separated with a MenuDivider.
 MenuDividers are used to create hierarchy by setting some options apart from others.`,

--- a/src/website/app/demos/Menu/examples/MenuGroup/menuGroup.js
+++ b/src/website/app/demos/Menu/examples/MenuGroup/menuGroup.js
@@ -6,7 +6,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'menu-group',
   title: 'Grouping MenuItems',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `To group [MenuItems](/components/menu-item) together, wrap them in a MenuGroup.
 Optionally, provide a title to provide context if the grouping is large or not immediately obvious.

--- a/src/website/app/demos/Menu/examples/MenuItem/customRender.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/customRender.js
@@ -11,7 +11,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'custom-render',
   title: 'Custom Rendering',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `MenuItem can use a custom function for its rendering. This
 allows you to render any item data you might need (like an avatar, below). To

--- a/src/website/app/demos/Menu/examples/MenuItem/disabled.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/disabled.js
@@ -6,7 +6,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'disabled',
   title: 'Disabled',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `MenuItems can be disabled.
 Render a disabled MenuItem to let your user know that the option is available under the right conditions.

--- a/src/website/app/demos/Menu/examples/MenuItem/icons.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/icons.js
@@ -7,7 +7,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'icons',
   title: 'Menu Items with Icons',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `A MenuItem can display an [Icon](/components/icon) at its start, end, or both.
 If both \`startIcon\` and \`variant\` props are provided, \`startIcon\` will be used.`,

--- a/src/website/app/demos/Menu/examples/MenuItem/kitchenSink.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/kitchenSink.js
@@ -19,7 +19,6 @@ export default {
   id: 'kitchen-sink',
   description: `MenuItems are flexible enough to accommodate many different use cases.`,
   title: 'Kitchen Sink',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   hideFromProd: true,
   scope: { DemoLayout, IconCloud, Menu, MenuItem },

--- a/src/website/app/demos/Menu/examples/MenuItem/menuItem.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/menuItem.js
@@ -6,7 +6,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'basic',
   title: 'Basic Usage',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `
 MenuItems are used to trigger an action or navigate to a new location.

--- a/src/website/app/demos/Menu/examples/MenuItem/rtl.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/rtl.js
@@ -7,7 +7,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'rtl',
   title: 'Bidirectionality',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `MenuItems with Icons are reversed when the \`direction\` theme variable is set to \`rtl\` (right-to-left).
 A subset of Icons that [convey directionality](/components/icon#rtl) will be reversed.`,

--- a/src/website/app/demos/Menu/examples/MenuItem/secondaryText.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/secondaryText.js
@@ -6,7 +6,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'secondary-text',
   title: 'Secondary Text',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `A MenuItem can render secondary text, which will wrap when necessary.
 Use secondary text to give hints about extra functionality or show app status related to the action.`,

--- a/src/website/app/demos/Menu/examples/MenuItem/states.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/states.js
@@ -7,7 +7,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'states',
   title: 'States',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   hideFromProd: true,
   hideSource: true,

--- a/src/website/app/demos/Menu/examples/MenuItem/variants.js
+++ b/src/website/app/demos/Menu/examples/MenuItem/variants.js
@@ -6,7 +6,6 @@ import DemoLayout from '../../components/DemoLayout';
 export default {
   id: 'variants',
   title: 'Variants',
-  // $FlowFixMe
   backgroundColor: mineralTheme.color_gray_10,
   description: `Use available [variants](/color#guidelines-variants) to help communicate purpose.
 A \`startIcon\` will be automatically inserted to reinforce the intent.`,

--- a/src/website/app/pages/PaletteDemo/Picker.js
+++ b/src/website/app/pages/PaletteDemo/Picker.js
@@ -250,7 +250,6 @@ export default class Picker extends Component<Props, State> {
               return (
                 <Flip
                   activeColor={activeColor}
-                  /* $FlowFixMe colorName is a string, but should be Colors */
                   colorName={colorName}
                   handleColorChange={this.handleColorChange}
                   in={index < visibleThemeCount}


### PR DESCRIPTION
### Description

Remove a bunch of no longer needed `$FlowFixMe’s`

### Motivation and context

I noticed that some `$FlowFixMe's` weren't actually needed.  They used to error when when they were used unnecessarily.  I am assuming that that behavior changed and that some of the issues have either been resolved by flow or inadvertently by us.

### How to test

1. If it builds on CI, it should be good to go.
2. You can test it locally via `npm run flow:restart`

### Types of changes

- Other (provide details below)

build/maintenance

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
