### PR TITLE
Fix Avatar display of child svg images in IE 11

### DIFF
--- a/src/library/Avatar/Avatar.js
+++ b/src/library/Avatar/Avatar.js
@@ -84,7 +84,8 @@ const Root = createStyledComponent(
       '& > img': {
         borderRadius: '100%',
         display: 'block',
-        width: '100%'
+        flex: '0 0 auto',
+        maxWidth: '100%'
       },
 
       '& > [role="img"]': {

--- a/src/library/Avatar/__tests__/__snapshots__/Avatar.spec.js.snap
+++ b/src/library/Avatar/__tests__/__snapshots__/Avatar.spec.js.snap
@@ -60,7 +60,9 @@ exports[`Avatar demo examples Snapshots: basic 1`] = `
 [data-css-1] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-1 > [role="img"],
@@ -122,7 +124,9 @@ exports[`Avatar demo examples Snapshots: basic 1`] = `
 [data-css-3] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-3 > [role="img"],
@@ -177,7 +181,9 @@ exports[`Avatar demo examples Snapshots: basic 1`] = `
 [data-css-5] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-5 > [role="img"],
@@ -369,7 +375,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-1] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-1 > [role="img"],
@@ -431,7 +439,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-3] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-3 > [role="img"],
@@ -493,7 +503,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-5] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-5 > [role="img"],
@@ -555,7 +567,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-7] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-7 > [role="img"],
@@ -617,7 +631,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-9] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-9 > [role="img"],
@@ -679,7 +695,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-11] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-11 > [role="img"],
@@ -741,7 +759,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-13] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-13 > [role="img"],
@@ -803,7 +823,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-15] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-15 > [role="img"],
@@ -865,7 +887,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-17] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-17 > [role="img"],
@@ -927,7 +951,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-19] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-19 > [role="img"],
@@ -989,7 +1015,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-21] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-21 > [role="img"],
@@ -1051,7 +1079,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-23] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-23 > [role="img"],
@@ -1113,7 +1143,9 @@ exports[`Avatar demo examples Snapshots: colors 1`] = `
 [data-css-25] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-25 > [role="img"],
@@ -1491,7 +1523,9 @@ exports[`Avatar demo examples Snapshots: custom-text-abbr 1`] = `
 [data-css-0] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-0 > [role="img"],
@@ -1582,7 +1616,9 @@ exports[`Avatar demo examples Snapshots: shapes 1`] = `
 [data-css-1] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-1 > [role="img"],
@@ -1644,7 +1680,9 @@ exports[`Avatar demo examples Snapshots: shapes 1`] = `
 [data-css-3] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-3 > [role="img"],
@@ -1705,7 +1743,9 @@ exports[`Avatar demo examples Snapshots: shapes 1`] = `
 [data-css-5] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-5 > [role="img"],
@@ -1849,7 +1889,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-1] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-1 > [role="img"],
@@ -1911,7 +1953,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-3] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-3 > [role="img"],
@@ -1966,7 +2010,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-5] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-5 > [role="img"],
@@ -2035,7 +2081,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-8] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-8 > [role="img"],
@@ -2097,7 +2145,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-10] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-10 > [role="img"],
@@ -2152,7 +2202,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-12] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-12 > [role="img"],
@@ -2221,7 +2273,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-15] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-15 > [role="img"],
@@ -2283,7 +2337,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-17] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-17 > [role="img"],
@@ -2338,7 +2394,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-19] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-19 > [role="img"],
@@ -2399,7 +2457,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-21] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-21 > [role="img"],
@@ -2461,7 +2521,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-23] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-23 > [role="img"],
@@ -2516,7 +2578,9 @@ exports[`Avatar demo examples Snapshots: sizes 1`] = `
 [data-css-25] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-25 > [role="img"],

--- a/src/library/Card/__tests__/__snapshots__/Card.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/Card.spec.js.snap
@@ -846,7 +846,9 @@ exports[`Card demo examples Snapshots: avatar 1`] = `
 [data-css-19] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-19 > [role="img"],
@@ -6081,7 +6083,9 @@ exports[`Card demo examples Snapshots: rtl 3`] = `
 [data-css-12] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-12 > [role="img"],

--- a/src/library/Menu/__tests__/__snapshots__/Menu.spec.js.snap
+++ b/src/library/Menu/__tests__/__snapshots__/Menu.spec.js.snap
@@ -797,7 +797,9 @@ exports[`Menu demo examples Snapshots: custom-item 1`] = `
 [data-css-19] > img {
   border-radius: 100%;
   display: block;
-  width: 100%;
+  flex: 0 0 auto;
+  max-width: 100%;
+  -webkit-flex: 0 0 auto;
 }
 
 .css-19 > [role="img"],


### PR DESCRIPTION
### Description

Fixes Avatar display of child svg images in IE 11

### Motivation and context

closes #712 

### Screenshots, videos, or demo, if appropriate

<img width="267" alt="screen shot 2018-06-08 at 7 07 36 am" src="https://user-images.githubusercontent.com/202773/41159869-31e20b1e-6aeb-11e8-879a-d308fa1782b6.png">

https://712-avatar--mineral-ui.netlify.com/

### How to test

1. Do some cross-browser testing - https://712-avatar--mineral-ui.netlify.com/components/avatar

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
