### PR TITLE
test(happo): Update to happo.io@1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "flow-typed": "2.4.0",
     "fs-extra": "5.0.0",
     "glob": "7.1.2",
-    "happo.io": "1.2.0",
+    "happo.io": "1.5.0",
     "html-webpack-plugin": "3.1.0",
     "husky": "0.14.3",
     "inquirer": "5.2.0",


### PR DESCRIPTION
### Description

Recently, I've been working on making Happo runs work for PRs coming
from forks. Version 1.5.0 of the happo.io client has support for
temporary authentication tied to a specific PR on github. This is
helpful when running happo in CI (Travis/CircleCI/etc) because in
general, secret environment variables aren't sent to the job running for
the fork (for obvious reasons: anyone would be able to extract secrets).


### Motivation and context

This change will enable running screenshot testing via happo.io on outside contributions. 

### How to test

It's hard to test this particular change in isolation. The upcoming PR (which I'll work on as soon as this is on master) will validate that things are working. If you want to be extra thorough with this change, I recommend checking it out locally and running `npm install && npm run happo` and make sure there are no errors. You can also take a look at the list of changes between 1.2.0 (the previous version you were running) and 1.5.0: 
https://github.com/enduire/happo.io/compare/v1.2.0...v1.5.0
