### PR TITLE
test(happo): Update to happo.io 1.2.0

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const { RemoteBrowserTarget } = require('happo.io');
 
-const babelLoader = require.resolve('babel-loader');
-
 const { HAPPO_KEY, HAPPO_SECRET } = process.env;
 
 module.exports = {
@@ -37,18 +35,4 @@ module.exports = {
   getRootElement(document) {
     return document.querySelector('.react-live-preview');
   },
-
-  // We need to tell happo how to load certain modules.
-  customizeWebpackConfig: (config) => {
-    config.module = {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          loader: babelLoader
-        }
-      ]
-    };
-    return config;
-  }
 };

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "glamor": "2.20.40",
     "glamorous": "4.12.1",
     "glob": "7.1.2",
-    "happo.io": "1.1.0",
+    "happo.io": "1.2.0",
     "html-webpack-plugin": "3.1.0",
     "husky": "0.14.3",
     "inquirer": "5.2.0",


### PR DESCRIPTION
### Description

This version has a few improvements compared to 1.1.0. Those that
mineral-ui will most likely benefit from are:

- Local images (e.g. url(/foo.png)) found in CSS will now be part of the
screenshot (technically, the happo client inlines them as base64).

- No need for a customizeWebpackConfig function in config. Happo now has
a babel loader as the default config.

- Better error messages. Instead of seeing an error in a call to `eval`,
you now see the component and variant where the error happened, plus a
location in a js file (this is still the tmp file which isn't ideal, but
better than before at least).

- A polyfill for requestAnimationFrame will get rid of warnings from
React during rendering.

Full list of changes is available here:
https://github.com/enduire/happo.io/releases/tag/v1.2.0

### Motivation and context
There's mutual benefit here. Mineral-ui benefits from staying up-to-date, I make sure that happo works out in the wild. And it's a pain to support old clients out there

### How to test
Happo results for this change should show no diff or one or more diffs where images are now visible (due to better detection of local images). 

### How does this PR make you feel?
![IKEA](https://media.giphy.com/media/ovja5oh1fmvtu/giphy.gif)
