### PR TITLE
[TextInput] Fix Safari display of search inputs

### DIFF
--- a/src/library/TextInput/TextInput.js
+++ b/src/library/TextInput/TextInput.js
@@ -43,6 +43,7 @@ type Props = {
     | 'month'
     | 'number'
     | 'password'
+    | 'search'
     | 'tel'
     | 'text'
     | 'time'
@@ -96,7 +97,16 @@ const styles = {
       fontFamily: 'inherit',
       height: getNormalizedValue(theme[`TextInput_height_${size}`], fontSize),
       minWidth: 0,
-      width: '100%'
+      width: '100%',
+
+      // Normalize Safari search inputs
+      '&[type="search"]': {
+        WebkitAppearance: 'none',
+
+        '&::-webkit-search-decoration': {
+          WebkitAppearance: 'none'
+        }
+      }
     };
   },
   root: ({ theme: baseTheme, variant }) => {

--- a/src/library/TextInput/__tests__/TextInput.spec.js
+++ b/src/library/TextInput/__tests__/TextInput.spec.js
@@ -11,7 +11,7 @@ function shallowTextInput() {
 
 describe('TextInput', () => {
   testDemoExamples(examples, {
-    exclude: ['states']
+    exclude: ['states', 'types']
   });
 
   it('renders', () => {

--- a/src/website/app/demos/TextInput/examples/index.js
+++ b/src/website/app/demos/TextInput/examples/index.js
@@ -15,6 +15,7 @@ import required from './required';
 import rtl from './rtl';
 import sizes from './sizes';
 import states from './states';
+import types from './types';
 import uncontrolled from './uncontrolled';
 import variants from './variants';
 
@@ -35,6 +36,7 @@ export default [
   rtl,
   formField,
   nextToButton,
+  types,
   kitchenSink,
   states
 ];

--- a/src/website/app/demos/TextInput/examples/types.js
+++ b/src/website/app/demos/TextInput/examples/types.js
@@ -1,0 +1,52 @@
+/* @flow */
+import React from 'react';
+import FormField from '../../../../../library/Form/FormField';
+import TextInput from '../../../../../library/TextInput/';
+import DemoLayout from '../../shared/DemoLayout';
+
+const types = [
+  'date',
+  'datetime-local',
+  'email',
+  'month',
+  'number',
+  'password',
+  'search',
+  'tel',
+  'text',
+  'time',
+  'url',
+  'week'
+  /* Unsupported types
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit'
+  */
+];
+
+const Demo = () => {
+  return (
+    <DemoLayout>
+      {types.map((type, index) => (
+        <FormField label={type} input={TextInput} type={type} key={index} />
+      ))}
+    </DemoLayout>
+  );
+};
+
+export default {
+  id: 'types',
+  title: 'Input Types',
+  description: `Various input types`,
+  hideFromProd: true,
+  hideSource: true,
+  scope: { Demo },
+  source: `<Demo />`
+};


### PR DESCRIPTION
### Description

Fix Safari display of search inputs

* Adds dev-only types example to TextInput demo - useful for visual comparison across different browsers

### Motivation and context

closes #709 

### Screenshots, videos, or demo, if appropriate

https://709-textinput--mineral-ui.netlify.com/

### How to test

Validate that Safari now displays TextInputs properly when `type="search"` is specified.

As the types example is dev-only, you'll either need to run the branch locally to use that.  Alternatively, you can just add `type="search"` to any TextInput example.  Alternative to that, Select's [Custom Menu](https://709-textinput--mineral-ui.netlify.com/components/select/custom-menu) example contains a search input and you can just look at that.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
