### PR TITLE
test(happo): Remove IE from visual regression tests

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -16,9 +16,6 @@ module.exports = {
   targets: {
     'chrome': new RemoteBrowserTarget('chrome', {
       viewport: '800x600'
-    }),
-    'internet explorer': new RemoteBrowserTarget('internet explorer', {
-      viewport: '800x600'
     })
   },
 


### PR DESCRIPTION
### Description

Remove IE from visual regression tests

### Motivation and context

Testing in IE increases test duration and currently provides little value.

### How to test

1. Note that happo tests on this PR worked properly
2. Note that the only diffs are to remove IE specific tests
3. Note if the happo test suite ran faster

### Types of changes

- Other (provide details below)

build/test updates

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
