### PR TITLE
[ButtonGroup] Add New Component

### DIFF
--- a/src/library/Avatar/__tests__/__snapshots__/Avatar.spec.js.snap
+++ b/src/library/Avatar/__tests__/__snapshots__/Avatar.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Avatar demo examples Snapshots: basic 1`] = `
-.emotion-4 > * {
+.emotion-4[class] > * {
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
@@ -297,7 +297,7 @@ exports[`Avatar demo examples Snapshots: basic 1`] = `
 `;
 
 exports[`Avatar demo examples Snapshots: colors 1`] = `
-.emotion-14 > * {
+.emotion-14[class] > * {
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
@@ -1453,7 +1453,7 @@ exports[`Avatar demo examples Snapshots: custom-text-abbr 1`] = `
 `;
 
 exports[`Avatar demo examples Snapshots: shapes 1`] = `
-.emotion-3 > * {
+.emotion-3[class] > * {
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
@@ -1708,7 +1708,7 @@ exports[`Avatar demo examples Snapshots: shapes 1`] = `
 `;
 
 exports[`Avatar demo examples Snapshots: sizes 1`] = `
-.emotion-16 > * {
+.emotion-16[class] > * {
   margin-right: 1rem;
   margin-bottom: 1rem;
 }

--- a/src/library/Button/Button.js
+++ b/src/library/Button/Button.js
@@ -29,7 +29,7 @@ type Props = {
   /** Available types */
   type?: string,
   /** Available variants */
-  variant?: 'regular' | 'danger' | 'success' | 'warning'
+  variant?: 'danger' | 'success' | 'warning'
 };
 
 // prettier-ignore
@@ -84,20 +84,20 @@ function chooseColor({ disabled, primary, minimal }: Props, theme) {
 }
 
 const styles = {
-  button: (props) => {
-    let theme = componentTheme(props.theme);
-    const {
-      circular,
-      disabled,
-      fullWidth,
-      minimal,
-      primary,
-      size,
-      text,
-      variant
-    } = props;
+  button: ({
+    circular,
+    disabled,
+    fullWidth,
+    minimal,
+    primary,
+    size,
+    text,
+    theme: baseTheme,
+    variant
+  }) => {
+    let theme = componentTheme(baseTheme);
 
-    if (variant !== 'regular') {
+    if (variant) {
       // prettier-ignore
       theme = {
         ...theme,
@@ -113,7 +113,7 @@ const styles = {
       };
     }
 
-    const color = chooseColor(props, theme);
+    const color = chooseColor({ disabled, primary, minimal }, theme);
     return {
       backgroundColor: (() => {
         if (disabled && !minimal) {
@@ -140,6 +140,7 @@ const styles = {
       display: 'inline-block',
       fontWeight: theme.Button_fontWeight,
       height: theme[`Button_height_${size}`],
+      margin: 0,
       // if the user puts in a small icon in a large button
       // we want to force the button to be round/square
       // (really just pertinent on icon-only buttons)
@@ -223,9 +224,8 @@ const styles = {
       }
     };
   },
-  content: (props) => {
-    const theme = componentTheme(props.theme);
-    const { size } = props;
+  content: ({ size, theme: baseTheme }) => {
+    const theme = componentTheme(baseTheme);
 
     let paddings;
 
@@ -266,6 +266,7 @@ const styles = {
     display: 'inline-flex',
     justifyContent: 'center',
     maxHeight: '100%',
+    pointerEvents: 'none',
     width: '100%'
   }
 };
@@ -319,8 +320,7 @@ export default class Button extends Component<Props> {
   static defaultProps = {
     element: 'button',
     size: 'large',
-    type: 'button',
-    variant: 'regular'
+    type: 'button'
   };
 
   componentWillUpdate(nextProps: Props) {
@@ -338,7 +338,7 @@ export default class Button extends Component<Props> {
       iconEnd,
       size = Button.defaultProps.size,
       type = Button.defaultProps.type,
-      variant = Button.defaultProps.variant,
+      variant,
       ...restProps
     } = this.props;
 

--- a/src/library/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/library/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button demo examples Snapshots: circular 1`] = `
-.emotion-18 > * {
+.emotion-18[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -20,6 +20,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -55,6 +56,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -128,6 +130,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -200,6 +203,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -272,6 +276,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0.1875em;
   -webkit-text-decoration: none;
@@ -345,6 +350,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -418,6 +424,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0.8125em;
   -webkit-text-decoration: none;
@@ -495,7 +502,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
             iconStart={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -503,7 +509,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
               element="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -557,7 +562,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
             primary={true}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -566,7 +570,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
               primary={true}
               size="large"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -620,7 +623,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
             minimal={true}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -629,7 +631,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
               minimal={true}
               size="large"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -682,7 +683,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
             iconStart={<IconCloud />}
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -690,7 +690,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
               element="button"
               size="small"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -743,7 +742,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
             iconStart={<IconCloud />}
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -751,7 +749,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
               element="button"
               size="medium"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -804,7 +801,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
             iconStart={<IconCloud />}
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -812,7 +808,6 @@ exports[`Button demo examples Snapshots: circular 1`] = `
               element="button"
               size="jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -866,7 +861,7 @@ exports[`Button demo examples Snapshots: circular 1`] = `
 `;
 
 exports[`Button demo examples Snapshots: default 1`] = `
-.emotion-15 > * {
+.emotion-15[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -885,6 +880,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -925,6 +921,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -998,6 +995,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1071,6 +1069,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1144,6 +1143,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1217,6 +1217,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1287,14 +1288,12 @@ exports[`Button demo examples Snapshots: default 1`] = `
           element="button"
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
             size="large"
             text="Default"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-2"
@@ -1428,7 +1427,6 @@ exports[`Button demo examples Snapshots: default 1`] = `
           element="button"
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             disabled={true}
@@ -1436,7 +1434,6 @@ exports[`Button demo examples Snapshots: default 1`] = `
             size="large"
             text="Disabled"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-14"
@@ -1468,7 +1465,7 @@ exports[`Button demo examples Snapshots: default 1`] = `
 `;
 
 exports[`Button demo examples Snapshots: icon-only 1`] = `
-.emotion-18 > * {
+.emotion-18[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -1487,6 +1484,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1522,6 +1520,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -1595,6 +1594,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -1667,6 +1667,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -1739,6 +1740,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0.1875em;
   -webkit-text-decoration: none;
@@ -1812,6 +1814,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -1885,6 +1888,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0.8125em;
   -webkit-text-decoration: none;
@@ -1961,14 +1965,12 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
             iconStart={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
               element="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -2021,7 +2023,6 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
             primary={true}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -2029,7 +2030,6 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
               primary={true}
               size="large"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -2082,7 +2082,6 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
             minimal={true}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
@@ -2090,7 +2089,6 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
               minimal={true}
               size="large"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -2142,14 +2140,12 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
             iconStart={<IconCloud />}
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
               element="button"
               size="small"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -2201,14 +2197,12 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
             iconStart={<IconCloud />}
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
               element="button"
               size="medium"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -2260,14 +2254,12 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
             iconStart={<IconCloud />}
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               aria-label="Cloud"
               element="button"
               size="jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 aria-label="Cloud"
@@ -2321,7 +2313,7 @@ exports[`Button demo examples Snapshots: icon-only 1`] = `
 `;
 
 exports[`Button demo examples Snapshots: icons 1`] = `
-.emotion-53 > * {
+.emotion-53[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -2344,6 +2336,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2412,6 +2405,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2452,6 +2446,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2525,6 +2520,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2598,6 +2594,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2671,6 +2668,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2744,6 +2742,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2814,6 +2813,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2886,6 +2886,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2970,6 +2971,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3054,6 +3056,7 @@ exports[`Button demo examples Snapshots: icons 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3162,14 +3165,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Start icon"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-3"
@@ -3228,14 +3229,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconEnd={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="End icon"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-3"
@@ -3295,14 +3294,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Both icons"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-3"
@@ -3394,7 +3391,6 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             primary={true}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -3402,7 +3398,6 @@ exports[`Button demo examples Snapshots: icons 1`] = `
               size="large"
               text="Primary"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-16"
@@ -3462,7 +3457,6 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             minimal={true}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -3470,7 +3464,6 @@ exports[`Button demo examples Snapshots: icons 1`] = `
               size="large"
               text="Minimal"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-20"
@@ -3728,7 +3721,6 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               disabled={true}
@@ -3736,7 +3728,6 @@ exports[`Button demo examples Snapshots: icons 1`] = `
               size="large"
               text="Disabled"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-36"
@@ -3798,14 +3789,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="small"
               text="Small"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-40"
@@ -3864,14 +3853,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="medium"
               text="Medium"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-44"
@@ -3930,14 +3917,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Large"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-3"
@@ -3996,14 +3981,12 @@ exports[`Button demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="jumbo"
               text="Jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-52"
@@ -4079,6 +4062,7 @@ exports[`Button demo examples Snapshots: link 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4119,6 +4103,7 @@ exports[`Button demo examples Snapshots: link 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4179,7 +4164,6 @@ exports[`Button demo examples Snapshots: link 1`] = `
   href="#link"
   size="large"
   type="button"
-  variant="regular"
 >
   <Button
     element="a"
@@ -4187,7 +4171,6 @@ exports[`Button demo examples Snapshots: link 1`] = `
     size="large"
     text="Link"
     type="button"
-    variant="regular"
   >
     <a
       className="emotion-2"
@@ -4214,7 +4197,7 @@ exports[`Button demo examples Snapshots: link 1`] = `
 `;
 
 exports[`Button demo examples Snapshots: minimal 1`] = `
-.emotion-15 > * {
+.emotion-15[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -4233,6 +4216,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4273,6 +4257,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4345,6 +4330,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4417,6 +4403,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4489,6 +4476,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4561,6 +4549,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4631,7 +4620,6 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
           minimal={true}
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
@@ -4639,7 +4627,6 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
             size="large"
             text="Default"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-2"
@@ -4780,7 +4767,6 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
           minimal={true}
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             disabled={true}
@@ -4789,7 +4775,6 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
             size="large"
             text="Disabled"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-14"
@@ -4821,7 +4806,7 @@ exports[`Button demo examples Snapshots: minimal 1`] = `
 `;
 
 exports[`Button demo examples Snapshots: primary 1`] = `
-.emotion-15 > * {
+.emotion-15[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -4844,6 +4829,7 @@ exports[`Button demo examples Snapshots: primary 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4912,6 +4898,7 @@ exports[`Button demo examples Snapshots: primary 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4952,6 +4939,7 @@ exports[`Button demo examples Snapshots: primary 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5024,6 +5012,7 @@ exports[`Button demo examples Snapshots: primary 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5096,6 +5085,7 @@ exports[`Button demo examples Snapshots: primary 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5168,6 +5158,7 @@ exports[`Button demo examples Snapshots: primary 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5239,7 +5230,6 @@ exports[`Button demo examples Snapshots: primary 1`] = `
           primary={true}
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
@@ -5247,7 +5237,6 @@ exports[`Button demo examples Snapshots: primary 1`] = `
             size="large"
             text="Default"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-2"
@@ -5388,7 +5377,6 @@ exports[`Button demo examples Snapshots: primary 1`] = `
           primary={true}
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             disabled={true}
@@ -5397,7 +5385,6 @@ exports[`Button demo examples Snapshots: primary 1`] = `
             size="large"
             text="Disabled"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-14"
@@ -5443,6 +5430,7 @@ exports[`Button demo examples Snapshots: rtl 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -5464,6 +5452,7 @@ exports[`Button demo examples Snapshots: rtl 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5558,14 +5547,12 @@ exports[`Button demo examples Snapshots: rtl 1`] = `
         iconStart={<IconBackspace />}
         size="large"
         type="button"
-        variant="regular"
       >
         <Button
           element="button"
           size="large"
           text="قم بعمل ما"
           type="button"
-          variant="regular"
         >
           <button
             className="emotion-3"
@@ -5625,7 +5612,7 @@ exports[`Button demo examples Snapshots: rtl 1`] = `
 `;
 
 exports[`Button demo examples Snapshots: sizes 1`] = `
-.emotion-15 > * {
+.emotion-15[class] > * {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -5644,6 +5631,7 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -5684,6 +5672,7 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5757,6 +5746,7 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5841,6 +5831,7 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5925,6 +5916,7 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6017,6 +6009,7 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6091,14 +6084,12 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
           element="button"
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
             size="small"
             text="Small"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-2"
@@ -6126,14 +6117,12 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
           element="button"
           size="medium"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
             size="medium"
             text="Medium"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-5"
@@ -6161,14 +6150,12 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
           element="button"
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
             size="large"
             text="Large"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-8"
@@ -6196,14 +6183,12 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
           element="button"
           size="jumbo"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
             size="jumbo"
             text="Jumbo"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-11"
@@ -6232,7 +6217,6 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
           fullWidth={true}
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
@@ -6240,7 +6224,6 @@ exports[`Button demo examples Snapshots: sizes 1`] = `
             size="large"
             text="Full Width"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-14"
@@ -6285,6 +6268,7 @@ exports[`Button demo examples Snapshots: truncation 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -6325,6 +6309,7 @@ exports[`Button demo examples Snapshots: truncation 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6392,14 +6377,12 @@ exports[`Button demo examples Snapshots: truncation 1`] = `
       element="button"
       size="large"
       type="button"
-      variant="regular"
     >
       <Button
         element="button"
         size="large"
         text="Supercalifragilisticexpialidocious"
         type="button"
-        variant="regular"
       >
         <button
           className="emotion-2"
@@ -6446,6 +6429,7 @@ exports[`Button type prop is filtered when type=[button type] when element=NonFi
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6506,7 +6490,6 @@ exports[`Button type prop is filtered when type=[button type] when element=NonFi
   onClick={[MockFunction]}
   size="large"
   type="button"
-  variant="regular"
 >
   <Button
     element={[Function]}
@@ -6514,7 +6497,6 @@ exports[`Button type prop is filtered when type=[button type] when element=NonFi
     size="large"
     text="Do Something"
     type="button"
-    variant="regular"
   >
     <Button
       className="emotion-0"
@@ -6548,6 +6530,7 @@ exports[`Button type prop is filtered when type=[button type] when element=a 1`]
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -6588,6 +6571,7 @@ exports[`Button type prop is filtered when type=[button type] when element=a 1`]
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6648,7 +6632,6 @@ exports[`Button type prop is filtered when type=[button type] when element=a 1`]
   onClick={[MockFunction]}
   size="large"
   type="button"
-  variant="regular"
 >
   <Button
     element="a"
@@ -6656,7 +6639,6 @@ exports[`Button type prop is filtered when type=[button type] when element=a 1`]
     size="large"
     text="Do Something"
     type="button"
-    variant="regular"
   >
     <a
       className="emotion-2"
@@ -6697,6 +6679,7 @@ exports[`Button type prop is filtered when type=[not a button type] when element
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -6737,6 +6720,7 @@ exports[`Button type prop is filtered when type=[not a button type] when element
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6797,7 +6781,6 @@ exports[`Button type prop is filtered when type=[not a button type] when element
   onClick={[MockFunction]}
   size="large"
   type="foo"
-  variant="regular"
 >
   <Button
     element="button"
@@ -6805,7 +6788,6 @@ exports[`Button type prop is filtered when type=[not a button type] when element
     size="large"
     text="Do Something"
     type="foo"
-    variant="regular"
   >
     <button
       className="emotion-2"
@@ -6850,6 +6832,7 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=Non
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6910,7 +6893,6 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=Non
   onClick={[MockFunction]}
   size="large"
   type="video"
-  variant="regular"
 >
   <Button
     element={[Function]}
@@ -6918,7 +6900,6 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=Non
     size="large"
     text="Do Something"
     type="video"
-    variant="regular"
   >
     <Button
       className="emotion-0"
@@ -6954,6 +6935,7 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=a 1
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -6994,6 +6976,7 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=a 1
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -7054,7 +7037,6 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=a 1
   onClick={[MockFunction]}
   size="large"
   type="video"
-  variant="regular"
 >
   <Button
     element="a"
@@ -7062,7 +7044,6 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=a 1
     size="large"
     text="Do Something"
     type="video"
-    variant="regular"
   >
     <a
       className="emotion-2"
@@ -7104,6 +7085,7 @@ exports[`Button type prop is not filtered when type=[button type] when element=b
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -7144,6 +7126,7 @@ exports[`Button type prop is not filtered when type=[button type] when element=b
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -7204,7 +7187,6 @@ exports[`Button type prop is not filtered when type=[button type] when element=b
   onClick={[MockFunction]}
   size="large"
   type="button"
-  variant="regular"
 >
   <Button
     element="button"
@@ -7212,7 +7194,6 @@ exports[`Button type prop is not filtered when type=[button type] when element=b
     size="large"
     text="Do Something"
     type="button"
-    variant="regular"
   >
     <button
       className="emotion-2"

--- a/src/library/ButtonGroup/ButtonGroup.js
+++ b/src/library/ButtonGroup/ButtonGroup.js
@@ -1,0 +1,294 @@
+/* @flow */
+import React, { Children, Component, cloneElement } from 'react';
+import { createStyledComponent } from '../styles';
+import { setFromArray, toArray } from '../utils/collections';
+import composeEventHandlers from '../utils/composeEventHandlers';
+
+type Props = {
+  /** Accessible label */
+  'aria-label': string,
+  /**
+   * Index or array of indices of the selected [Button(s)](/components/button).
+   * Primarily for use with controlled components with a `mode` prop defined.
+   * If this prop is specified, an `onClick` handler must also be specified.
+   * See also: `defaultChecked`
+   */
+  checked?: number | Array<number>,
+  /** Mineral [Button](/components/button) components */
+  children: React$Node,
+  /**
+   * Index or array of indices of the selected [Button(s)](/components/button);
+   * primarily for use with uncontrolled components with a `mode` prop defined.
+   */
+  defaultChecked?: number | Array<number>,
+  /** Disable all [Button](/components/button) children */
+  disabled?: boolean,
+  /** Stretch ButtonGroup to fill its container */
+  fullWidth?: boolean,
+  /** Behavioral mode of [Button](/components/button) children: either
+   [Radio](/components/radio) or [Checkbox](/components/checkbox) */
+  mode?: 'checkbox' | 'radio',
+  /** Called when a toggleable Button is selected */
+  onChange?: (event: SyntheticEvent<HTMLButtonElement>) => void,
+  /** Called with the click event */
+  onClick?: (event: SyntheticEvent<HTMLButtonElement>) => void,
+  /** Available sizes */
+  size?: 'small' | 'medium' | 'large' | 'jumbo',
+  /** Available variants */
+  variant?: 'danger' | 'success' | 'warning'
+};
+
+type State = {
+  checked: Set<number>
+};
+
+export const componentTheme = (baseTheme: Object) => ({
+  ButtonGroupButton_backgroundColor_checkedDisabled: baseTheme.color_gray_40,
+  ButtonGroupButton_border_disabled: `solid 1px ${baseTheme.borderColor}`,
+  ButtonGroupButton_borderStartColor: baseTheme.borderColor,
+  ButtonGroupButton_borderStartColor_checked: 'currentcolor',
+  ButtonGroupButton_color_checkedDisabled: baseTheme.color_gray_60,
+
+  ...baseTheme
+});
+
+const styles = ({ fullWidth, theme: baseTheme }) => {
+  let theme = componentTheme(baseTheme);
+  const { direction } = theme;
+  const rtl = direction === 'rtl';
+
+  return {
+    display: 'flex',
+
+    '& button': {
+      flexGrow: fullWidth && 1,
+
+      '&:focus, &:active': {
+        position: 'relative'
+      },
+
+      '&[disabled]': {
+        border: theme.ButtonGroupButton_border_disabled,
+
+        '&[aria-checked=true]': {
+          backgroundColor:
+            theme.ButtonGroupButton_backgroundColor_checkedDisabled,
+          color: theme.ButtonGroupButton_color_checkedDisabled,
+
+          '&:hover': {
+            color: theme.ButtonGroupButton_color_checkedDisabled
+          }
+        }
+      }
+    },
+
+    '& > button:not(:first-child), & > *:not(:first-child) button': rtl
+      ? {
+          borderRightColor: 'transparent',
+          borderBottomRightRadius: 0,
+          borderTopRightRadius: 0
+        }
+      : {
+          borderLeftColor: 'transparent',
+          borderBottomLeftRadius: 0,
+          borderTopLeftRadius: 0
+        },
+
+    '& > button:not(:last-child), & > *:not(:last-child) button': rtl
+      ? {
+          borderBottomLeftRadius: 0,
+          borderTopLeftRadius: 0
+        }
+      : {
+          borderBottomRightRadius: 0,
+          borderTopRightRadius: 0
+        },
+
+    '& > [aria-checked]:not(:last-child)': rtl
+      ? { borderLeftColor: 'transparent' }
+      : { borderRightColor: 'transparent' },
+
+    '& > [aria-checked=false] + *:not(button) button': rtl
+      ? { borderRightColor: theme.ButtonGroupButton_borderStartColor }
+      : { borderLeftColor: theme.ButtonGroupButton_borderStartColor },
+
+    '& > [aria-checked=true] + [aria-checked=true]': {
+      '&:not(:focus), & button:not(:focus)': {
+        borderLeftColor:
+          !rtl && theme.ButtonGroupButton_borderStartColor_checked,
+        borderRightColor:
+          rtl && theme.ButtonGroupButton_borderStartColor_checked
+      }
+    },
+
+    '& > [aria-checked=false], & > *:not([aria-checked])': {
+      '&:focus, & button:focus': {
+        borderLeftColor: theme.ButtonGroupButton_borderStartColor,
+        borderRightColor: theme.ButtonGroupButton_borderStartColor
+      }
+    },
+    '& > [aria-checked=false] + [aria-checked=false]': {
+      '&:not(:focus)': {
+        borderLeftColor: !rtl && theme.ButtonGroupButton_borderStartColor,
+        borderRightColor: rtl && theme.ButtonGroupButton_borderStartColor
+      }
+    }
+  };
+};
+
+const isChecked = (checked: number | Array<number> | Set<number>, index) => {
+  const isSet = checked instanceof Set;
+  const checkedSet = isSet ? checked : setFromArray(toArray(checked));
+  // $FlowFixMe - Refinement to Set not working
+  return checkedSet.has(index);
+};
+
+const getDefaultCheckedState = (props: Props) => {
+  const { children: _children, defaultChecked, mode } = props;
+  const children = Children.toArray(_children);
+
+  if (mode && defaultChecked !== undefined) {
+    const defaultCheckedArray = toArray(defaultChecked);
+    const checked =
+      mode === 'checkbox' ? defaultCheckedArray : [defaultCheckedArray[0]];
+    return setFromArray(checked);
+  }
+
+  const checked: Set<number> = new Set();
+
+  children.forEach((child, index) => {
+    if (mode === 'checkbox') {
+      if (child.props.defaultChecked) {
+        checked.add(index);
+      }
+    } else if (mode === 'radio') {
+      const selectedChild = children.find(
+        (child) => child.props.defaultChecked
+      );
+      const index = children.indexOf(selectedChild);
+      if (index !== -1) {
+        checked.add(index);
+      }
+    }
+  });
+
+  return checked;
+};
+
+const Root = createStyledComponent('div', styles, {
+  displayName: 'ButtonGroup',
+  includeStyleReset: true
+});
+
+/**
+ * ButtonGroup allows authors to stylistically group a set of related
+ * [Buttons](/components/button) or construct a group of selectable Buttons that
+ * behave like [Radios](/components/radio) or [Checkboxes](/components/checkbox).
+ */
+export default class ButtonGroup extends Component<Props, State> {
+  static displayName = 'ButtonGroup';
+
+  state = {
+    checked: getDefaultCheckedState(this.props)
+  };
+
+  render() {
+    const {
+      children,
+      disabled,
+      fullWidth,
+      mode,
+      onClick: ignoreOnClick,
+      size,
+      variant,
+      ...restProps
+    } = this.props;
+    const rootProps = {
+      disabled,
+      fullWidth,
+      mode,
+      role: mode === 'radio' ? 'radiogroup' : 'group',
+      ...restProps
+    };
+    const checked = this.getControllableValue('checked');
+    const buttons = Children.map(children, (child, index) => {
+      const isChildToggleable = mode;
+      const isChildChecked = isChecked(checked, index);
+
+      return cloneElement(child, {
+        ...(isChildToggleable ? { 'aria-checked': isChildChecked } : undefined),
+        'data-index': index,
+        disabled: disabled || child.props.disabled,
+        key: index,
+        ...(isChildToggleable && isChildChecked
+          ? { primary: true }
+          : undefined),
+        onClick: composeEventHandlers(
+          child.props.onClick,
+          this.handleClick.bind(null, index)
+        ),
+        ...(isChildToggleable ? { role: mode } : undefined),
+        size,
+        ...(variant ? { variant } : undefined)
+      });
+    });
+
+    return <Root {...rootProps}>{buttons}</Root>;
+  }
+
+  handleClick = (index: number, event: SyntheticEvent<HTMLButtonElement>) => {
+    const { mode } = this.props;
+
+    if (!mode) {
+      return this.clickActions(event, false);
+    }
+
+    event.persist();
+    const { currentTarget: target } = event;
+
+    if (this.isControlled('checked')) {
+      this.clickActions(event, true);
+    } else {
+      let changed;
+      this.setState(
+        (prevState) => {
+          let checked;
+          if (mode === 'checkbox') {
+            changed = true;
+            checked = prevState.checked;
+            const dataIndex = parseInt(target.getAttribute('data-index'));
+            checked.has(dataIndex)
+              ? checked.delete(dataIndex)
+              : checked.add(dataIndex);
+          } else {
+            checked = setFromArray([index]);
+            changed = [...prevState.checked][0] !== [...checked][0];
+          }
+
+          return { checked };
+        },
+        () => {
+          this.clickActions(event, changed);
+        }
+      );
+    }
+  };
+
+  clickActions = (
+    event: SyntheticEvent<HTMLButtonElement>,
+    changed: boolean
+  ) => {
+    const { onChange, onClick } = this.props;
+
+    onClick && onClick(event);
+    changed && onChange && onChange(event);
+  };
+
+  isControlled = (prop: string) => {
+    return this.props.hasOwnProperty(prop);
+  };
+
+  getControllableValue = (key: string) => {
+    return this.isControlled(key) ? this.props[key] : this.state[key];
+  };
+}

--- a/src/library/ButtonGroup/__tests__/ButtonGroup.spec.js
+++ b/src/library/ButtonGroup/__tests__/ButtonGroup.spec.js
@@ -1,0 +1,105 @@
+/* @flow */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { mountInThemeProvider } from '../../../../utils/enzymeUtils';
+import Button from '../../../library/Button';
+import ButtonGroup from '../ButtonGroup';
+import examples from '../../../website/app/demos/ButtonGroup/examples';
+import testDemoExamples from '../../../../utils/testDemoExamples';
+
+const defaultProps = {
+  'aria-label': 'Test',
+  children: <Button>Content</Button>,
+  onChange: jest.fn(),
+  onClick: jest.fn()
+};
+
+function shallowButtonGroup(props = {}) {
+  const buttonGroupProps = {
+    ...defaultProps,
+    ...props
+  };
+  return shallow(<ButtonGroup {...buttonGroupProps} />);
+}
+
+function mountButtonGroup(props = {}) {
+  const buttonGroupProps = {
+    ...defaultProps,
+    ...props
+  };
+
+  return mountInThemeProvider(<ButtonGroup {...buttonGroupProps} />);
+}
+
+describe('ButtonGroup', () => {
+  testDemoExamples(examples);
+
+  it('renders', () => {
+    const buttonGroup = shallowButtonGroup();
+
+    expect(buttonGroup.exists()).toEqual(true);
+  });
+
+  describe('event handlers', () => {
+    let button, buttonGroup;
+
+    beforeEach(() => {
+      defaultProps.onClick.mockReset();
+      defaultProps.onChange.mockReset();
+    });
+
+    describe('when no mode', () => {
+      beforeEach(() => {
+        [, buttonGroup] = mountButtonGroup();
+        button = buttonGroup.find('button');
+
+        button.simulate('click');
+      });
+
+      it('calls onClick handler', () => {
+        expect(defaultProps.onClick).toHaveBeenCalled();
+      });
+      it('does not call onChange handler', () => {
+        expect(defaultProps.onChange).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when mode=checkbox', () => {
+      beforeEach(() => {
+        [, buttonGroup] = mountButtonGroup({ mode: 'checkbox' });
+        button = buttonGroup.find('button');
+
+        button.simulate('click');
+      });
+
+      it('calls onClick handler', () => {
+        expect(defaultProps.onClick).toHaveBeenCalled();
+      });
+
+      it('calls onChange handler', () => {
+        button.simulate('click');
+
+        expect(defaultProps.onChange).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('when mode=radio', () => {
+      beforeEach(() => {
+        [, buttonGroup] = mountButtonGroup({ mode: 'radio' });
+        button = buttonGroup.find('button');
+
+        button.simulate('click');
+      });
+
+      it('calls onClick handler', () => {
+        expect(defaultProps.onClick).toHaveBeenCalled();
+      });
+
+      it('calls onChange when Button is toggled', () => {
+        button.simulate('click');
+
+        expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/library/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/library/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -1,0 +1,7404 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonGroup demo examples Snapshots: basic 1`] = `
+.emotion-9 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9 button:focus,
+.emotion-9 button:active {
+  position: relative;
+}
+
+.emotion-9 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-9 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-9 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-9 > button:not(:first-child),
+.emotion-9 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-9 > button:not(:last-child),
+.emotion-9 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-9 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-9 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-9 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-9 > [aria-checked=false]:focus,
+.emotion-9 > *:not([aria-checked]):focus,
+.emotion-9 > [aria-checked=false] button:focus,
+.emotion-9 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+<ButtonGroup
+  aria-label="Edit text"
+>
+  <ButtonGroup
+    aria-label="Edit text"
+    role="group"
+  >
+    <div
+      aria-label="Edit text"
+      className="emotion-9"
+      role="group"
+    >
+      <Button
+        data-index={0}
+        element="button"
+        key="0/.0"
+        onClick={[Function]}
+        size="large"
+        type="button"
+      >
+        <Button
+          data-index={0}
+          element="button"
+          onClick={[Function]}
+          size="large"
+          text="Cut"
+          type="button"
+        >
+          <button
+            className="emotion-2"
+            data-index={0}
+            onClick={[Function]}
+            type="button"
+          >
+            <Styled(span)>
+              <span
+                className="emotion-1"
+              >
+                <Styled(span)
+                  size="large"
+                >
+                  <span
+                    className="emotion-0"
+                  >
+                    Cut
+                  </span>
+                </Styled(span)>
+              </span>
+            </Styled(span)>
+          </button>
+        </Button>
+      </Button>
+      <Button
+        data-index={1}
+        element="button"
+        key="1/.1"
+        onClick={[Function]}
+        size="large"
+        type="button"
+      >
+        <Button
+          data-index={1}
+          element="button"
+          onClick={[Function]}
+          size="large"
+          text="Copy"
+          type="button"
+        >
+          <button
+            className="emotion-2"
+            data-index={1}
+            onClick={[Function]}
+            type="button"
+          >
+            <Styled(span)>
+              <span
+                className="emotion-1"
+              >
+                <Styled(span)
+                  size="large"
+                >
+                  <span
+                    className="emotion-0"
+                  >
+                    Copy
+                  </span>
+                </Styled(span)>
+              </span>
+            </Styled(span)>
+          </button>
+        </Button>
+      </Button>
+      <Button
+        data-index={2}
+        element="button"
+        key="2/.2"
+        onClick={[Function]}
+        size="large"
+        type="button"
+      >
+        <Button
+          data-index={2}
+          element="button"
+          onClick={[Function]}
+          size="large"
+          text="Paste"
+          type="button"
+        >
+          <button
+            className="emotion-2"
+            data-index={2}
+            onClick={[Function]}
+            type="button"
+          >
+            <Styled(span)>
+              <span
+                className="emotion-1"
+              >
+                <Styled(span)
+                  size="large"
+                >
+                  <span
+                    className="emotion-0"
+                  >
+                    Paste
+                  </span>
+                </Styled(span)>
+              </span>
+            </Styled(span)>
+          </button>
+        </Button>
+      </Button>
+    </div>
+  </ButtonGroup>
+</ButtonGroup>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
+.emotion-25 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-25 *,
+.emotion-25 *::before,
+.emotion-25 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-25 button:focus,
+.emotion-25 button:active {
+  position: relative;
+}
+
+.emotion-25 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-25 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-25 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-25 > button:not(:first-child),
+.emotion-25 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-25 > button:not(:last-child),
+.emotion-25 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-25 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-25 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-25 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-25 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-25 > [aria-checked=false]:focus,
+.emotion-25 > *:not([aria-checked]):focus,
+.emotion-25 > [aria-checked=false] button:focus,
+.emotion-25 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-25 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-18 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1.5em;
+  width: 1.5em;
+}
+
+@media only screen and (max-width:450px) {
+  .emotion-26 > * button {
+    max-width: 5rem;
+  }
+}
+
+@media only screen and (max-width:380px) {
+  .emotion-26 > * button {
+    max-width: 4rem;
+  }
+}
+
+.emotion-8 {
+  box-sizing: border-box;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+}
+
+.emotion-8 *,
+.emotion-8 *::before,
+.emotion-8 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-6 {
+  display: inline-block;
+}
+
+<Styled(div)>
+  <div
+    className="emotion-26"
+  >
+    <ButtonGroup
+      aria-label="Optional compositions"
+    >
+      <ButtonGroup
+        aria-label="Optional compositions"
+        role="group"
+      >
+        <div
+          aria-label="Optional compositions"
+          className="emotion-25"
+          role="group"
+        >
+          <Button
+            data-index={0}
+            element="button"
+            key="0/.0"
+            onClick={[Function]}
+            size="large"
+            type="button"
+          >
+            <Button
+              data-index={0}
+              element="button"
+              onClick={[Function]}
+              size="large"
+              text="Button"
+              type="button"
+            >
+              <button
+                className="emotion-2"
+                data-index={0}
+                onClick={[Function]}
+                type="button"
+              >
+                <Styled(span)>
+                  <span
+                    className="emotion-1"
+                  >
+                    <Styled(span)
+                      size="large"
+                    >
+                      <span
+                        className="emotion-0"
+                      >
+                        Button
+                      </span>
+                    </Styled(span)>
+                  </span>
+                </Styled(span)>
+              </button>
+            </Button>
+          </Button>
+          <Tooltip
+            content="Lorem ipsum dolor sit amet"
+            data-index={1}
+            hasArrow={true}
+            key="1/.1"
+            onClick={[Function]}
+          >
+            <WithTheme(Themed(Popover))
+              content={[Function]}
+              data-index={1}
+              focusTriggerOnClose={false}
+              hasArrow={true}
+              id="tooltip-19"
+              isOpen={false}
+              onClick={[Function]}
+              onClose={[Function]}
+              onOpen={[Function]}
+            >
+              <Themed(Popover)
+                content={[Function]}
+                data-index={1}
+                focusTriggerOnClose={false}
+                hasArrow={true}
+                id="tooltip-19"
+                isOpen={false}
+                onClick={[Function]}
+                onClose={[Function]}
+                onOpen={[Function]}
+              >
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <Popover
+                      content={[Function]}
+                      data-index={1}
+                      focusTriggerOnClose={false}
+                      hasArrow={true}
+                      id="tooltip-19"
+                      isOpen={false}
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onOpen={[Function]}
+                      placement="bottom"
+                    >
+                      <Popover
+                        content={[Function]}
+                        data-index={1}
+                        focusTriggerOnClose={false}
+                        hasArrow={true}
+                        id="tooltip-19"
+                        isOpen={false}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onOpen={[Function]}
+                        placement="bottom"
+                        tag="span"
+                      >
+                        <Popover
+                          className="emotion-8"
+                          data-index={1}
+                          id="tooltip-19"
+                          onClick={[Function]}
+                          tag="span"
+                        >
+                          <span
+                            className="emotion-8"
+                            data-index={1}
+                            id="tooltip-19"
+                            onClick={[Function]}
+                          >
+                            <PopoverTrigger
+                              aria-describedby="tooltip-19-content"
+                              aria-owns="tooltip-19-content"
+                              element="button"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              role="button"
+                              size="large"
+                              tabIndex={0}
+                              type="button"
+                            >
+                              <PopoverTrigger
+                                component="span"
+                              >
+                                <PopoverTrigger
+                                  className="emotion-6"
+                                  component="span"
+                                >
+                                  <span
+                                    className="emotion-6"
+                                  >
+                                    <Button
+                                      aria-describedby="tooltip-19-content"
+                                      aria-owns="tooltip-19-content"
+                                      element="button"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      role="button"
+                                      size="large"
+                                      tabIndex={0}
+                                      type="button"
+                                    >
+                                      <Button
+                                        aria-describedby="tooltip-19-content"
+                                        aria-owns="tooltip-19-content"
+                                        element="button"
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        role="button"
+                                        size="large"
+                                        tabIndex={0}
+                                        text="Tooltip"
+                                        type="button"
+                                      >
+                                        <button
+                                          aria-describedby="tooltip-19-content"
+                                          aria-owns="tooltip-19-content"
+                                          className="emotion-2"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          role="button"
+                                          tabIndex={0}
+                                          type="button"
+                                        >
+                                          <Styled(span)>
+                                            <span
+                                              className="emotion-1"
+                                            >
+                                              <Styled(span)
+                                                size="large"
+                                              >
+                                                <span
+                                                  className="emotion-0"
+                                                >
+                                                  Tooltip
+                                                </span>
+                                              </Styled(span)>
+                                            </span>
+                                          </Styled(span)>
+                                        </button>
+                                      </Button>
+                                    </Button>
+                                  </span>
+                                </PopoverTrigger>
+                              </PopoverTrigger>
+                            </PopoverTrigger>
+                          </span>
+                        </Popover>
+                      </Popover>
+                    </Popover>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(Popover)>
+            </WithTheme(Themed(Popover))>
+          </Tooltip>
+          <Popover
+            content={<DemoContent />}
+            data-index={2}
+            focusTriggerOnClose={true}
+            hasArrow={true}
+            key="2/.2"
+            onClick={[Function]}
+            placement="bottom"
+          >
+            <Popover
+              content={<DemoContent />}
+              data-index={2}
+              focusTriggerOnClose={true}
+              hasArrow={true}
+              onClick={[Function]}
+              placement="bottom"
+              tag="span"
+            >
+              <Popover
+                className="emotion-8"
+                data-index={2}
+                onClick={[Function]}
+                tag="span"
+              >
+                <span
+                  className="emotion-8"
+                  data-index={2}
+                  onClick={[Function]}
+                >
+                  <PopoverTrigger
+                    aria-describedby="popover-20-content"
+                    aria-expanded={false}
+                    aria-owns="popover-20-content"
+                    element="button"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    role="button"
+                    size="large"
+                    type="button"
+                  >
+                    <PopoverTrigger
+                      component="span"
+                    >
+                      <PopoverTrigger
+                        className="emotion-6"
+                        component="span"
+                      >
+                        <span
+                          className="emotion-6"
+                        >
+                          <Button
+                            aria-describedby="popover-20-content"
+                            aria-expanded={false}
+                            aria-owns="popover-20-content"
+                            element="button"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            role="button"
+                            size="large"
+                            type="button"
+                          >
+                            <Button
+                              aria-describedby="popover-20-content"
+                              aria-expanded={false}
+                              aria-owns="popover-20-content"
+                              element="button"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              role="button"
+                              size="large"
+                              text="Popover"
+                              type="button"
+                            >
+                              <button
+                                aria-describedby="popover-20-content"
+                                aria-expanded={false}
+                                aria-owns="popover-20-content"
+                                className="emotion-2"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                role="button"
+                                type="button"
+                              >
+                                <Styled(span)>
+                                  <span
+                                    className="emotion-1"
+                                  >
+                                    <Styled(span)
+                                      size="large"
+                                    >
+                                      <span
+                                        className="emotion-0"
+                                      >
+                                        Popover
+                                      </span>
+                                    </Styled(span)>
+                                  </span>
+                                </Styled(span)>
+                              </button>
+                            </Button>
+                          </Button>
+                        </span>
+                      </PopoverTrigger>
+                    </PopoverTrigger>
+                  </PopoverTrigger>
+                </span>
+              </Popover>
+            </Popover>
+          </Popover>
+          <Dropdown
+            data={
+              Array [
+                Object {
+                  "items": Array [
+                    Object {
+                      "text": "Light years",
+                    },
+                    Object {
+                      "text": "Star stuff",
+                    },
+                    Object {
+                      "text": "Encyclopaedia galactica",
+                    },
+                    Object {
+                      "text": "Cosmic ocean",
+                    },
+                  ],
+                },
+              ]
+            }
+            data-index={3}
+            itemKey="text"
+            key="3/.3"
+            onClick={[Function]}
+            placement="bottom-start"
+          >
+            <Popover
+              content={[Function]}
+              data-index={3}
+              focusTriggerOnClose={true}
+              hasArrow={true}
+              id="dropdown-21"
+              isOpen={false}
+              itemKey="text"
+              onClick={[Function]}
+              onClose={[Function]}
+              onOpen={[Function]}
+              placement="bottom-start"
+              triggerRef={[Function]}
+            >
+              <Popover
+                content={[Function]}
+                data-index={3}
+                focusTriggerOnClose={true}
+                hasArrow={true}
+                id="dropdown-21"
+                isOpen={false}
+                itemKey="text"
+                onClick={[Function]}
+                onClose={[Function]}
+                onOpen={[Function]}
+                placement="bottom-start"
+                tag="span"
+                triggerRef={[Function]}
+              >
+                <Popover
+                  className="emotion-8"
+                  data-index={3}
+                  id="dropdown-21"
+                  onClick={[Function]}
+                  tag="span"
+                >
+                  <span
+                    className="emotion-8"
+                    data-index={3}
+                    id="dropdown-21"
+                    onClick={[Function]}
+                  >
+                    <PopoverTrigger
+                      aria-describedby="dropdown-21-content"
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-owns="dropdown-21-content"
+                      element="button"
+                      iconEnd={<IconArrowDropDown />}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      role="button"
+                      size="large"
+                      type="button"
+                    >
+                      <PopoverTrigger
+                        component="span"
+                      >
+                        <PopoverTrigger
+                          className="emotion-6"
+                          component="span"
+                        >
+                          <span
+                            className="emotion-6"
+                          >
+                            <Button
+                              aria-describedby="dropdown-21-content"
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-owns="dropdown-21-content"
+                              element="button"
+                              iconEnd={<IconArrowDropDown />}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              onKeyUp={[Function]}
+                              role="button"
+                              size="large"
+                              type="button"
+                            >
+                              <Button
+                                aria-describedby="dropdown-21-content"
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-owns="dropdown-21-content"
+                                element="button"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                role="button"
+                                size="large"
+                                text="Dropdown"
+                                type="button"
+                              >
+                                <button
+                                  aria-describedby="dropdown-21-content"
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  aria-owns="dropdown-21-content"
+                                  className="emotion-2"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  role="button"
+                                  type="button"
+                                >
+                                  <Styled(span)>
+                                    <span
+                                      className="emotion-1"
+                                    >
+                                      <Styled(span)
+                                        size="large"
+                                      >
+                                        <span
+                                          className="emotion-0"
+                                        >
+                                          Dropdown
+                                        </span>
+                                      </Styled(span)>
+                                      <IconArrowDropDown
+                                        key="iconEnd"
+                                        size="1.5em"
+                                      >
+                                        <Icon
+                                          rtl={false}
+                                          size="1.5em"
+                                        >
+                                          <Styled(svg)
+                                            aria-hidden={true}
+                                            role="img"
+                                            rtl={false}
+                                            size="1.5em"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="emotion-18"
+                                              role="img"
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <g>
+                                                <path
+                                                  d="M7 10l5 5 5-5z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </Styled(svg)>
+                                        </Icon>
+                                      </IconArrowDropDown>
+                                    </span>
+                                  </Styled(span)>
+                                </button>
+                              </Button>
+                            </Button>
+                          </span>
+                        </PopoverTrigger>
+                      </PopoverTrigger>
+                    </PopoverTrigger>
+                  </span>
+                </Popover>
+              </Popover>
+            </Popover>
+          </Dropdown>
+        </div>
+      </ButtonGroup>
+    </ButtonGroup>
+  </div>
+</Styled(div)>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: controlled 1`] = `
+.emotion-9 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9 button:focus,
+.emotion-9 button:active {
+  position: relative;
+}
+
+.emotion-9 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-9 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-9 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-9 > button:not(:first-child),
+.emotion-9 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-9 > button:not(:last-child),
+.emotion-9 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-9 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-9 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-9 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-9 > [aria-checked=false]:focus,
+.emotion-9 > *:not([aria-checked]):focus,
+.emotion-9 > [aria-checked=false] button:focus,
+.emotion-9 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-5 *,
+.emotion-5 *::before,
+.emotion-5 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-5:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-5:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-5:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-5::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-5 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-5 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-5 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-5 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-13[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #ffffff;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #3272d9;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #3272d9;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #5691f0;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #1d5bbf;
+  color: #ffffff;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-12 {
+  box-sizing: border-box;
+  color: #3272d9;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 1.5em;
+  margin: 0;
+  min-width: 1.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-12:focus {
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #3272d9;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-12:hover {
+  background-color: #f5f7fa;
+  color: #3272d9;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-12:active {
+  background-color: #ebeff5;
+  color: #3272d9;
+}
+
+.emotion-12::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-12 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-12 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-12 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-12 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-10 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.75em;
+  line-height: 2em;
+}
+
+<Component>
+  <MyForm>
+    <DemoLayout>
+      <Styled(div)
+        marginBottom="1rem"
+      >
+        <div
+          className="emotion-13"
+        >
+          <ButtonGroup
+            aria-label="Align text"
+            checked={0}
+            mode="radio"
+            onChange={[Function]}
+          >
+            <ButtonGroup
+              aria-label="Align text"
+              checked={0}
+              mode="radio"
+              onChange={[Function]}
+              role="radiogroup"
+            >
+              <div
+                aria-label="Align text"
+                className="emotion-9"
+                onChange={[Function]}
+                role="radiogroup"
+              >
+                <Button
+                  aria-checked={true}
+                  data-index={0}
+                  element="button"
+                  key="0/.0"
+                  onClick={[Function]}
+                  primary={true}
+                  role="radio"
+                  size="large"
+                  type="button"
+                >
+                  <Button
+                    aria-checked={true}
+                    data-index={0}
+                    element="button"
+                    onClick={[Function]}
+                    primary={true}
+                    role="radio"
+                    size="large"
+                    text="Left"
+                    type="button"
+                  >
+                    <button
+                      aria-checked={true}
+                      className="emotion-2"
+                      data-index={0}
+                      onClick={[Function]}
+                      role="radio"
+                      type="button"
+                    >
+                      <Styled(span)>
+                        <span
+                          className="emotion-1"
+                        >
+                          <Styled(span)
+                            size="large"
+                          >
+                            <span
+                              className="emotion-0"
+                            >
+                              Left
+                            </span>
+                          </Styled(span)>
+                        </span>
+                      </Styled(span)>
+                    </button>
+                  </Button>
+                </Button>
+                <Button
+                  aria-checked={false}
+                  data-index={1}
+                  element="button"
+                  key="1/.1"
+                  onClick={[Function]}
+                  role="radio"
+                  size="large"
+                  type="button"
+                >
+                  <Button
+                    aria-checked={false}
+                    data-index={1}
+                    element="button"
+                    onClick={[Function]}
+                    role="radio"
+                    size="large"
+                    text="Center"
+                    type="button"
+                  >
+                    <button
+                      aria-checked={false}
+                      className="emotion-5"
+                      data-index={1}
+                      onClick={[Function]}
+                      role="radio"
+                      type="button"
+                    >
+                      <Styled(span)>
+                        <span
+                          className="emotion-1"
+                        >
+                          <Styled(span)
+                            size="large"
+                          >
+                            <span
+                              className="emotion-0"
+                            >
+                              Center
+                            </span>
+                          </Styled(span)>
+                        </span>
+                      </Styled(span)>
+                    </button>
+                  </Button>
+                </Button>
+                <Button
+                  aria-checked={false}
+                  data-index={2}
+                  element="button"
+                  key="2/.2"
+                  onClick={[Function]}
+                  role="radio"
+                  size="large"
+                  type="button"
+                >
+                  <Button
+                    aria-checked={false}
+                    data-index={2}
+                    element="button"
+                    onClick={[Function]}
+                    role="radio"
+                    size="large"
+                    text="Right"
+                    type="button"
+                  >
+                    <button
+                      aria-checked={false}
+                      className="emotion-5"
+                      data-index={2}
+                      onClick={[Function]}
+                      role="radio"
+                      type="button"
+                    >
+                      <Styled(span)>
+                        <span
+                          className="emotion-1"
+                        >
+                          <Styled(span)
+                            size="large"
+                          >
+                            <span
+                              className="emotion-0"
+                            >
+                              Right
+                            </span>
+                          </Styled(span)>
+                        </span>
+                      </Styled(span)>
+                    </button>
+                  </Button>
+                </Button>
+              </div>
+            </ButtonGroup>
+          </ButtonGroup>
+          <Button
+            element="button"
+            minimal={true}
+            onClick={[Function]}
+            size="small"
+            type="button"
+          >
+            <Button
+              element="button"
+              minimal={true}
+              onClick={[Function]}
+              size="small"
+              text="Reset to Default Alignment"
+              type="button"
+            >
+              <button
+                className="emotion-12"
+                onClick={[Function]}
+                type="button"
+              >
+                <Styled(span)>
+                  <span
+                    className="emotion-1"
+                  >
+                    <Styled(span)
+                      size="small"
+                    >
+                      <span
+                        className="emotion-10"
+                      >
+                        Reset to Default Alignment
+                      </span>
+                    </Styled(span)>
+                  </span>
+                </Styled(span)>
+              </button>
+            </Button>
+          </Button>
+        </div>
+      </Styled(div)>
+    </DemoLayout>
+  </MyForm>
+</Component>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: disabled 1`] = `
+.emotion-9 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9 button:focus,
+.emotion-9 button:active {
+  position: relative;
+}
+
+.emotion-9 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-9 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-9 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-9 > button:not(:first-child),
+.emotion-9 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-9 > button:not(:last-child),
+.emotion-9 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-9 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-9 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-9 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-9 > [aria-checked=false]:focus,
+.emotion-9 > *:not([aria-checked]):focus,
+.emotion-9 > [aria-checked=false] button:focus,
+.emotion-9 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-15 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-15 *,
+.emotion-15 *::before,
+.emotion-15 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-15:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-15:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-15:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-15::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-15 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-15 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-15 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-15 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-40[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-32 {
+  box-sizing: border-box;
+  color: #ffffff;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #3272d9;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-32 *,
+.emotion-32 *::before,
+.emotion-32 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-32:focus {
+  background-color: #3272d9;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-32:hover {
+  background-color: #5691f0;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-32:active {
+  background-color: #1d5bbf;
+  color: #ffffff;
+}
+
+.emotion-32::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-32 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-32 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-32 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-32 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #afbacc;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #dde3ed;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: default;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #afbacc;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  color: #afbacc;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  color: #afbacc;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-22 {
+  box-sizing: border-box;
+  color: #afbacc;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #dde3ed;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: default;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-22 *,
+.emotion-22 *::before,
+.emotion-22 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-22:focus {
+  background-color: #3272d9;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #afbacc;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-22:hover {
+  color: #afbacc;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-22:active {
+  color: #afbacc;
+}
+
+.emotion-22::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-22 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-22 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-22 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-22 [role="img"]:only-child {
+  margin: 0;
+}
+
+<DemoLayout>
+  <Styled(div)
+    marginBottom="1rem"
+  >
+    <div
+      className="emotion-40"
+    >
+      <ButtonGroup
+        aria-label="Edit text"
+        disabled={true}
+      >
+        <ButtonGroup
+          aria-label="Edit text"
+          disabled={true}
+          role="group"
+        >
+          <div
+            aria-label="Edit text"
+            className="emotion-9"
+            role="group"
+          >
+            <Button
+              data-index={0}
+              disabled={true}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              size="large"
+              type="button"
+            >
+              <Button
+                data-index={0}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Cut"
+                type="button"
+              >
+                <button
+                  className="emotion-2"
+                  data-index={0}
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Cut
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={1}
+              disabled={true}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              size="large"
+              type="button"
+            >
+              <Button
+                data-index={1}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Copy"
+                type="button"
+              >
+                <button
+                  className="emotion-2"
+                  data-index={1}
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Copy
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={2}
+              disabled={true}
+              element="button"
+              key="2/.2"
+              onClick={[Function]}
+              size="large"
+              type="button"
+            >
+              <Button
+                data-index={2}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Paste"
+                type="button"
+              >
+                <button
+                  className="emotion-2"
+                  data-index={2}
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Paste
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Edit text"
+      >
+        <ButtonGroup
+          aria-label="Edit text"
+          role="group"
+        >
+          <div
+            aria-label="Edit text"
+            className="emotion-9"
+            role="group"
+          >
+            <Button
+              data-index={0}
+              disabled={true}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              size="large"
+              type="button"
+            >
+              <Button
+                data-index={0}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Cut"
+                type="button"
+              >
+                <button
+                  className="emotion-2"
+                  data-index={0}
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Cut
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              size="large"
+              type="button"
+            >
+              <Button
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Copy"
+                type="button"
+              >
+                <button
+                  className="emotion-15"
+                  data-index={1}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Copy
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={2}
+              element="button"
+              key="2/.2"
+              onClick={[Function]}
+              size="large"
+              type="button"
+            >
+              <Button
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Paste"
+                type="button"
+              >
+                <button
+                  className="emotion-15"
+                  data-index={2}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Paste
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Align text"
+        defaultChecked={0}
+        disabled={true}
+        mode="radio"
+      >
+        <ButtonGroup
+          aria-label="Align text"
+          defaultChecked={0}
+          disabled={true}
+          mode="radio"
+          role="radiogroup"
+        >
+          <div
+            aria-label="Align text"
+            className="emotion-9"
+            defaultChecked={0}
+            role="radiogroup"
+          >
+            <Button
+              aria-checked={true}
+              data-index={0}
+              disabled={true}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              primary={true}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={true}
+                data-index={0}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                primary={true}
+                role="radio"
+                size="large"
+                text="Left"
+                type="button"
+              >
+                <button
+                  aria-checked={true}
+                  className="emotion-22"
+                  data-index={0}
+                  disabled={true}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Left
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={1}
+              disabled={true}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={1}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Center"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-2"
+                  data-index={1}
+                  disabled={true}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Center
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={2}
+              disabled={true}
+              element="button"
+              key="2/.2"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={2}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Right"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-2"
+                  data-index={2}
+                  disabled={true}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Right
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Align text"
+        defaultChecked={0}
+        mode="radio"
+      >
+        <ButtonGroup
+          aria-label="Align text"
+          defaultChecked={0}
+          mode="radio"
+          role="radiogroup"
+        >
+          <div
+            aria-label="Align text"
+            className="emotion-9"
+            defaultChecked={0}
+            role="radiogroup"
+          >
+            <Button
+              aria-checked={true}
+              data-index={0}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              primary={true}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={true}
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                primary={true}
+                role="radio"
+                size="large"
+                text="Left"
+                type="button"
+              >
+                <button
+                  aria-checked={true}
+                  className="emotion-32"
+                  data-index={0}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Left
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Center"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-15"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Center
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={2}
+              disabled={true}
+              element="button"
+              key="2/.2"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={2}
+                disabled={true}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Right"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-2"
+                  data-index={2}
+                  disabled={true}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Right
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+    </div>
+  </Styled(div)>
+</DemoLayout>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: icons 1`] = `
+.emotion-12 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-12 button:focus,
+.emotion-12 button:active {
+  position: relative;
+}
+
+.emotion-12 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-12 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-12 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-12 > button:not(:first-child),
+.emotion-12 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-12 > button:not(:last-child),
+.emotion-12 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-12 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-12 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-12 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-12 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-12 > [aria-checked=false]:focus,
+.emotion-12 > *:not([aria-checked]):focus,
+.emotion-12 > [aria-checked=false] button:focus,
+.emotion-12 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-12 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-7 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-7 *,
+.emotion-7 *::before,
+.emotion-7 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-7:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-7:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-7:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-7::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-7 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-7 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-7 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-7 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-1 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-1:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-1:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-33[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  color: #ffffff;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #3272d9;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-3 *,
+.emotion-3 *::before,
+.emotion-3 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-3:focus {
+  background-color: #3272d9;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:hover {
+  background-color: #5691f0;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:active {
+  background-color: #1d5bbf;
+  color: #ffffff;
+}
+
+.emotion-3::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-3 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-3 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-3 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-3 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-0 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.emotion-15 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0.4375em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-15 *,
+.emotion-15 *::before,
+.emotion-15 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-15:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-15:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-15:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-15::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-15 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-15 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-15 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-15 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-25 {
+  box-sizing: border-box;
+  color: #2a854e;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0.4375em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-25 *,
+.emotion-25 *::before,
+.emotion-25 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-25:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
+  color: #2a854e;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-25:hover {
+  background-color: #f5f7fa;
+  color: #2a854e;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-25:active {
+  background-color: #dde3ed;
+  color: #2a854e;
+}
+
+.emotion-25::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-25 [role="img"] {
+  box-sizing: content-box;
+  color: #2a854e;
+  display: block;
+}
+
+.emotion-25 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-25 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-25 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-28 {
+  box-sizing: border-box;
+  color: #ad5f00;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0.4375em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-28 *,
+.emotion-28 *::before,
+.emotion-28 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-28:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
+  color: #ad5f00;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-28:hover {
+  background-color: #f5f7fa;
+  color: #ad5f00;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-28:active {
+  background-color: #dde3ed;
+  color: #ad5f00;
+}
+
+.emotion-28::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-28 [role="img"] {
+  box-sizing: content-box;
+  color: #ad5f00;
+  display: block;
+}
+
+.emotion-28 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-28 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-28 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-31 {
+  box-sizing: border-box;
+  color: #de1b1b;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0.4375em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-31 *,
+.emotion-31 *::before,
+.emotion-31 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-31:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
+  color: #de1b1b;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-31:hover {
+  background-color: #f5f7fa;
+  color: #de1b1b;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-31:active {
+  background-color: #dde3ed;
+  color: #de1b1b;
+}
+
+.emotion-31::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-31 [role="img"] {
+  box-sizing: content-box;
+  color: #de1b1b;
+  display: block;
+}
+
+.emotion-31 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-31 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-31 [role="img"]:only-child {
+  margin: 0;
+}
+
+<DemoLayout>
+  <Styled(div)
+    marginBottom="1rem"
+  >
+    <div
+      className="emotion-33"
+    >
+      <ButtonGroup
+        aria-label="Align text"
+        mode="radio"
+      >
+        <ButtonGroup
+          aria-label="Align text"
+          mode="radio"
+          role="radiogroup"
+        >
+          <div
+            aria-label="Align text"
+            className="emotion-12"
+            role="radiogroup"
+          >
+            <Button
+              aria-checked={true}
+              data-index={0}
+              defaultChecked={true}
+              element="button"
+              iconStart={<IconFormatAlignLeft />}
+              key="0/.0"
+              onClick={[Function]}
+              primary={true}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={true}
+                data-index={0}
+                defaultChecked={true}
+                element="button"
+                onClick={[Function]}
+                primary={true}
+                role="radio"
+                size="large"
+                text="Left"
+                type="button"
+              >
+                <button
+                  aria-checked={true}
+                  className="emotion-3"
+                  data-index={0}
+                  defaultChecked={true}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconFormatAlignLeft
+                        key="iconStart"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M15 15H3v2h12v-2zm0-8H3v2h12V7zM3 13h18v-2H3v2zm0 8h18v-2H3v2zM3 3v2h18V3H3z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatAlignLeft>
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-1"
+                        >
+                          Left
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={1}
+              element="button"
+              iconStart={<IconFormatAlignCenter />}
+              key="1/.1"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Center"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-7"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconFormatAlignCenter
+                        key="iconStart"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M7 15v2h10v-2H7zm-4 6h18v-2H3v2zm0-8h18v-2H3v2zm4-6v2h10V7H7zM3 3v2h18V3H3z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatAlignCenter>
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-1"
+                        >
+                          Center
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={2}
+              element="button"
+              iconStart={<IconFormatAlignRight />}
+              key="2/.2"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Right"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-7"
+                  data-index={2}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconFormatAlignRight
+                        key="iconStart"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M3 21h18v-2H3v2zm6-4h12v-2H9v2zm-6-4h18v-2H3v2zm6-4h12V7H9v2zM3 3v2h18V3H3z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatAlignRight>
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-1"
+                        >
+                          Right
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Format text"
+        mode="checkbox"
+      >
+        <ButtonGroup
+          aria-label="Format text"
+          mode="checkbox"
+          role="group"
+        >
+          <div
+            aria-label="Format text"
+            className="emotion-12"
+            role="group"
+          >
+            <Button
+              aria-checked={false}
+              aria-label="Bold"
+              data-index={0}
+              element="button"
+              iconEnd={<IconFormatBold />}
+              key="0/.0"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                aria-label="Bold"
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  aria-label="Bold"
+                  className="emotion-15"
+                  data-index={0}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconFormatBold
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H7v14h7.04c2.09 0 3.71-1.7 3.71-3.79 0-1.52-.86-2.82-2.15-3.42zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatBold>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              aria-label="Italic"
+              data-index={1}
+              element="button"
+              iconEnd={<IconFormatItalic />}
+              key="1/.1"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                aria-label="Italic"
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  aria-label="Italic"
+                  className="emotion-15"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconFormatItalic
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M10 4v3h2.21l-3.42 8H6v3h8v-3h-2.21l3.42-8H18V4z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatItalic>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              aria-label="Underlined"
+              data-index={2}
+              element="button"
+              iconEnd={<IconFormatUnderlined />}
+              key="2/.2"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                aria-label="Underlined"
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  aria-label="Underlined"
+                  className="emotion-15"
+                  data-index={2}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconFormatUnderlined
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatUnderlined>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Sentiments"
+        mode="radio"
+      >
+        <ButtonGroup
+          aria-label="Sentiments"
+          mode="radio"
+          role="radiogroup"
+        >
+          <div
+            aria-label="Sentiments"
+            className="emotion-12"
+            role="radiogroup"
+          >
+            <Button
+              aria-checked={false}
+              aria-label="Satisfied"
+              data-index={0}
+              element="button"
+              iconEnd={<IconSentimentSatisfied />}
+              key="0/.0"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+              variant="success"
+            >
+              <Button
+                aria-checked={false}
+                aria-label="Satisfied"
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                type="button"
+                variant="success"
+              >
+                <button
+                  aria-checked={false}
+                  aria-label="Satisfied"
+                  className="emotion-25"
+                  data-index={0}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconSentimentSatisfied
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <circle
+                                  cx="15.5"
+                                  cy="9.5"
+                                  r="1.5"
+                                />
+                                <circle
+                                  cx="8.5"
+                                  cy="9.5"
+                                  r="1.5"
+                                />
+                                <path
+                                  d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-4c-1.48 0-2.75-.81-3.45-2H6.88a5.495 5.495 0 0 0 10.24 0h-1.67c-.7 1.19-1.97 2-3.45 2z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconSentimentSatisfied>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              aria-label="Neutral"
+              data-index={1}
+              element="button"
+              iconEnd={<IconSentimentNeutral />}
+              key="1/.1"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+              variant="warning"
+            >
+              <Button
+                aria-checked={false}
+                aria-label="Neutral"
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                type="button"
+                variant="warning"
+              >
+                <button
+                  aria-checked={false}
+                  aria-label="Neutral"
+                  className="emotion-28"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconSentimentNeutral
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M9 14h6v1.5H9z"
+                                />
+                                <circle
+                                  cx="15.5"
+                                  cy="9.5"
+                                  r="1.5"
+                                />
+                                <circle
+                                  cx="8.5"
+                                  cy="9.5"
+                                  r="1.5"
+                                />
+                                <path
+                                  d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconSentimentNeutral>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              aria-label="Unsatisfied"
+              data-index={2}
+              element="button"
+              iconEnd={<IconSentimentDissatisfied />}
+              key="2/.2"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+              variant="danger"
+            >
+              <Button
+                aria-checked={false}
+                aria-label="Unsatisfied"
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                type="button"
+                variant="danger"
+              >
+                <button
+                  aria-checked={false}
+                  aria-label="Unsatisfied"
+                  className="emotion-31"
+                  data-index={2}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <IconSentimentDissatisfied
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-0"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <circle
+                                  cx="15.5"
+                                  cy="9.5"
+                                  r="1.5"
+                                />
+                                <circle
+                                  cx="8.5"
+                                  cy="9.5"
+                                  r="1.5"
+                                />
+                                <path
+                                  d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-6c-2.33 0-4.32 1.45-5.12 3.5h1.67c.69-1.19 1.97-2 3.45-2s2.75.81 3.45 2h1.67c-.8-2.05-2.79-3.5-5.12-3.5z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconSentimentDissatisfied>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+    </div>
+  </Styled(div)>
+</DemoLayout>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: mode 1`] = `
+.emotion-9 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9 button:focus,
+.emotion-9 button:active {
+  position: relative;
+}
+
+.emotion-9 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-9 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-9 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-9 > button:not(:first-child),
+.emotion-9 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-9 > button:not(:last-child),
+.emotion-9 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-9 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-9 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-9 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-9 > [aria-checked=false]:focus,
+.emotion-9 > *:not([aria-checked]):focus,
+.emotion-9 > [aria-checked=false] button:focus,
+.emotion-9 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-5 *,
+.emotion-5 *::before,
+.emotion-5 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-5:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-5:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-5:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-5::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-5 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-5 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-5 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-5 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-20[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #ffffff;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #3272d9;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #3272d9;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #5691f0;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #1d5bbf;
+  color: #ffffff;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+<DemoLayout>
+  <Styled(div)
+    marginBottom="1rem"
+  >
+    <div
+      className="emotion-20"
+    >
+      <ButtonGroup
+        aria-label="Align text"
+        defaultChecked={0}
+        mode="radio"
+      >
+        <ButtonGroup
+          aria-label="Align text"
+          defaultChecked={0}
+          mode="radio"
+          role="radiogroup"
+        >
+          <div
+            aria-label="Align text"
+            className="emotion-9"
+            defaultChecked={0}
+            role="radiogroup"
+          >
+            <Button
+              aria-checked={true}
+              data-index={0}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              primary={true}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={true}
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                primary={true}
+                role="radio"
+                size="large"
+                text="Left"
+                type="button"
+              >
+                <button
+                  aria-checked={true}
+                  className="emotion-2"
+                  data-index={0}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Left
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Center"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-5"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Center
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={2}
+              element="button"
+              key="2/.2"
+              onClick={[Function]}
+              role="radio"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                role="radio"
+                size="large"
+                text="Right"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-5"
+                  data-index={2}
+                  onClick={[Function]}
+                  role="radio"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Right
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Text Decoration"
+        defaultChecked={
+          Array [
+            0,
+            1,
+          ]
+        }
+        mode="checkbox"
+      >
+        <ButtonGroup
+          aria-label="Text Decoration"
+          defaultChecked={
+            Array [
+              0,
+              1,
+            ]
+          }
+          mode="checkbox"
+          role="group"
+        >
+          <div
+            aria-label="Text Decoration"
+            className="emotion-9"
+            defaultChecked={
+              Array [
+                0,
+                1,
+              ]
+            }
+            role="group"
+          >
+            <Button
+              aria-checked={true}
+              data-index={0}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              primary={true}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={true}
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                primary={true}
+                role="checkbox"
+                size="large"
+                text="Bold"
+                type="button"
+              >
+                <button
+                  aria-checked={true}
+                  className="emotion-2"
+                  data-index={0}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Bold
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={true}
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              primary={true}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={true}
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                primary={true}
+                role="checkbox"
+                size="large"
+                text="Italic"
+                type="button"
+              >
+                <button
+                  aria-checked={true}
+                  className="emotion-2"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Italic
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={2}
+              element="button"
+              key="2/.2"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                text="Underline"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-5"
+                  data-index={2}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Underline
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+    </div>
+  </Styled(div)>
+</DemoLayout>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: rtl 1`] = `
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-1 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.emotion-12 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-12 button:focus,
+.emotion-12 button:active {
+  position: relative;
+}
+
+.emotion-12 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-12 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-12 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-12 > button:not(:first-child),
+.emotion-12 > *:not(:first-child) button {
+  border-right-color: transparent;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-12 > button:not(:last-child),
+.emotion-12 > *:not(:last-child) button {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-12 > [aria-checked]:not(:last-child) {
+  border-left-color: transparent;
+}
+
+.emotion-12 > [aria-checked=false] + *:not(button) button {
+  border-right-color: #c8d1e0;
+}
+
+.emotion-12 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-12 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-right-color: currentcolor;
+}
+
+.emotion-12 > [aria-checked=false]:focus,
+.emotion-12 > *:not([aria-checked]):focus,
+.emotion-12 > [aria-checked=false] button:focus,
+.emotion-12 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-12 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-right-color: #c8d1e0;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-3 *,
+.emotion-3 *::before,
+.emotion-3 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-3:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-3:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-3::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-3 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-3 [role="img"]:first-child {
+  margin-left: 0.5em;
+}
+
+.emotion-3 [role="img"]:last-child {
+  margin-right: 0.5em;
+}
+
+.emotion-3 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-left: 0.5714285714285714em;
+}
+
+<div
+  dir="rtl"
+>
+  <ThemeProvider>
+    <ThemeProvider>
+      <ButtonGroup
+        aria-label="Format text"
+        mode="checkbox"
+      >
+        <ButtonGroup
+          aria-label="Format text"
+          mode="checkbox"
+          role="group"
+        >
+          <div
+            aria-label="Format text"
+            className="emotion-12"
+            role="group"
+          >
+            <Button
+              aria-checked={false}
+              data-index={0}
+              element="button"
+              iconEnd={<IconFormatBold />}
+              key="0/.0"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                text="بالخط العريض"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-3"
+                  data-index={0}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          بالخط العريض
+                        </span>
+                      </Styled(span)>
+                      <IconFormatBold
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-1"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H7v14h7.04c2.09 0 3.71-1.7 3.71-3.79 0-1.52-.86-2.82-2.15-3.42zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatBold>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={1}
+              element="button"
+              iconEnd={<IconFormatItalic />}
+              key="1/.1"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                text="مائل"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-3"
+                  data-index={1}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          مائل
+                        </span>
+                      </Styled(span)>
+                      <IconFormatItalic
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-1"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M10 4v3h2.21l-3.42 8H6v3h8v-3h-2.21l3.42-8H18V4z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatItalic>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              aria-checked={false}
+              data-index={2}
+              element="button"
+              iconEnd={<IconFormatUnderlined />}
+              key="2/.2"
+              onClick={[Function]}
+              role="checkbox"
+              size="large"
+              type="button"
+            >
+              <Button
+                aria-checked={false}
+                data-index={2}
+                element="button"
+                onClick={[Function]}
+                role="checkbox"
+                size="large"
+                text="أكد"
+                type="button"
+              >
+                <button
+                  aria-checked={false}
+                  className="emotion-3"
+                  data-index={2}
+                  onClick={[Function]}
+                  role="checkbox"
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-2"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          أكد
+                        </span>
+                      </Styled(span)>
+                      <IconFormatUnderlined
+                        key="iconEnd"
+                        size="1.5em"
+                      >
+                        <Icon
+                          rtl={false}
+                          size="1.5em"
+                        >
+                          <Styled(svg)
+                            aria-hidden={true}
+                            role="img"
+                            rtl={false}
+                            size="1.5em"
+                            viewBox="0 0 24 24"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="emotion-1"
+                              role="img"
+                              viewBox="0 0 24 24"
+                            >
+                              <g>
+                                <path
+                                  d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z"
+                                />
+                              </g>
+                            </svg>
+                          </Styled(svg)>
+                        </Icon>
+                      </IconFormatUnderlined>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+    </ThemeProvider>
+  </ThemeProvider>
+</div>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: sizes 1`] = `
+.emotion-9 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9 button:focus,
+.emotion-9 button:active {
+  position: relative;
+}
+
+.emotion-9 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-9 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-9 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-9 > button:not(:first-child),
+.emotion-9 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-9 > button:not(:last-child),
+.emotion-9 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-9 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-9 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-9 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-9 > [aria-checked=false]:focus,
+.emotion-9 > *:not([aria-checked]):focus,
+.emotion-9 > [aria-checked=false] button:focus,
+.emotion-9 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-22 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-22 *,
+.emotion-22 *::before,
+.emotion-22 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-22:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-22:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-22:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-22::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-22 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-22 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-22 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-22 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-20 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-20:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-20:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-50[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.75em;
+  line-height: 2em;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 1.5em;
+  margin: 0;
+  min-width: 1.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-12 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2em;
+  margin: 0;
+  min-width: 2em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-12:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-12:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-12:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-12::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-12 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-12 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-12 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-12 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-10 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.2857142857142856em;
+}
+
+.emotion-32 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 3.25em;
+  margin: 0;
+  min-width: 3.25em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-32 *,
+.emotion-32 *::before,
+.emotion-32 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-32:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-32:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-32:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-32::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-32 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-32 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-32 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-32 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-30 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 3.7142857142857144em;
+}
+
+.emotion-30:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-30:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-49 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-49 *,
+.emotion-49 *::before,
+.emotion-49 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-49 button {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.emotion-49 button:focus,
+.emotion-49 button:active {
+  position: relative;
+}
+
+.emotion-49 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-49 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-49 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-49 > button:not(:first-child),
+.emotion-49 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-49 > button:not(:last-child),
+.emotion-49 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-49 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-49 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-49 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-49 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-49 > [aria-checked=false]:focus,
+.emotion-49 > *:not([aria-checked]):focus,
+.emotion-49 > [aria-checked=false] button:focus,
+.emotion-49 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-49 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+<Component>
+  <DemoLayout>
+    <Styled(div)
+      marginBottom="1rem"
+    >
+      <div
+        className="emotion-50"
+      >
+        <ButtonGroup
+          aria-label="Edit text"
+          key="small"
+          size="small"
+        >
+          <ButtonGroup
+            aria-label="Edit text"
+            role="group"
+          >
+            <div
+              aria-label="Edit text"
+              className="emotion-9"
+              role="group"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                key="0/.0"
+                onClick={[Function]}
+                size="small"
+                type="button"
+              >
+                <Button
+                  data-index={0}
+                  element="button"
+                  onClick={[Function]}
+                  size="small"
+                  text="Cut"
+                  type="button"
+                >
+                  <button
+                    className="emotion-2"
+                    data-index={0}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="small"
+                        >
+                          <span
+                            className="emotion-0"
+                          >
+                            Cut
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={1}
+                element="button"
+                key="1/.1"
+                onClick={[Function]}
+                size="small"
+                type="button"
+              >
+                <Button
+                  data-index={1}
+                  element="button"
+                  onClick={[Function]}
+                  size="small"
+                  text="Copy"
+                  type="button"
+                >
+                  <button
+                    className="emotion-2"
+                    data-index={1}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="small"
+                        >
+                          <span
+                            className="emotion-0"
+                          >
+                            Copy
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={2}
+                element="button"
+                key="2/.2"
+                onClick={[Function]}
+                size="small"
+                type="button"
+              >
+                <Button
+                  data-index={2}
+                  element="button"
+                  onClick={[Function]}
+                  size="small"
+                  text="Paste"
+                  type="button"
+                >
+                  <button
+                    className="emotion-2"
+                    data-index={2}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="small"
+                        >
+                          <span
+                            className="emotion-0"
+                          >
+                            Paste
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+            </div>
+          </ButtonGroup>
+        </ButtonGroup>
+        <ButtonGroup
+          aria-label="Edit text"
+          key="medium"
+          size="medium"
+        >
+          <ButtonGroup
+            aria-label="Edit text"
+            role="group"
+          >
+            <div
+              aria-label="Edit text"
+              className="emotion-9"
+              role="group"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                key="0/.0"
+                onClick={[Function]}
+                size="medium"
+                type="button"
+              >
+                <Button
+                  data-index={0}
+                  element="button"
+                  onClick={[Function]}
+                  size="medium"
+                  text="Cut"
+                  type="button"
+                >
+                  <button
+                    className="emotion-12"
+                    data-index={0}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="medium"
+                        >
+                          <span
+                            className="emotion-10"
+                          >
+                            Cut
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={1}
+                element="button"
+                key="1/.1"
+                onClick={[Function]}
+                size="medium"
+                type="button"
+              >
+                <Button
+                  data-index={1}
+                  element="button"
+                  onClick={[Function]}
+                  size="medium"
+                  text="Copy"
+                  type="button"
+                >
+                  <button
+                    className="emotion-12"
+                    data-index={1}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="medium"
+                        >
+                          <span
+                            className="emotion-10"
+                          >
+                            Copy
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={2}
+                element="button"
+                key="2/.2"
+                onClick={[Function]}
+                size="medium"
+                type="button"
+              >
+                <Button
+                  data-index={2}
+                  element="button"
+                  onClick={[Function]}
+                  size="medium"
+                  text="Paste"
+                  type="button"
+                >
+                  <button
+                    className="emotion-12"
+                    data-index={2}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="medium"
+                        >
+                          <span
+                            className="emotion-10"
+                          >
+                            Paste
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+            </div>
+          </ButtonGroup>
+        </ButtonGroup>
+        <ButtonGroup
+          aria-label="Edit text"
+          key="large"
+          size="large"
+        >
+          <ButtonGroup
+            aria-label="Edit text"
+            role="group"
+          >
+            <div
+              aria-label="Edit text"
+              className="emotion-9"
+              role="group"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                key="0/.0"
+                onClick={[Function]}
+                size="large"
+                type="button"
+              >
+                <Button
+                  data-index={0}
+                  element="button"
+                  onClick={[Function]}
+                  size="large"
+                  text="Cut"
+                  type="button"
+                >
+                  <button
+                    className="emotion-22"
+                    data-index={0}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="large"
+                        >
+                          <span
+                            className="emotion-20"
+                          >
+                            Cut
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={1}
+                element="button"
+                key="1/.1"
+                onClick={[Function]}
+                size="large"
+                type="button"
+              >
+                <Button
+                  data-index={1}
+                  element="button"
+                  onClick={[Function]}
+                  size="large"
+                  text="Copy"
+                  type="button"
+                >
+                  <button
+                    className="emotion-22"
+                    data-index={1}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="large"
+                        >
+                          <span
+                            className="emotion-20"
+                          >
+                            Copy
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={2}
+                element="button"
+                key="2/.2"
+                onClick={[Function]}
+                size="large"
+                type="button"
+              >
+                <Button
+                  data-index={2}
+                  element="button"
+                  onClick={[Function]}
+                  size="large"
+                  text="Paste"
+                  type="button"
+                >
+                  <button
+                    className="emotion-22"
+                    data-index={2}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="large"
+                        >
+                          <span
+                            className="emotion-20"
+                          >
+                            Paste
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+            </div>
+          </ButtonGroup>
+        </ButtonGroup>
+        <ButtonGroup
+          aria-label="Edit text"
+          key="jumbo"
+          size="jumbo"
+        >
+          <ButtonGroup
+            aria-label="Edit text"
+            role="group"
+          >
+            <div
+              aria-label="Edit text"
+              className="emotion-9"
+              role="group"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                key="0/.0"
+                onClick={[Function]}
+                size="jumbo"
+                type="button"
+              >
+                <Button
+                  data-index={0}
+                  element="button"
+                  onClick={[Function]}
+                  size="jumbo"
+                  text="Cut"
+                  type="button"
+                >
+                  <button
+                    className="emotion-32"
+                    data-index={0}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="jumbo"
+                        >
+                          <span
+                            className="emotion-30"
+                          >
+                            Cut
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={1}
+                element="button"
+                key="1/.1"
+                onClick={[Function]}
+                size="jumbo"
+                type="button"
+              >
+                <Button
+                  data-index={1}
+                  element="button"
+                  onClick={[Function]}
+                  size="jumbo"
+                  text="Copy"
+                  type="button"
+                >
+                  <button
+                    className="emotion-32"
+                    data-index={1}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="jumbo"
+                        >
+                          <span
+                            className="emotion-30"
+                          >
+                            Copy
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={2}
+                element="button"
+                key="2/.2"
+                onClick={[Function]}
+                size="jumbo"
+                type="button"
+              >
+                <Button
+                  data-index={2}
+                  element="button"
+                  onClick={[Function]}
+                  size="jumbo"
+                  text="Paste"
+                  type="button"
+                >
+                  <button
+                    className="emotion-32"
+                    data-index={2}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="jumbo"
+                        >
+                          <span
+                            className="emotion-30"
+                          >
+                            Paste
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+            </div>
+          </ButtonGroup>
+        </ButtonGroup>
+        <ButtonGroup
+          aria-label="Edit text"
+          fullWidth={true}
+        >
+          <ButtonGroup
+            aria-label="Edit text"
+            fullWidth={true}
+            role="group"
+          >
+            <div
+              aria-label="Edit text"
+              className="emotion-49"
+              role="group"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                key="0/.0"
+                onClick={[Function]}
+                size="large"
+                type="button"
+              >
+                <Button
+                  data-index={0}
+                  element="button"
+                  onClick={[Function]}
+                  size="large"
+                  text="Cut"
+                  type="button"
+                >
+                  <button
+                    className="emotion-22"
+                    data-index={0}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="large"
+                        >
+                          <span
+                            className="emotion-20"
+                          >
+                            Cut
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={1}
+                element="button"
+                key="1/.1"
+                onClick={[Function]}
+                size="large"
+                type="button"
+              >
+                <Button
+                  data-index={1}
+                  element="button"
+                  onClick={[Function]}
+                  size="large"
+                  text="Copy"
+                  type="button"
+                >
+                  <button
+                    className="emotion-22"
+                    data-index={1}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="large"
+                        >
+                          <span
+                            className="emotion-20"
+                          >
+                            Copy
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+              <Button
+                data-index={2}
+                element="button"
+                key="2/.2"
+                onClick={[Function]}
+                size="large"
+                type="button"
+              >
+                <Button
+                  data-index={2}
+                  element="button"
+                  onClick={[Function]}
+                  size="large"
+                  text="Paste"
+                  type="button"
+                >
+                  <button
+                    className="emotion-22"
+                    data-index={2}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <Styled(span)>
+                      <span
+                        className="emotion-1"
+                      >
+                        <Styled(span)
+                          size="large"
+                        >
+                          <span
+                            className="emotion-20"
+                          >
+                            Paste
+                          </span>
+                        </Styled(span)>
+                      </span>
+                    </Styled(span)>
+                  </button>
+                </Button>
+              </Button>
+            </div>
+          </ButtonGroup>
+        </ButtonGroup>
+      </div>
+    </Styled(div)>
+  </DemoLayout>
+</Component>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: uncontrolled 1`] = `
+.emotion-9 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9 button:focus,
+.emotion-9 button:active {
+  position: relative;
+}
+
+.emotion-9 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-9 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-9 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-9 > button:not(:first-child),
+.emotion-9 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-9 > button:not(:last-child),
+.emotion-9 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-9 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-9 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-9 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-9 > [aria-checked=false]:focus,
+.emotion-9 > *:not([aria-checked]):focus,
+.emotion-9 > [aria-checked=false] button:focus,
+.emotion-9 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-9 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-5 *,
+.emotion-5 *::before,
+.emotion-5 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-5:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-5:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-5:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-5::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-5 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-5 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-5 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-5 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #ffffff;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #3272d9;
+  border-color: transparent;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #3272d9;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #5691f0;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #1d5bbf;
+  color: #ffffff;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+<ButtonGroup
+  aria-label="Align text"
+  mode="radio"
+>
+  <ButtonGroup
+    aria-label="Align text"
+    mode="radio"
+    role="radiogroup"
+  >
+    <div
+      aria-label="Align text"
+      className="emotion-9"
+      role="radiogroup"
+    >
+      <Button
+        aria-checked={true}
+        data-index={0}
+        defaultChecked={true}
+        element="button"
+        key="0/.0"
+        onClick={[Function]}
+        primary={true}
+        role="radio"
+        size="large"
+        type="button"
+      >
+        <Button
+          aria-checked={true}
+          data-index={0}
+          defaultChecked={true}
+          element="button"
+          onClick={[Function]}
+          primary={true}
+          role="radio"
+          size="large"
+          text="Left"
+          type="button"
+        >
+          <button
+            aria-checked={true}
+            className="emotion-2"
+            data-index={0}
+            defaultChecked={true}
+            onClick={[Function]}
+            role="radio"
+            type="button"
+          >
+            <Styled(span)>
+              <span
+                className="emotion-1"
+              >
+                <Styled(span)
+                  size="large"
+                >
+                  <span
+                    className="emotion-0"
+                  >
+                    Left
+                  </span>
+                </Styled(span)>
+              </span>
+            </Styled(span)>
+          </button>
+        </Button>
+      </Button>
+      <Button
+        aria-checked={false}
+        data-index={1}
+        element="button"
+        key="1/.1"
+        onClick={[Function]}
+        role="radio"
+        size="large"
+        type="button"
+      >
+        <Button
+          aria-checked={false}
+          data-index={1}
+          element="button"
+          onClick={[Function]}
+          role="radio"
+          size="large"
+          text="Center"
+          type="button"
+        >
+          <button
+            aria-checked={false}
+            className="emotion-5"
+            data-index={1}
+            onClick={[Function]}
+            role="radio"
+            type="button"
+          >
+            <Styled(span)>
+              <span
+                className="emotion-1"
+              >
+                <Styled(span)
+                  size="large"
+                >
+                  <span
+                    className="emotion-0"
+                  >
+                    Center
+                  </span>
+                </Styled(span)>
+              </span>
+            </Styled(span)>
+          </button>
+        </Button>
+      </Button>
+      <Button
+        aria-checked={false}
+        data-index={2}
+        element="button"
+        key="2/.2"
+        onClick={[Function]}
+        role="radio"
+        size="large"
+        type="button"
+      >
+        <Button
+          aria-checked={false}
+          data-index={2}
+          element="button"
+          onClick={[Function]}
+          role="radio"
+          size="large"
+          text="Right"
+          type="button"
+        >
+          <button
+            aria-checked={false}
+            className="emotion-5"
+            data-index={2}
+            onClick={[Function]}
+            role="radio"
+            type="button"
+          >
+            <Styled(span)>
+              <span
+                className="emotion-1"
+              >
+                <Styled(span)
+                  size="large"
+                >
+                  <span
+                    className="emotion-0"
+                  >
+                    Right
+                  </span>
+                </Styled(span)>
+              </span>
+            </Styled(span)>
+          </button>
+        </Button>
+      </Button>
+    </div>
+  </ButtonGroup>
+</ButtonGroup>
+`;
+
+exports[`ButtonGroup demo examples Snapshots: variants 1`] = `
+.emotion-6 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-6 *,
+.emotion-6 *::before,
+.emotion-6 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-6 button:focus,
+.emotion-6 button:active {
+  position: relative;
+}
+
+.emotion-6 button[disabled] {
+  border: solid 1px #c8d1e0;
+}
+
+.emotion-6 button[disabled][aria-checked=true] {
+  background-color: #c8d1e0;
+  color: #8e99ab;
+}
+
+.emotion-6 button[disabled][aria-checked=true]:hover {
+  color: #8e99ab;
+}
+
+.emotion-6 > button:not(:first-child),
+.emotion-6 > *:not(:first-child) button {
+  border-left-color: transparent;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.emotion-6 > button:not(:last-child),
+.emotion-6 > *:not(:last-child) button {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.emotion-6 > [aria-checked]:not(:last-child) {
+  border-right-color: transparent;
+}
+
+.emotion-6 > [aria-checked=false] + *:not(button) button {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-6 > [aria-checked=true] + [aria-checked=true]:not(:focus),
+.emotion-6 > [aria-checked=true] + [aria-checked=true] button:not(:focus) {
+  border-left-color: currentcolor;
+}
+
+.emotion-6 > [aria-checked=false]:focus,
+.emotion-6 > *:not([aria-checked]):focus,
+.emotion-6 > [aria-checked=false] button:focus,
+.emotion-6 > *:not([aria-checked]) button:focus {
+  border-left-color: #c8d1e0;
+  border-right-color: #c8d1e0;
+}
+
+.emotion-6 > [aria-checked=false] + [aria-checked=false]:not(:focus) {
+  border-left-color: #c8d1e0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-21[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #2a854e;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
+  color: #2a854e;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #f5f7fa;
+  color: #2a854e;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  background-color: #dde3ed;
+  color: #2a854e;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  color: #2a854e;
+  display: block;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-9 {
+  box-sizing: border-box;
+  color: #ad5f00;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-9:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
+  color: #ad5f00;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-9:hover {
+  background-color: #f5f7fa;
+  color: #ad5f00;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-9:active {
+  background-color: #dde3ed;
+  color: #ad5f00;
+}
+
+.emotion-9::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-9 [role="img"] {
+  box-sizing: content-box;
+  color: #ad5f00;
+  display: block;
+}
+
+.emotion-9 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-9 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-9 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-16 {
+  box-sizing: border-box;
+  color: #de1b1b;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-16 *,
+.emotion-16 *::before,
+.emotion-16 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-16:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
+  color: #de1b1b;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-16:hover {
+  background-color: #f5f7fa;
+  color: #de1b1b;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-16:active {
+  background-color: #dde3ed;
+  color: #de1b1b;
+}
+
+.emotion-16::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-16 [role="img"] {
+  box-sizing: content-box;
+  color: #de1b1b;
+  display: block;
+}
+
+.emotion-16 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-16 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-16 [role="img"]:only-child {
+  margin: 0;
+}
+
+<DemoLayout>
+  <Styled(div)
+    marginBottom="1rem"
+  >
+    <div
+      className="emotion-21"
+    >
+      <ButtonGroup
+        aria-label="Shopping options"
+        variant="success"
+      >
+        <ButtonGroup
+          aria-label="Shopping options"
+          role="group"
+        >
+          <div
+            aria-label="Shopping options"
+            className="emotion-6"
+            role="group"
+          >
+            <Button
+              data-index={0}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              size="large"
+              type="button"
+              variant="success"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Donate $5"
+                type="button"
+                variant="success"
+              >
+                <button
+                  className="emotion-2"
+                  data-index={0}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Donate $5
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              size="large"
+              type="button"
+              variant="success"
+            >
+              <Button
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Donate $10"
+                type="button"
+                variant="success"
+              >
+                <button
+                  className="emotion-2"
+                  data-index={1}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Donate $10
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Shopping options"
+        variant="warning"
+      >
+        <ButtonGroup
+          aria-label="Shopping options"
+          role="group"
+        >
+          <div
+            aria-label="Shopping options"
+            className="emotion-6"
+            role="group"
+          >
+            <Button
+              data-index={0}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              size="large"
+              type="button"
+              variant="warning"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Revoke Author Permissions"
+                type="button"
+                variant="warning"
+              >
+                <button
+                  className="emotion-9"
+                  data-index={0}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Revoke Author Permissions
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              size="large"
+              type="button"
+              variant="warning"
+            >
+              <Button
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Revoke Group Permissions"
+                type="button"
+                variant="warning"
+              >
+                <button
+                  className="emotion-9"
+                  data-index={1}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Revoke Group Permissions
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+      <ButtonGroup
+        aria-label="Shopping options"
+        variant="danger"
+      >
+        <ButtonGroup
+          aria-label="Shopping options"
+          role="group"
+        >
+          <div
+            aria-label="Shopping options"
+            className="emotion-6"
+            role="group"
+          >
+            <Button
+              data-index={0}
+              element="button"
+              key="0/.0"
+              onClick={[Function]}
+              size="large"
+              type="button"
+              variant="danger"
+            >
+              <Button
+                data-index={0}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Send Storm Watch"
+                type="button"
+                variant="danger"
+              >
+                <button
+                  className="emotion-16"
+                  data-index={0}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Send Storm Watch
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+            <Button
+              data-index={1}
+              element="button"
+              key="1/.1"
+              onClick={[Function]}
+              size="large"
+              type="button"
+              variant="danger"
+            >
+              <Button
+                data-index={1}
+                element="button"
+                onClick={[Function]}
+                size="large"
+                text="Send Storm Warning"
+                type="button"
+                variant="danger"
+              >
+                <button
+                  className="emotion-16"
+                  data-index={1}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <Styled(span)>
+                    <span
+                      className="emotion-1"
+                    >
+                      <Styled(span)
+                        size="large"
+                      >
+                        <span
+                          className="emotion-0"
+                        >
+                          Send Storm Warning
+                        </span>
+                      </Styled(span)>
+                    </span>
+                  </Styled(span)>
+                </button>
+              </Button>
+            </Button>
+          </div>
+        </ButtonGroup>
+      </ButtonGroup>
+    </div>
+  </Styled(div)>
+</DemoLayout>
+`;

--- a/src/library/ButtonGroup/index.js
+++ b/src/library/ButtonGroup/index.js
@@ -1,0 +1,2 @@
+/* @flow */
+export { default } from './ButtonGroup';

--- a/src/library/Card/__tests__/__snapshots__/Card.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/Card.spec.js.snap
@@ -117,6 +117,7 @@ exports[`Card demo examples Snapshots: actions-menu 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -186,6 +187,7 @@ exports[`Card demo examples Snapshots: actions-menu 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -455,7 +457,6 @@ exports[`Card demo examples Snapshots: actions-menu 1`] = `
                                         role="button"
                                         size="large"
                                         type="button"
-                                        variant="regular"
                                       >
                                         <PopoverTrigger
                                           component="span"
@@ -486,7 +487,6 @@ exports[`Card demo examples Snapshots: actions-menu 1`] = `
                                                 role="button"
                                                 size="large"
                                                 type="button"
-                                                variant="regular"
                                               >
                                                 <Button
                                                   aria-describedby="dropdown-19-content"
@@ -508,7 +508,6 @@ exports[`Card demo examples Snapshots: actions-menu 1`] = `
                                                   role="button"
                                                   size="large"
                                                   type="button"
-                                                  variant="regular"
                                                 >
                                                   <Button
                                                     aria-describedby="dropdown-19-content"
@@ -525,7 +524,6 @@ exports[`Card demo examples Snapshots: actions-menu 1`] = `
                                                     role="button"
                                                     size="large"
                                                     type="button"
-                                                    variant="regular"
                                                   >
                                                     <button
                                                       aria-describedby="dropdown-19-content"
@@ -1336,6 +1334,7 @@ exports[`Card demo examples Snapshots: basic 2`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1393,6 +1392,7 @@ exports[`Card demo examples Snapshots: basic 2`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1476,6 +1476,7 @@ exports[`Card demo examples Snapshots: basic 2`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1548,6 +1549,7 @@ exports[`Card demo examples Snapshots: basic 2`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1628,6 +1630,7 @@ exports[`Card demo examples Snapshots: basic 2`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -1724,14 +1727,12 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                       element="button"
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
                         size="medium"
                         text="Button 1"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-4"
@@ -1768,14 +1769,12 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                       iconStart={<IconCloud />}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
                         size="medium"
                         text="Button 2"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-4"
@@ -1876,7 +1875,6 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                       minimal={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -1884,7 +1882,6 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                         size="medium"
                         text="Button 1"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-17"
@@ -1922,7 +1919,6 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                       primary={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -1930,7 +1926,6 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                         size="medium"
                         text="Button 2"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-22"
@@ -2036,14 +2031,12 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                       minimal={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
                         minimal={true}
                         size="medium"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-30"
@@ -2115,14 +2108,12 @@ exports[`Card demo examples Snapshots: basic 2`] = `
                       minimal={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
                         minimal={true}
                         size="medium"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-30"
@@ -3029,6 +3020,7 @@ exports[`Card demo examples Snapshots: children 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3099,6 +3091,7 @@ exports[`Card demo examples Snapshots: children 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3166,7 +3159,6 @@ exports[`Card demo examples Snapshots: children 1`] = `
                 fullWidth={true}
                 size="large"
                 type="button"
-                variant="regular"
               >
                 <Button
                   element="button"
@@ -3174,7 +3166,6 @@ exports[`Card demo examples Snapshots: children 1`] = `
                   size="large"
                   text="Button"
                   type="button"
-                  variant="regular"
                 >
                   <button
                     className="emotion-6"
@@ -3338,6 +3329,7 @@ exports[`Card demo examples Snapshots: children 2`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3408,6 +3400,7 @@ exports[`Card demo examples Snapshots: children 2`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3489,7 +3482,6 @@ exports[`Card demo examples Snapshots: children 2`] = `
                           fullWidth={true}
                           size="large"
                           type="button"
-                          variant="regular"
                         >
                           <Button
                             element="button"
@@ -3497,7 +3489,6 @@ exports[`Card demo examples Snapshots: children 2`] = `
                             size="large"
                             text="Button"
                             type="button"
-                            variant="regular"
                           >
                             <button
                               className="emotion-6"
@@ -4049,6 +4040,7 @@ exports[`Card demo examples Snapshots: order 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4135,6 +4127,7 @@ exports[`Card demo examples Snapshots: order 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4218,6 +4211,7 @@ exports[`Card demo examples Snapshots: order 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4391,7 +4385,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                       minimal={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -4399,7 +4392,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                         size="medium"
                         text="Button 1"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-9"
@@ -4436,7 +4428,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                       primary={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -4444,7 +4435,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                         size="medium"
                         text="Button 2"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-13"
@@ -4581,7 +4571,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                       minimal={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -4589,7 +4578,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                         size="medium"
                         text="Button 1"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-9"
@@ -4626,7 +4614,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                       primary={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -4634,7 +4621,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                         size="medium"
                         text="Button 2"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-13"
@@ -4771,7 +4757,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                       minimal={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -4779,7 +4764,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                         size="medium"
                         text="Button 1"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-9"
@@ -4816,7 +4800,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                       primary={true}
                       size="medium"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         element="button"
@@ -4824,7 +4807,6 @@ exports[`Card demo examples Snapshots: order 1`] = `
                         size="medium"
                         text="Button 2"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           className="emotion-13"
@@ -4967,6 +4949,7 @@ exports[`Card demo examples Snapshots: rtl 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -5042,6 +5025,7 @@ exports[`Card demo examples Snapshots: rtl 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5143,14 +5127,12 @@ exports[`Card demo examples Snapshots: rtl 1`] = `
                           element="button"
                           size="medium"
                           type="button"
-                          variant="regular"
                         >
                           <Button
                             element="button"
                             size="medium"
                             text="زر واحد"
                             type="button"
-                            variant="regular"
                           >
                             <button
                               className="emotion-4"
@@ -5187,14 +5169,12 @@ exports[`Card demo examples Snapshots: rtl 1`] = `
                           iconStart={<IconCloud />}
                           size="medium"
                           type="button"
-                          variant="regular"
                         >
                           <Button
                             element="button"
                             size="medium"
                             text="زر اثنين"
                             type="button"
-                            variant="regular"
                           >
                             <button
                               className="emotion-4"
@@ -7109,12 +7089,10 @@ exports[`Card demo examples Snapshots: with-links 1`] = `
                         element="a"
                         href="https://example.com"
                         target="_blank"
-                        variant="regular"
                       >
                         <Link
                           href="https://example.com"
                           target="_blank"
-                          variant="regular"
                         >
                           <a
                             className="emotion-2"
@@ -7141,12 +7119,10 @@ exports[`Card demo examples Snapshots: with-links 1`] = `
                         element="a"
                         href="https://example.com"
                         target="_blank"
-                        variant="regular"
                       >
                         <Link
                           href="https://example.com"
                           target="_blank"
-                          variant="regular"
                         >
                           <a
                             className="emotion-2"

--- a/src/library/Checkbox/Checkbox.js
+++ b/src/library/Checkbox/Checkbox.js
@@ -43,7 +43,7 @@ type Props = {
   /** Used to uniquely define a group of checkboxes */
   name?: string,
   /** Function called when a checkbox is selected */
-  onChange?: (event: SyntheticEvent<>) => void,
+  onChange?: (event: SyntheticInputEvent<>) => void,
   /** Indicates that the user must select an option before submitting a form */
   required?: boolean,
   /** Available sizes */

--- a/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -4913,6 +4913,7 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6896,6 +6897,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -7213,6 +7215,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -7369,6 +7372,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -7597,6 +7601,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;

--- a/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -222,7 +222,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                               value="fluorite"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -257,8 +257,8 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -267,7 +267,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                             >
                               Fluorite
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -363,7 +363,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                               value="quartz"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -398,8 +398,8 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -408,7 +408,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                             >
                               Quartz
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -504,7 +504,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                               value="magnetite"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -539,8 +539,8 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -549,7 +549,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                             >
                               Magnetite
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -941,7 +941,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                               value="fluorite"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -976,8 +976,8 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                                 </Icon>
                                               </IconCheckBoxCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -986,7 +986,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                             >
                                               Fluorite
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -1083,7 +1083,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                               value="magnetite"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -1118,8 +1118,8 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                                 </Icon>
                                               </IconCheckBoxCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -1128,7 +1128,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                             >
                                               Magnetite
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -1225,7 +1225,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                               value="quartz"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -1260,8 +1260,8 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                                 </Icon>
                                               </IconCheckBoxCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -1270,7 +1270,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                             >
                                               Quartz
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -1664,7 +1664,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1699,8 +1699,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1709,7 +1709,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1800,7 +1800,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1835,8 +1835,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1845,7 +1845,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1936,7 +1936,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1971,8 +1971,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1981,7 +1981,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -2147,7 +2147,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                           value="azurite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -2182,8 +2182,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -2192,7 +2192,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Azurite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -2283,7 +2283,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                           value="hematite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -2318,8 +2318,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -2328,7 +2328,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Hematite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -2419,7 +2419,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                           value="pyrite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -2454,8 +2454,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -2464,7 +2464,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Pyrite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -2690,7 +2690,7 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -2726,8 +2726,8 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -2737,7 +2737,7 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -2828,7 +2828,7 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -2864,8 +2864,8 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -2875,7 +2875,7 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -3413,7 +3413,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                   value="natural"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3448,8 +3448,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3458,7 +3458,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Naturally occurring
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3554,7 +3554,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                   value="inorganic"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3589,8 +3589,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3599,7 +3599,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Inorganic
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3695,7 +3695,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                   value="solid"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3730,8 +3730,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3740,7 +3740,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Solid
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3836,7 +3836,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                   value="composition"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3871,8 +3871,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3881,7 +3881,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Definite chemical composition
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3977,7 +3977,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                   value="crystalline"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -4012,8 +4012,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -4022,7 +4022,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Crystalline structure
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -4431,7 +4431,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4466,8 +4466,8 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4476,7 +4476,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4567,7 +4567,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4602,8 +4602,8 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4612,7 +4612,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4703,7 +4703,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4738,8 +4738,8 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4748,7 +4748,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4983,6 +4983,7 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -5084,7 +5085,7 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
                               value="1"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -5119,8 +5120,8 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -5129,7 +5130,7 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
                             >
                               Option 1
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -5143,7 +5144,6 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
             onClick={[Function]}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -5151,7 +5151,6 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
               size="large"
               text="Focus the input"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-7"
@@ -5403,7 +5402,7 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -5438,8 +5437,8 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -5448,7 +5447,7 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -5538,7 +5537,7 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -5573,8 +5572,8 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -5583,7 +5582,7 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -5963,7 +5962,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -5998,8 +5997,8 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -6008,7 +6007,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6102,7 +6101,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="start"
                         size="large"
                       >
@@ -6137,8 +6136,8 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="start"
                         size="large"
                       >
@@ -6147,7 +6146,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6246,7 +6245,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                           value="azurite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -6281,8 +6280,8 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         justify={true}
                         labelPosition="end"
                         size="large"
@@ -6292,7 +6291,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         >
                           Azurite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6391,7 +6390,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                           value="hematite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="start"
                         size="large"
                       >
@@ -6426,8 +6425,8 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         justify={true}
                         labelPosition="start"
                         size="large"
@@ -6437,7 +6436,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         >
                           Hematite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6659,7 +6658,7 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
                           type="checkbox"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -6694,8 +6693,8 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -6704,7 +6703,7 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
                         >
                           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis.
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6967,6 +6966,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -7758,7 +7758,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="checkbox"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="small"
                           >
@@ -7793,8 +7793,8 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="small"
                           >
@@ -7803,7 +7803,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Small
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -7896,14 +7896,12 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="small"
               text="Small"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-12"
@@ -7998,7 +7996,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="checkbox"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="medium"
                           >
@@ -8033,8 +8031,8 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="medium"
                           >
@@ -8043,7 +8041,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Medium
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -8136,14 +8134,12 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="medium"
               text="Medium"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-25"
@@ -8238,7 +8234,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="checkbox"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -8273,8 +8269,8 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -8283,7 +8279,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Large
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -8376,14 +8372,12 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Large"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-38"
@@ -8478,7 +8472,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="checkbox"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="jumbo"
                           >
@@ -8513,8 +8507,8 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconCheckBoxCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="jumbo"
                           >
@@ -8523,7 +8517,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Jumbo
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -8616,14 +8610,12 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="jumbo"
               text="Jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-51"
@@ -8876,7 +8868,7 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -8911,8 +8903,8 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -8921,7 +8913,7 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -9013,7 +9005,7 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -9048,8 +9040,8 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -9058,7 +9050,7 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -9437,7 +9429,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                 type="checkbox"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="end"
                               size="large"
                             >
@@ -9472,8 +9464,8 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconCheckBoxCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               labelPosition="end"
                               size="large"
                             >
@@ -9482,7 +9474,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -9560,7 +9552,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                 type="checkbox"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="start"
                               size="large"
                             >
@@ -9595,8 +9587,8 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconCheckBoxCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               labelPosition="start"
                               size="large"
                             >
@@ -9605,7 +9597,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -9698,7 +9690,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                 type="checkbox"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="end"
                               size="large"
                             >
@@ -9733,8 +9725,8 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconCheckBoxCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               justify={true}
                               labelPosition="end"
                               size="large"
@@ -9744,7 +9736,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -9827,7 +9819,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                 type="checkbox"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="start"
                               size="large"
                             >
@@ -9862,8 +9854,8 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconCheckBoxCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               justify={true}
                               labelPosition="start"
                               size="large"
@@ -9873,7 +9865,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -10138,7 +10130,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                           value="small"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="small"
                       >
@@ -10173,8 +10165,8 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="small"
                       >
@@ -10183,7 +10175,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         >
                           Small
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -10267,7 +10259,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                           value="medium"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="medium"
                       >
@@ -10302,8 +10294,8 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="medium"
                       >
@@ -10312,7 +10304,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         >
                           Medium
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -10402,7 +10394,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                           value="large"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -10437,8 +10429,8 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -10447,7 +10439,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         >
                           Large
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -10531,7 +10523,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                           value="jumbo"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="jumbo"
                       >
@@ -10566,8 +10558,8 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="jumbo"
                       >
@@ -10576,7 +10568,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         >
                           Jumbo
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -10798,7 +10790,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                           value="unchecked"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -10833,8 +10825,8 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -10843,7 +10835,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                         >
                           Unchecked
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -10933,7 +10925,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                           value="checked"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -10968,8 +10960,8 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -10978,7 +10970,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                         >
                           Checked
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -11069,7 +11061,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                           value="indeterminate"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -11104,8 +11096,8 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                             </Icon>
                           </IconCheckBoxIndeterminate>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -11114,7 +11106,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                         >
                           Indeterminate
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -11342,7 +11334,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -11377,8 +11369,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -11387,7 +11379,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -11471,7 +11463,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -11506,8 +11498,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                             </Icon>
                           </IconCheckBoxCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -11516,7 +11508,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -11894,7 +11886,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -11929,8 +11921,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -11939,7 +11931,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -12030,7 +12022,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -12065,8 +12057,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -12075,7 +12067,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -12166,7 +12158,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -12201,8 +12193,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -12211,7 +12203,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>

--- a/src/library/Checkbox/__tests__/__snapshots__/CheckboxGroup.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/CheckboxGroup.spec.js.snap
@@ -376,7 +376,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                               value="fluorite"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -411,8 +411,8 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                                 </Icon>
                                               </IconCheckBoxCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -421,7 +421,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                             >
                                               Fluorite
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -518,7 +518,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                               value="magnetite"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -553,8 +553,8 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                                 </Icon>
                                               </IconCheckBoxCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -563,7 +563,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                             >
                                               Magnetite
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -660,7 +660,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                               value="quartz"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -695,8 +695,8 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                                 </Icon>
                                               </IconCheckBoxCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -705,7 +705,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                             >
                                               Quartz
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -1099,7 +1099,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1134,8 +1134,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1144,7 +1144,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1235,7 +1235,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1270,8 +1270,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1280,7 +1280,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1371,7 +1371,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1406,8 +1406,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1416,7 +1416,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1582,7 +1582,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="azurite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1617,8 +1617,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1627,7 +1627,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Azurite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1718,7 +1718,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="hematite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1753,8 +1753,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1763,7 +1763,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Hematite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1854,7 +1854,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="pyrite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1889,8 +1889,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1899,7 +1899,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Pyrite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -2445,7 +2445,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                   value="natural"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2480,8 +2480,8 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2490,7 +2490,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Naturally occurring
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -2586,7 +2586,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                   value="inorganic"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2621,8 +2621,8 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2631,7 +2631,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Inorganic
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -2727,7 +2727,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                   value="solid"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2762,8 +2762,8 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2772,7 +2772,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Solid
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -2868,7 +2868,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                   value="composition"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2903,8 +2903,8 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2913,7 +2913,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Definite chemical composition
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3009,7 +3009,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                   value="crystalline"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3044,8 +3044,8 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconCheckBoxCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -3054,7 +3054,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Crystalline structure
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3463,7 +3463,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3498,8 +3498,8 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3508,7 +3508,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -3599,7 +3599,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3634,8 +3634,8 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3644,7 +3644,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -3735,7 +3735,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3770,8 +3770,8 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3780,7 +3780,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4166,7 +4166,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4201,8 +4201,8 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4211,7 +4211,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4302,7 +4302,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4337,8 +4337,8 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4347,7 +4347,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4438,7 +4438,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4473,8 +4473,8 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                             </Icon>
                                           </IconCheckBoxCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4483,7 +4483,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>

--- a/src/library/Choice/Choice.js
+++ b/src/library/Choice/Choice.js
@@ -36,7 +36,7 @@ type Props = {
   /** Used to uniquely define a group of inputs */
   name?: string,
   /** Function called when a input is selected */
-  onChange?: (event: SyntheticEvent<>) => void,
+  onChange?: (event: SyntheticInputEvent<>) => void,
   /** Indicates that the user must select an option before submitting a form */
   required?: boolean,
   /** Available sizes */
@@ -212,8 +212,12 @@ const Root = createStyledComponent('label', styles.root, {
 const Input = createStyledComponent('input', styles.input, {
   rootEl: 'input'
 });
-const Text = createStyledComponent('span', styles.text);
-const Control = createStyledComponent('span', styles.control);
+const Text = createStyledComponent('span', styles.text, {
+  displayName: 'Text'
+});
+const Control = createStyledComponent('span', styles.control, {
+  displayName: 'Control'
+});
 
 /**
  * Choice is base renderer for Checkbox and Radio.

--- a/src/library/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/library/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -40,6 +40,7 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -109,6 +110,7 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -202,7 +204,6 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
             role="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <PopoverTrigger
               component="span"
@@ -227,7 +228,6 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
                     role="button"
                     size="large"
                     type="button"
-                    variant="regular"
                   >
                     <Button
                       aria-describedby="dropdown-1-content"
@@ -243,7 +243,6 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
                       size="large"
                       text="Menu"
                       type="button"
-                      variant="regular"
                     >
                       <button
                         aria-describedby="dropdown-1-content"
@@ -327,6 +326,7 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -396,6 +396,7 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -511,7 +512,6 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
                   role="button"
                   size="large"
                   type="button"
-                  variant="regular"
                 >
                   <PopoverTrigger
                     component="span"
@@ -536,7 +536,6 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
                           role="button"
                           size="large"
                           type="button"
-                          variant="regular"
                         >
                           <Button
                             aria-describedby="dropdown-19-content"
@@ -552,7 +551,6 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
                             size="large"
                             text="Open Dropdown"
                             type="button"
-                            variant="regular"
                           >
                             <button
                               aria-describedby="dropdown-19-content"
@@ -599,7 +597,6 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
         onClick={[Function]}
         size="large"
         type="button"
-        variant="regular"
       >
         <Button
           element="button"
@@ -607,7 +604,6 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
           size="large"
           text="Open Dropdown"
           type="button"
-          variant="regular"
         >
           <button
             className="emotion-2"
@@ -677,6 +673,7 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -746,6 +743,7 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -840,7 +838,6 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -865,7 +862,6 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="dropdown-23-content"
@@ -881,7 +877,6 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
                         size="large"
                         text="Menu"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="dropdown-23-content"
@@ -966,6 +961,7 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1035,6 +1031,7 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1130,7 +1127,6 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -1155,7 +1151,6 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="dropdown-25-content"
@@ -1171,7 +1166,6 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
                         size="large"
                         text="Menu"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="dropdown-25-content"
@@ -1385,6 +1379,7 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1454,6 +1449,7 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1560,7 +1556,6 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -1585,7 +1580,6 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="dropdown-3-content"
@@ -1601,7 +1595,6 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
                         size="large"
                         text="Menu"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="dropdown-3-content"
@@ -1682,6 +1675,7 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1722,6 +1716,7 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1849,7 +1844,6 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
             role="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <PopoverTrigger
               component="span"
@@ -1875,7 +1869,6 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
                     role="button"
                     size="large"
                     type="button"
-                    variant="regular"
                   >
                     <Button
                       aria-describedby="dropdown-17-content"
@@ -1892,7 +1885,6 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
                       size="large"
                       text="Menu"
                       type="button"
-                      variant="regular"
                     >
                       <button
                         aria-describedby="dropdown-17-content"
@@ -1977,6 +1969,7 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2046,6 +2039,7 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2142,7 +2136,6 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -2167,7 +2160,6 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="dropdown-15-content"
@@ -2183,7 +2175,6 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
                         size="large"
                         text="Menu"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="dropdown-15-content"
@@ -2268,6 +2259,7 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2337,6 +2329,7 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2440,7 +2433,6 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
                 role="button"
                 size="large"
                 type="button"
-                variant="regular"
               >
                 <PopoverTrigger
                   component="span"
@@ -2465,7 +2457,6 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
                         role="button"
                         size="large"
                         type="button"
-                        variant="regular"
                       >
                         <Button
                           aria-describedby="dropdown-9-content"
@@ -2481,7 +2472,6 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
                           size="large"
                           text="Menu"
                           type="button"
-                          variant="regular"
                         >
                           <button
                             aria-describedby="dropdown-9-content"
@@ -2567,6 +2557,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2636,6 +2627,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2920,7 +2912,6 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                 role="button"
                 size="large"
                 type="button"
-                variant="regular"
               >
                 <PopoverTrigger
                   component="span"
@@ -2946,7 +2937,6 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                         role="button"
                         size="large"
                         type="button"
-                        variant="regular"
                       >
                         <Button
                           aria-activedescendant="dropdown-7-menu"
@@ -2963,7 +2953,6 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                           size="large"
                           text="Menu"
                           type="button"
-                          variant="regular"
                         >
                           <button
                             aria-activedescendant="dropdown-7-menu"
@@ -3668,6 +3657,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3737,6 +3727,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3787,6 +3778,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3996,7 +3988,6 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                           role="button"
                           size="large"
                           type="button"
-                          variant="regular"
                         >
                           <PopoverTrigger
                             component="span"
@@ -4022,7 +4013,6 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                                   role="button"
                                   size="large"
                                   type="button"
-                                  variant="regular"
                                 >
                                   <Button
                                     aria-activedescendant="dropdown-13-menu"
@@ -4039,7 +4029,6 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                                     size="large"
                                     text="Menu"
                                     type="button"
-                                    variant="regular"
                                   >
                                     <button
                                       aria-activedescendant="dropdown-13-menu"
@@ -4111,7 +4100,6 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-12"
@@ -4120,7 +4108,6 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-12"
@@ -4130,7 +4117,6 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-11"
@@ -4197,6 +4183,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4339,6 +4326,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4547,7 +4535,6 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                     role="button"
                     size="large"
                     type="button"
-                    variant="regular"
                   >
                     <PopoverTrigger
                       component="span"
@@ -4573,7 +4560,6 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                             role="button"
                             size="large"
                             type="button"
-                            variant="regular"
                           >
                             <Button
                               aria-activedescendant="dropdown-21-menu"
@@ -4590,7 +4576,6 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                               size="large"
                               text="Menu"
                               type="button"
-                              variant="regular"
                             >
                               <button
                                 aria-activedescendant="dropdown-21-menu"
@@ -5297,6 +5282,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5366,6 +5352,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -5609,6 +5596,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5770,7 +5758,6 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                           role="button"
                           size="large"
                           type="button"
-                          variant="regular"
                         >
                           <PopoverTrigger
                             component="span"
@@ -5796,7 +5783,6 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                                   role="button"
                                   size="large"
                                   type="button"
-                                  variant="regular"
                                 >
                                   <Button
                                     aria-activedescendant="dropdown-11-menu"
@@ -5813,7 +5799,6 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                                     size="large"
                                     text="Menu"
                                     type="button"
-                                    variant="regular"
                                   >
                                     <button
                                       aria-activedescendant="dropdown-11-menu"
@@ -6484,7 +6469,6 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-38"
@@ -6493,7 +6477,6 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-38"
@@ -6503,7 +6486,6 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-37"
@@ -6574,6 +6556,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6643,6 +6626,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -6918,7 +6902,6 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                 role="button"
                 size="large"
                 type="button"
-                variant="regular"
               >
                 <PopoverTrigger
                   component="span"
@@ -6944,7 +6927,6 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                         role="button"
                         size="large"
                         type="button"
-                        variant="regular"
                       >
                         <Button
                           aria-activedescendant="dropdown-5-menu"
@@ -6961,7 +6943,6 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                           size="large"
                           text="Menu"
                           type="button"
-                          variant="regular"
                         >
                           <button
                             aria-activedescendant="dropdown-5-menu"

--- a/src/library/Form/__tests__/__snapshots__/FormField.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormField.spec.js.snap
@@ -2823,6 +2823,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2892,6 +2893,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3064,7 +3066,6 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
             onClick={[Function]}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -3072,7 +3073,6 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
               size="large"
               text="Validate"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-10"

--- a/src/library/Link/Link.js
+++ b/src/library/Link/Link.js
@@ -10,7 +10,7 @@ type Props = {
   /** Element to be used as the root node - e.g. `a` or `ReactRouterLink` */
   element?: $FlowFixMe, // Should allow string | React class
   /** Available variants */
-  variant?: 'regular' | 'danger' | 'success' | 'warning'
+  variant?: 'danger' | 'success' | 'warning'
 };
 
 export const componentTheme = (baseTheme: Object) => ({
@@ -26,7 +26,7 @@ export const componentTheme = (baseTheme: Object) => ({
 const linkStyles = ({ variant, theme: baseTheme }) => {
   let theme = componentTheme(baseTheme);
 
-  if (variant !== 'regular') {
+  if (variant) {
     // prettier-ignore
     theme = {
       ...theme,
@@ -80,8 +80,7 @@ const Link = (props: Props) => {
 };
 
 Link.defaultProps = {
-  element: 'a',
-  variant: 'regular'
+  element: 'a'
 };
 
 export default Link;

--- a/src/library/Link/__tests__/__snapshots__/Link.spec.js.snap
+++ b/src/library/Link/__tests__/__snapshots__/Link.spec.js.snap
@@ -59,12 +59,10 @@ exports[`Link demo examples Snapshots: basic 1`] = `
             element="a"
             href="http://example.com"
             target="_blank"
-            variant="regular"
           >
             <Link
               href="http://example.com"
               target="_blank"
-              variant="regular"
             >
               <a
                 className="emotion-0"
@@ -91,12 +89,10 @@ exports[`Link demo examples Snapshots: basic 1`] = `
             element="a"
             href="http://example.com"
             target="_blank"
-            variant="regular"
           >
             <Link
               href="http://example.com"
               target="_blank"
-              variant="regular"
             >
               <a
                 className="emotion-0"
@@ -123,12 +119,10 @@ exports[`Link demo examples Snapshots: basic 1`] = `
             element="a"
             href="http://example.com"
             target="_blank"
-            variant="regular"
           >
             <Link
               href="http://example.com"
               target="_blank"
-              variant="regular"
             >
               <a
                 className="emotion-0"
@@ -155,12 +149,10 @@ exports[`Link demo examples Snapshots: basic 1`] = `
             element="a"
             href="http://example.com"
             target="_blank"
-            variant="regular"
           >
             <Link
               href="http://example.com"
               target="_blank"
-              variant="regular"
             >
               <a
                 className="emotion-0"
@@ -198,6 +190,7 @@ exports[`Link demo examples Snapshots: button 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -267,6 +260,7 @@ exports[`Link demo examples Snapshots: button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -294,7 +288,6 @@ exports[`Link demo examples Snapshots: button 1`] = `
   href="#button"
   size="large"
   type="button"
-  variant="regular"
 >
   <Button
     element="a"
@@ -302,7 +295,6 @@ exports[`Link demo examples Snapshots: button 1`] = `
     size="large"
     text="Link"
     type="button"
-    variant="regular"
   >
     <a
       className="emotion-2"
@@ -358,12 +350,10 @@ exports[`Link demo examples Snapshots: children 1`] = `
     element="a"
     href="http://example.com"
     target="_blank"
-    variant="regular"
   >
     <Link
       href="http://example.com"
       target="_blank"
-      variant="regular"
     >
       <a
         className="emotion-0"
@@ -437,12 +427,10 @@ exports[`Link demo examples Snapshots: other 1`] = `
         <Link
           element={[Function]}
           to="/components/link"
-          variant="regular"
         >
           <Link
             replace={false}
             to="/components/link"
-            variant="regular"
           >
             <Link
               className="emotion-0"
@@ -616,19 +604,17 @@ exports[`Link demo examples Snapshots: variants 1`] = `
               element="a"
               href="http://example.com"
               target="_blank"
-              variant="regular"
             >
               <Link
                 href="http://example.com"
                 target="_blank"
-                variant="regular"
               >
                 <a
                   className="emotion-0"
                   href="http://example.com"
                   target="_blank"
                 >
-                  Regular
+                  Default
                 </a>
               </Link>
             </Link>

--- a/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -40,6 +40,7 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -109,6 +110,7 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -161,7 +163,6 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
           role="button"
           size="large"
           type="button"
-          variant="regular"
         >
           <PopoverTrigger
             component="span"
@@ -183,7 +184,6 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
                   role="button"
                   size="large"
                   type="button"
-                  variant="regular"
                 >
                   <Button
                     aria-describedby="popover-1-content"
@@ -196,7 +196,6 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
                     size="large"
                     text="Open Popover"
                     type="button"
-                    variant="regular"
                   >
                     <button
                       aria-describedby="popover-1-content"
@@ -276,6 +275,7 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -345,6 +345,7 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -422,7 +423,6 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
                 role="button"
                 size="large"
                 type="button"
-                variant="regular"
               >
                 <PopoverTrigger
                   component="span"
@@ -444,7 +444,6 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
                         role="button"
                         size="large"
                         type="button"
-                        variant="regular"
                       >
                         <Button
                           aria-describedby="popover-17-content"
@@ -457,7 +456,6 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
                           size="large"
                           text="Open Popover"
                           type="button"
-                          variant="regular"
                         >
                           <button
                             aria-describedby="popover-17-content"
@@ -500,7 +498,6 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
         onClick={[Function]}
         size="large"
         type="button"
-        variant="regular"
       >
         <Button
           element="button"
@@ -508,7 +505,6 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
           size="large"
           text="Open Popover"
           type="button"
-          variant="regular"
         >
           <button
             className="emotion-2"
@@ -578,6 +574,7 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -647,6 +644,7 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -700,7 +698,6 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
             role="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <PopoverTrigger
               component="span"
@@ -722,7 +719,6 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
                     role="button"
                     size="large"
                     type="button"
-                    variant="regular"
                   >
                     <Button
                       aria-describedby="popover-21-content"
@@ -735,7 +731,6 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
                       size="large"
                       text="Open Popover"
                       type="button"
-                      variant="regular"
                     >
                       <button
                         aria-describedby="popover-21-content"
@@ -893,6 +888,7 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -933,6 +929,7 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1018,7 +1015,6 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
           role="button"
           size="large"
           type="button"
-          variant="regular"
         >
           <PopoverTrigger
             component="span"
@@ -1041,7 +1037,6 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
                   role="button"
                   size="large"
                   type="button"
-                  variant="regular"
                 >
                   <Button
                     aria-describedby="popover-15-content"
@@ -1055,7 +1050,6 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
                     size="large"
                     text="Open Popover"
                     type="button"
-                    variant="regular"
                   >
                     <button
                       aria-describedby="popover-15-content"
@@ -1136,6 +1130,7 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1205,6 +1200,7 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1262,7 +1258,6 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
             role="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <PopoverTrigger
               component="span"
@@ -1284,7 +1279,6 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
                     role="button"
                     size="large"
                     type="button"
-                    variant="regular"
                   >
                     <Button
                       aria-describedby="popover-13-content"
@@ -1297,7 +1291,6 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
                       size="large"
                       text="Open Popover"
                       type="button"
-                      variant="regular"
                     >
                       <button
                         aria-describedby="popover-13-content"
@@ -1378,6 +1371,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1447,6 +1441,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1587,7 +1582,6 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -1609,7 +1603,6 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="popover-7-content"
@@ -1622,7 +1615,6 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
                         size="large"
                         text="Open Popover"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="popover-7-content"
@@ -2021,6 +2013,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2090,6 +2083,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2240,7 +2234,6 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -2262,7 +2255,6 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="popover-5-content"
@@ -2275,7 +2267,6 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
                         size="large"
                         text="Open Popover"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="popover-5-content"
@@ -2674,6 +2665,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2743,6 +2735,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2817,6 +2810,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2953,7 +2947,6 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                         role="button"
                         size="large"
                         type="button"
-                        variant="regular"
                       >
                         <PopoverTrigger
                           component="span"
@@ -2975,7 +2968,6 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                                 role="button"
                                 size="large"
                                 type="button"
-                                variant="regular"
                               >
                                 <Button
                                   aria-describedby="popover-11-content"
@@ -2988,7 +2980,6 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                                   size="large"
                                   text="Open Popover"
                                   type="button"
-                                  variant="regular"
                                 >
                                   <button
                                     aria-describedby="popover-11-content"
@@ -3055,7 +3046,6 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-12"
@@ -3064,7 +3054,6 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-12"
@@ -3074,7 +3063,6 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-11"
@@ -3141,6 +3129,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3242,6 +3231,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3357,7 +3347,6 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                   role="button"
                   size="large"
                   type="button"
-                  variant="regular"
                 >
                   <PopoverTrigger
                     component="span"
@@ -3379,7 +3368,6 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                           role="button"
                           size="large"
                           type="button"
-                          variant="regular"
                         >
                           <Button
                             aria-describedby="popover-19-content"
@@ -3392,7 +3380,6 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                             size="large"
                             text="Open Popover"
                             type="button"
-                            variant="regular"
                           >
                             <button
                               aria-describedby="popover-19-content"
@@ -3793,6 +3780,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3862,6 +3850,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4012,6 +4001,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4132,7 +4122,6 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                         role="button"
                         size="large"
                         type="button"
-                        variant="regular"
                       >
                         <PopoverTrigger
                           component="span"
@@ -4154,7 +4143,6 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                                 role="button"
                                 size="large"
                                 type="button"
-                                variant="regular"
                               >
                                 <Button
                                   aria-describedby="popover-9-content"
@@ -4167,7 +4155,6 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                                   size="large"
                                   text="Open Popover"
                                   type="button"
-                                  variant="regular"
                                 >
                                   <button
                                     aria-describedby="popover-9-content"
@@ -4532,7 +4519,6 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-21"
@@ -4541,7 +4527,6 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-21"
@@ -4551,7 +4536,6 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-20"
@@ -4622,6 +4606,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -4691,6 +4676,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -4887,7 +4873,6 @@ exports[`Popover demo examples Snapshots: title 1`] = `
               role="button"
               size="large"
               type="button"
-              variant="regular"
             >
               <PopoverTrigger
                 component="span"
@@ -4909,7 +4894,6 @@ exports[`Popover demo examples Snapshots: title 1`] = `
                       role="button"
                       size="large"
                       type="button"
-                      variant="regular"
                     >
                       <Button
                         aria-describedby="popover-3-content"
@@ -4922,7 +4906,6 @@ exports[`Popover demo examples Snapshots: title 1`] = `
                         size="large"
                         text="Open Popover"
                         type="button"
-                        variant="regular"
                       >
                         <button
                           aria-describedby="popover-3-content"

--- a/src/library/Radio/Radio.js
+++ b/src/library/Radio/Radio.js
@@ -37,7 +37,7 @@ type Props = {
   /** Used to uniquely define a group of radio buttons */
   name?: string,
   /** Function called when a radio button is selected */
-  onChange?: (event: SyntheticEvent<>) => void,
+  onChange?: (event: SyntheticInputEvent<>) => void,
   /** Indicates that the user must select an option before submitting a form */
   required?: boolean,
   /** Available sizes */

--- a/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
@@ -222,7 +222,7 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                               value="quartz"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -259,8 +259,8 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -269,7 +269,7 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                             >
                               Quartz
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -365,7 +365,7 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                               value="magnetite"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -402,8 +402,8 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -412,7 +412,7 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                             >
                               Magnetite
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -632,7 +632,7 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -670,8 +670,8 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -681,7 +681,7 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -772,7 +772,7 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -810,8 +810,8 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         disabled={true}
                         labelPosition="end"
                         size="large"
@@ -821,7 +821,7 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -1048,6 +1048,7 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1149,7 +1150,7 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
                               value="1"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -1186,8 +1187,8 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -1196,7 +1197,7 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
                             >
                               Option 1
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -1210,7 +1211,6 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
             onClick={[Function]}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -1218,7 +1218,6 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
               size="large"
               text="Focus the input"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-7"
@@ -1470,7 +1469,7 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -1507,8 +1506,8 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -1517,7 +1516,7 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -1607,7 +1606,7 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -1644,8 +1643,8 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -1654,7 +1653,7 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -2034,7 +2033,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -2071,8 +2070,8 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -2081,7 +2080,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -2175,7 +2174,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="start"
                         size="large"
                       >
@@ -2212,8 +2211,8 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="start"
                         size="large"
                       >
@@ -2222,7 +2221,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -2321,7 +2320,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                           value="azurite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -2358,8 +2357,8 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         justify={true}
                         labelPosition="end"
                         size="large"
@@ -2369,7 +2368,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         >
                           Azurite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -2468,7 +2467,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                           value="hematite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="start"
                         size="large"
                       >
@@ -2505,8 +2504,8 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         justify={true}
                         labelPosition="start"
                         size="large"
@@ -2516,7 +2515,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         >
                           Hematite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -2738,7 +2737,7 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
                           type="radio"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -2775,8 +2774,8 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -2785,7 +2784,7 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
                         >
                           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis.
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -3048,6 +3047,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3839,7 +3839,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="radio"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="small"
                           >
@@ -3876,8 +3876,8 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="small"
                           >
@@ -3886,7 +3886,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Small
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -3979,14 +3979,12 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="small"
               text="Small"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-12"
@@ -4081,7 +4079,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="radio"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="medium"
                           >
@@ -4118,8 +4116,8 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="medium"
                           >
@@ -4128,7 +4126,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Medium
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -4221,14 +4219,12 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="medium"
               text="Medium"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-25"
@@ -4323,7 +4319,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="radio"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="large"
                           >
@@ -4360,8 +4356,8 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="large"
                           >
@@ -4370,7 +4366,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Large
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -4463,14 +4459,12 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Large"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-38"
@@ -4565,7 +4559,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                               type="radio"
                             />
                           </Styled(input)>
-                          <Styled(span)
+                          <Control
                             labelPosition="end"
                             size="jumbo"
                           >
@@ -4602,8 +4596,8 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                                 </Icon>
                               </IconRadioButtonCheck>
                             </span>
-                          </Styled(span)>
-                          <Styled(span)
+                          </Control>
+                          <Text
                             labelPosition="end"
                             size="jumbo"
                           >
@@ -4612,7 +4606,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             >
                               Jumbo
                             </span>
-                          </Styled(span)>
+                          </Text>
                         </label>
                       </Choice>
                     </Choice>
@@ -4705,14 +4699,12 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="jumbo"
               text="Jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-51"
@@ -4965,7 +4957,7 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -5002,8 +4994,8 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -5012,7 +5004,7 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -5104,7 +5096,7 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -5141,8 +5133,8 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -5151,7 +5143,7 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -5530,7 +5522,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                 type="radio"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="end"
                               size="large"
                             >
@@ -5567,8 +5559,8 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconRadioButtonCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               labelPosition="end"
                               size="large"
                             >
@@ -5577,7 +5569,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -5655,7 +5647,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                 type="radio"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="start"
                               size="large"
                             >
@@ -5692,8 +5684,8 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconRadioButtonCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               labelPosition="start"
                               size="large"
                             >
@@ -5702,7 +5694,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -5795,7 +5787,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                 type="radio"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="end"
                               size="large"
                             >
@@ -5832,8 +5824,8 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconRadioButtonCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               justify={true}
                               labelPosition="end"
                               size="large"
@@ -5843,7 +5835,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -5926,7 +5918,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                 type="radio"
                               />
                             </Styled(input)>
-                            <Styled(span)
+                            <Control
                               labelPosition="start"
                               size="large"
                             >
@@ -5963,8 +5955,8 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                                   </Icon>
                                 </IconRadioButtonCheck>
                               </span>
-                            </Styled(span)>
-                            <Styled(span)
+                            </Control>
+                            <Text
                               justify={true}
                               labelPosition="start"
                               size="large"
@@ -5974,7 +5966,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               >
                                 مرحبا بالعالم
                               </span>
-                            </Styled(span)>
+                            </Text>
                           </label>
                         </Choice>
                       </Choice>
@@ -6239,7 +6231,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                           value="small"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="small"
                       >
@@ -6276,8 +6268,8 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="small"
                       >
@@ -6286,7 +6278,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         >
                           Small
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6370,7 +6362,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                           value="medium"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="medium"
                       >
@@ -6407,8 +6399,8 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="medium"
                       >
@@ -6417,7 +6409,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         >
                           Medium
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6507,7 +6499,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                           value="large"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -6544,8 +6536,8 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -6554,7 +6546,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         >
                           Large
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6638,7 +6630,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                           value="jumbo"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="jumbo"
                       >
@@ -6675,8 +6667,8 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="jumbo"
                       >
@@ -6685,7 +6677,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         >
                           Jumbo
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -6913,7 +6905,7 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                           value="quartz"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -6950,8 +6942,8 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -6960,7 +6952,7 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                         >
                           Quartz
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>
@@ -7044,7 +7036,7 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                           value="magnetite"
                         />
                       </Styled(input)>
-                      <Styled(span)
+                      <Control
                         labelPosition="end"
                         size="large"
                       >
@@ -7081,8 +7073,8 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                             </Icon>
                           </IconRadioButtonCheck>
                         </span>
-                      </Styled(span)>
-                      <Styled(span)
+                      </Control>
+                      <Text
                         labelPosition="end"
                         size="large"
                       >
@@ -7091,7 +7083,7 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                         >
                           Magnetite
                         </span>
-                      </Styled(span)>
+                      </Text>
                     </label>
                   </Choice>
                 </Choice>

--- a/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
@@ -978,6 +978,7 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2977,6 +2978,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3294,6 +3296,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3450,6 +3453,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3678,6 +3682,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;

--- a/src/library/Radio/__tests__/__snapshots__/RadioGroup.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/RadioGroup.spec.js.snap
@@ -368,7 +368,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                               value="fluorite"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -405,8 +405,8 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                                 </Icon>
                                               </IconRadioButtonCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -415,7 +415,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                             >
                                               Fluorite
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -512,7 +512,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                               value="magnetite"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -549,8 +549,8 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                                 </Icon>
                                               </IconRadioButtonCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -559,7 +559,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                             >
                                               Magnetite
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -656,7 +656,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                               value="quartz"
                                             />
                                           </Styled(input)>
-                                          <Styled(span)
+                                          <Control
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -693,8 +693,8 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                                 </Icon>
                                               </IconRadioButtonCheck>
                                             </span>
-                                          </Styled(span)>
-                                          <Styled(span)
+                                          </Control>
+                                          <Text
                                             labelPosition="end"
                                             size="large"
                                           >
@@ -703,7 +703,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                             >
                                               Quartz
                                             </span>
-                                          </Styled(span)>
+                                          </Text>
                                         </label>
                                       </Choice>
                                     </Choice>
@@ -1089,7 +1089,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1126,8 +1126,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1136,7 +1136,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1227,7 +1227,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1264,8 +1264,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1274,7 +1274,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1365,7 +1365,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1402,8 +1402,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1412,7 +1412,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1570,7 +1570,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="azurite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1607,8 +1607,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1617,7 +1617,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Azurite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1708,7 +1708,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="hematite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1745,8 +1745,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1755,7 +1755,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Hematite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -1846,7 +1846,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                           value="pyrite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1883,8 +1883,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -1893,7 +1893,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         >
                                           Pyrite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -2431,7 +2431,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                   value="email"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2468,8 +2468,8 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconRadioButtonCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2478,7 +2478,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Email
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -2583,7 +2583,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                   value="telephone"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2620,8 +2620,8 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconRadioButtonCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2630,7 +2630,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Telephone
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -2735,7 +2735,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                   value="text"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2772,8 +2772,8 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconRadioButtonCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2782,7 +2782,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   Text message
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -2887,7 +2887,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                   value="none"
                                                 />
                                               </Styled(input)>
-                                              <Styled(span)
+                                              <Control
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2924,8 +2924,8 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                     </Icon>
                                                   </IconRadioButtonCheck>
                                                 </span>
-                                              </Styled(span)>
-                                              <Styled(span)
+                                              </Control>
+                                              <Text
                                                 labelPosition="end"
                                                 size="large"
                                               >
@@ -2934,7 +2934,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 >
                                                   None
                                                 </span>
-                                              </Styled(span)>
+                                              </Text>
                                             </label>
                                           </Choice>
                                         </Choice>
@@ -3334,7 +3334,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3371,8 +3371,8 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3381,7 +3381,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -3472,7 +3472,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3509,8 +3509,8 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3519,7 +3519,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -3610,7 +3610,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3647,8 +3647,8 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -3657,7 +3657,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4035,7 +4035,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                           value="fluorite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4072,8 +4072,8 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4082,7 +4082,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                         >
                                           Fluorite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4173,7 +4173,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                           value="magnetite"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4210,8 +4210,8 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4220,7 +4220,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                         >
                                           Magnetite
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>
@@ -4311,7 +4311,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                           value="quartz"
                                         />
                                       </Styled(input)>
-                                      <Styled(span)
+                                      <Control
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4348,8 +4348,8 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                             </Icon>
                                           </IconRadioButtonCheck>
                                         </span>
-                                      </Styled(span)>
-                                      <Styled(span)
+                                      </Control>
+                                      <Text
                                         labelPosition="end"
                                         size="large"
                                       >
@@ -4358,7 +4358,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                         >
                                           Quartz
                                         </span>
-                                      </Styled(span)>
+                                      </Text>
                                     </label>
                                   </Choice>
                                 </Choice>

--- a/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
@@ -11567,6 +11567,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -11638,6 +11639,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -12225,7 +12227,6 @@ exports[`Select demo examples Snapshots: portal 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-24"
@@ -12234,7 +12235,6 @@ exports[`Select demo examples Snapshots: portal 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-24"
@@ -12244,7 +12244,6 @@ exports[`Select demo examples Snapshots: portal 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-23"
@@ -15619,6 +15618,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -15690,6 +15690,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -16849,7 +16850,6 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-45"
@@ -16858,7 +16858,6 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-45"
@@ -16868,7 +16867,6 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-44"
@@ -19446,6 +19444,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -19467,6 +19466,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -20006,7 +20006,6 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
           onClick={[Function]}
           size="large"
           type="button"
-          variant="regular"
         >
           <Button
             element="button"
@@ -20014,7 +20013,6 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
             size="large"
             text="Focus the control"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-21"

--- a/src/library/Text/__tests__/__snapshots__/Text.spec.js.snap
+++ b/src/library/Text/__tests__/__snapshots__/Text.spec.js.snap
@@ -978,7 +978,7 @@ exports[`Text demo examples Snapshots: nested 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-14 > * {
+.emotion-14[class] > * {
   margin-bottom: 1em;
 }
 
@@ -1364,11 +1364,9 @@ exports[`Text demo examples Snapshots: nested-elements 1`] = `
           <Link
             element="a"
             href="http://example.com"
-            variant="regular"
           >
             <Link
               href="http://example.com"
-              variant="regular"
             >
               <a
                 className="emotion-5"

--- a/src/library/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
+++ b/src/library/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
@@ -1560,6 +1560,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1629,6 +1630,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1757,7 +1759,6 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
             onClick={[Function]}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -1765,7 +1766,6 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
               size="large"
               text="Focus the input"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-7"
@@ -2543,6 +2543,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2612,6 +2613,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2846,6 +2848,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3072,6 +3075,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3370,6 +3374,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3740,14 +3745,12 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="small"
               text="Small"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-17"
@@ -4057,14 +4060,12 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="medium"
               text="Medium"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-35"
@@ -4372,14 +4373,12 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Large"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-53"
@@ -4689,14 +4688,12 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
             element="button"
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="jumbo"
               text="Jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-71"

--- a/src/library/TextInput/__tests__/__snapshots__/TextInput.spec.js.snap
+++ b/src/library/TextInput/__tests__/__snapshots__/TextInput.spec.js.snap
@@ -1809,6 +1809,7 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1878,6 +1879,7 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1991,7 +1993,6 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
             onClick={[Function]}
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
@@ -1999,7 +2000,6 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
               size="large"
               text="Focus the input"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-7"
@@ -5806,6 +5806,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -5875,6 +5876,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -5955,6 +5957,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6039,6 +6042,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2em;
+  margin: 0;
   min-width: 2em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6123,6 +6127,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 3.25em;
+  margin: 0;
   min-width: 3.25em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -6293,14 +6298,12 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
             element="button"
             size="small"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="small"
               text="Small"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-7"
@@ -6410,14 +6413,12 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
             element="button"
             size="medium"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="medium"
               text="Medium"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-15"
@@ -6527,14 +6528,12 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
             element="button"
             size="large"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="large"
               text="Large"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-23"
@@ -6644,14 +6643,12 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
             element="button"
             size="jumbo"
             type="button"
-            variant="regular"
           >
             <Button
               element="button"
               size="jumbo"
               text="Jumbo"
               type="button"
-              variant="regular"
             >
               <button
                 className="emotion-31"

--- a/src/library/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
+++ b/src/library/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
@@ -40,6 +40,7 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -109,6 +110,7 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -191,7 +193,6 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
                     size="large"
                     tabIndex={0}
                     type="button"
-                    variant="regular"
                   >
                     <PopoverTrigger
                       component="span"
@@ -221,7 +222,6 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
                             size="large"
                             tabIndex={0}
                             type="button"
-                            variant="regular"
                           >
                             <Button
                               aria-describedby="tooltip-1-content"
@@ -236,7 +236,6 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
                               size="large"
                               tabIndex={0}
                               type="button"
-                              variant="regular"
                             >
                               <button
                                 aria-describedby="tooltip-1-content"
@@ -350,6 +349,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -443,6 +443,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -607,7 +608,6 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                           size="large"
                           tabIndex={0}
                           type="button"
-                          variant="regular"
                         >
                           <PopoverTrigger
                             component="span"
@@ -632,7 +632,6 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                   size="large"
                                   tabIndex={0}
                                   type="button"
-                                  variant="regular"
                                 >
                                   <Button
                                     aria-describedby="tooltip-21-content"
@@ -648,7 +647,6 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                     tabIndex={0}
                                     text="Button"
                                     type="button"
-                                    variant="regular"
                                   >
                                     <button
                                       aria-describedby="tooltip-21-content"
@@ -1029,7 +1027,6 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
         onClick={[Function]}
         size="large"
         type="button"
-        variant="regular"
       >
         <Button
           element="button"
@@ -1037,7 +1034,6 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
           size="large"
           text="Close Tooltip"
           type="button"
-          variant="regular"
         >
           <button
             className="emotion-2"
@@ -1086,6 +1082,7 @@ exports[`Tooltip demo examples Snapshots: disabled 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -1155,6 +1152,7 @@ exports[`Tooltip demo examples Snapshots: disabled 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1179,13 +1177,11 @@ exports[`Tooltip demo examples Snapshots: disabled 1`] = `
     }
     size="large"
     type="button"
-    variant="regular"
   >
     <Button
       element="button"
       size="large"
       type="button"
-      variant="regular"
     >
       <button
         className="emotion-2"
@@ -1278,6 +1274,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -1377,6 +1374,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -1526,7 +1524,6 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                         size="large"
                         tabIndex={0}
                         type="button"
-                        variant="regular"
                       >
                         <PopoverTrigger
                           component="span"
@@ -1551,7 +1548,6 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                                 size="large"
                                 tabIndex={0}
                                 type="button"
-                                variant="regular"
                               >
                                 <Button
                                   aria-describedby="tooltip-11-content"
@@ -1567,7 +1563,6 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                                   tabIndex={0}
                                   text="Button"
                                   type="button"
-                                  variant="regular"
                                 >
                                   <button
                                     aria-describedby="tooltip-11-content"
@@ -1983,6 +1978,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2099,6 +2095,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0.4375em;
   -webkit-text-decoration: none;
@@ -2725,6 +2722,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -2746,6 +2744,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -2872,6 +2871,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3071,7 +3071,6 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                                   size="large"
                                   tabIndex={0}
                                   type="button"
-                                  variant="regular"
                                 >
                                   <PopoverTrigger
                                     component="span"
@@ -3096,7 +3095,6 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                                           size="large"
                                           tabIndex={0}
                                           type="button"
-                                          variant="regular"
                                         >
                                           <Button
                                             aria-describedby="tooltip-15-content"
@@ -3112,7 +3110,6 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                                             tabIndex={0}
                                             text="Button"
                                             type="button"
-                                            variant="regular"
                                           >
                                             <button
                                               aria-describedby="tooltip-15-content"
@@ -3187,7 +3184,6 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-12"
@@ -3196,7 +3192,6 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-12"
@@ -3206,7 +3201,6 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-11"
@@ -3456,6 +3450,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -3549,6 +3544,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3675,6 +3671,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
   display: inline-block;
   font-weight: 600;
   height: 1.5em;
+  margin: 0;
   min-width: 1.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -3834,7 +3831,6 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                   size="large"
                                   tabIndex={0}
                                   type="button"
-                                  variant="regular"
                                 >
                                   <PopoverTrigger
                                     component="span"
@@ -3859,7 +3855,6 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                           size="large"
                                           tabIndex={0}
                                           type="button"
-                                          variant="regular"
                                         >
                                           <Button
                                             aria-describedby="tooltip-13-content"
@@ -3875,7 +3870,6 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                             tabIndex={0}
                                             text="Button"
                                             type="button"
-                                            variant="regular"
                                           >
                                             <button
                                               aria-describedby="tooltip-13-content"
@@ -4261,7 +4255,6 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
         onClick={[Function]}
         size="small"
         type="button"
-        variant="regular"
       >
         <Button
           className="emotion-20"
@@ -4270,7 +4263,6 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
           onClick={[Function]}
           size="small"
           type="button"
-          variant="regular"
         >
           <Button
             className="emotion-20"
@@ -4280,7 +4272,6 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
             size="small"
             text="Re-center"
             type="button"
-            variant="regular"
           >
             <button
               className="emotion-19"

--- a/src/library/index.js
+++ b/src/library/index.js
@@ -2,6 +2,7 @@
 export { default as Avatar } from './Avatar';
 export { default as Box } from './Box';
 export { default as Button } from './Button';
+export { default as ButtonGroup } from './ButtonGroup';
 export {
   default as Card,
   CardActions,

--- a/src/library/themes/__tests__/__snapshots__/createThemedComponent.spec.js.snap
+++ b/src/library/themes/__tests__/__snapshots__/createThemedComponent.spec.js.snap
@@ -616,11 +616,8 @@ exports[`createThemedComponent renders a Link correctly with a custom theme func
           >
             <Link
               element="a"
-              variant="regular"
             >
-              <Link
-                variant="regular"
-              >
+              <Link>
                 <a
                   className="emotion-0"
                 />
@@ -1250,11 +1247,8 @@ exports[`createThemedComponent renders a Link correctly with a custom theme obje
           >
             <Link
               element="a"
-              variant="regular"
             >
-              <Link
-                variant="regular"
-              >
+              <Link>
                 <a
                   className="emotion-0"
                 />

--- a/src/library/utils/collections.js
+++ b/src/library/utils/collections.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export const fromArray = <T>(array: Array<T>): Set<T> =>
+export const setFromArray = <T>(array: Array<T>): Set<T> =>
   array.reduce((acc, value) => {
     acc.add(value);
     return acc;
@@ -11,7 +11,7 @@ export const fromArray = <T>(array: Array<T>): Set<T> =>
 export const settify = (input: any) =>
   Object.keys(input).reduce((acc, key) => {
     const value = input[key];
-    acc[key] = Array.isArray(value) ? fromArray(value) : settify(value);
+    acc[key] = Array.isArray(value) ? setFromArray(value) : settify(value);
     return acc;
   }, {});
 

--- a/src/library/utils/index.js
+++ b/src/library/utils/index.js
@@ -5,4 +5,4 @@ export { default as isRenderProp } from './isRenderProp';
 export { default as isValidProp } from './isValidProp';
 export { isDevelopment, isProduction } from './nodeEnv';
 export { default as reactProps } from './reactProps';
-export { fromArray, settify, toArray } from './collections';
+export { setFromArray, settify, toArray } from './collections';

--- a/src/website/app/Label.js
+++ b/src/website/app/Label.js
@@ -4,14 +4,13 @@ import { createStyledComponent } from '../../library/styles';
 
 type Props = {
   children: React$Node,
-  variant?: 'regular' | 'success' | 'warning' | 'danger'
+  variant?: 'success' | 'warning' | 'danger'
 };
 
 const Root = createStyledComponent('span', ({ theme, variant }) => {
-  const backgroundColor =
-    variant === 'regular'
-      ? theme.color_theme_60
-      : theme[`backgroundColor_${variant}Primary`];
+  const backgroundColor = variant
+    ? theme[`backgroundColor_${variant}Primary`]
+    : theme.color_theme_60;
 
   return {
     backgroundColor,
@@ -26,15 +25,6 @@ const Root = createStyledComponent('span', ({ theme, variant }) => {
   };
 });
 
-const Label = (props: Props) => {
-  const { children, ...restProps } = props;
-  const rootProps = { ...restProps };
-
-  return <Root {...rootProps}>{children}</Root>;
-};
-
-Label.defaultProps = {
-  variant: 'regular'
-};
-
-export default Label;
+export default function Label(props: Props) {
+  return <Root {...props} />;
+}

--- a/src/website/app/Markdown.js
+++ b/src/website/app/Markdown.js
@@ -260,11 +260,13 @@ function ListItem({ children }: ListItemProps) {
         return child;
       }
 
-      const labelVariant = 'done' === labelText ? 'success' : 'regular';
+      const labelProps = {
+        ...(labelText === 'done' ? { variant: 'success' } : undefined)
+      };
 
       return [
         preLabelText,
-        <Label key={1} variant={labelVariant}>
+        <Label key={1} {...labelProps}>
           {labelText}
         </Label>
       ];

--- a/src/website/app/demos/Button/index.js
+++ b/src/website/app/demos/Button/index.js
@@ -1,20 +1,22 @@
 /* @flow */
 import { componentTheme } from '../../../../library/Button/Button';
-import bestPractices from './bestPractices';
 import examples from './examples';
+import bestPractices from './bestPractices';
 
 const doc = require('!!react-docgen-loader!../../../../library/Button/Button');
 
-export default {
-  bestPractices,
-  doc,
-  examples,
-  slug: 'button',
-  componentTheme,
-  title: 'Button',
-  whenHowToUse: `A Button should be used whenever you need to trigger an action in your app.
-Buttons should have concise labeling indicating to your user what will happen when the Button is clicked.
-The color of the button should be chosen according to the intent of the action.
+export default [
+  {
+    bestPractices,
+    componentTheme,
+    doc,
+    examples,
+    slug: 'button',
+    title: 'Button',
+    whenHowToUse: `A Button should be used whenever you need to trigger an action in your app.
+  Buttons should have concise labeling indicating to your user what will happen when the Button is clicked.
+  The color of the button should be chosen according to the intent of the action.
 
-For example, if clicking a Button will make a potentially destructive action, use \`variant="danger"\` instead of \`"success"\`.`
-};
+  For example, if clicking a Button will make a potentially destructive action, use \`variant="danger"\` instead of \`"success"\`.`
+  }
+];

--- a/src/website/app/demos/ButtonGroup/bestPractices.js
+++ b/src/website/app/demos/ButtonGroup/bestPractices.js
@@ -1,0 +1,77 @@
+/* @flow */
+import React from 'react';
+import IconAdd from 'mineral-ui-icons/IconAdd';
+import IconArchive from 'mineral-ui-icons/IconArchive';
+import IconDelete from 'mineral-ui-icons/IconDelete';
+import Button from '../../../../library/Button';
+import ButtonGroup from '../../../../library/ButtonGroup';
+import Flex, { FlexItem } from '../../../../library/Flex';
+
+export default [
+  {
+    type: 'do',
+    description: `Where space allows, add text to accompany icons in order to
+  clarify purpose.`,
+    example: (
+      <ButtonGroup aria-label="File Actions">
+        <Button iconStart={<IconAdd />}>Add</Button>
+        <Button iconStart={<IconDelete />}>Delete</Button>
+        <Button iconStart={<IconArchive />}>Archive</Button>
+      </ButtonGroup>
+    )
+  },
+  {
+    type: 'dont',
+    description: `Don't use ButtonGroup for unrelated buttons.`,
+    example: (
+      <ButtonGroup aria-label="Mixed-use Actions">
+        <Button>Go Back</Button>
+        <Button>Edit</Button>
+        <Button>Favorite</Button>
+      </ButtonGroup>
+    )
+  },
+  {
+    type: 'dont',
+    description: `Don't use long words or more than three words to describe a
+  ButtonGroup Button; instead, be as descriptive and concise as possible.`,
+    example: (
+      <ButtonGroup aria-label="Lengthy Actions">
+        <Button>Save</Button>
+        <Button>Invalidate/Disentangle</Button>
+        <Button>Click To View Previous Changes</Button>
+      </ButtonGroup>
+    )
+  },
+  {
+    type: 'dont',
+    description: `Don't use varying \`sizes\` for adjacent ButtonGroups.`,
+    example: (
+      <Flex marginTop="-1rem" wrap>
+        <FlexItem marginTop="1rem">
+          <ButtonGroup size="small" aria-label="Small Buttons" mode="radio">
+            <Button defaultChecked>List</Button>
+            <Button>Grid</Button>
+          </ButtonGroup>
+        </FlexItem>
+        <FlexItem marginTop="1rem">
+          <ButtonGroup aria-label="Default Buttons" mode="radio">
+            <Button defaultChecked>Light</Button>
+            <Button>Dark</Button>
+          </ButtonGroup>
+        </FlexItem>
+      </Flex>
+    )
+  },
+  {
+    type: 'dont',
+    description: `Don't use ButtonGroups for navigation; use tabs instead.`,
+    example: (
+      <ButtonGroup aria-label="Galaxies">
+        <Button>Home</Button>
+        <Button>Blog</Button>
+        <Button>Photos</Button>
+      </ButtonGroup>
+    )
+  }
+];

--- a/src/website/app/demos/ButtonGroup/examples/basic.js
+++ b/src/website/app/demos/ButtonGroup/examples/basic.js
@@ -1,0 +1,17 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+
+export default {
+  id: 'basic',
+  title: 'Basic',
+  description: `ButtonGroups stylistically group a set of buttons together.`,
+  scope: { Button, ButtonGroup },
+  source: `
+    <ButtonGroup aria-label="Edit text">
+      <Button>Cut</Button>
+      <Button>Copy</Button>
+      <Button>Paste</Button>
+    </ButtonGroup>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/composition.js
+++ b/src/website/app/demos/ButtonGroup/examples/composition.js
@@ -1,0 +1,59 @@
+/* @flow */
+import IconArrowDropDown from 'mineral-ui-icons/IconArrowDropDown';
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import Dropdown from '../../../../../library/Dropdown';
+import Popover from '../../../../../library/Popover';
+import { createStyledComponent } from '../../../../../library/styles';
+import Tooltip from '../../../../../library/Tooltip';
+import data from '../../Menu/components/menuData';
+import DemoContent from '../../Popover/components/DemoContent';
+
+const FixedWidthLayout = createStyledComponent('div', {
+  '@media only screen and (max-width: 450px)': {
+    '& > * button': {
+      maxWidth: '5rem'
+    }
+  },
+  '@media only screen and (max-width: 380px)': {
+    '& > * button': {
+      maxWidth: '4rem'
+    }
+  }
+});
+
+export default {
+  id: 'composition',
+  title: 'Composition',
+  description: `Other Mineral components that render a Mineral
+[Button](/components/button), such as [Tooltip](/components/tooltip),
+[Popover](/components/popover), or [Dropdown](/components/dropdown), may be
+composed in a ButtonGroup, though they are incompatible with the \`mode\` prop.`,
+  scope: {
+    Button,
+    ButtonGroup,
+    data,
+    DemoContent,
+    Dropdown,
+    FixedWidthLayout,
+    IconArrowDropDown,
+    Popover,
+    Tooltip
+  },
+  source: `
+    <FixedWidthLayout>
+      <ButtonGroup aria-label="Optional compositions">
+        <Button>Button</Button>
+        <Tooltip content="Lorem ipsum dolor sit amet">
+          <Button>Tooltip</Button>
+        </Tooltip>
+        <Popover content={<DemoContent />}>
+          <Button>Popover</Button>
+        </Popover>
+        <Dropdown data={data}>
+          <Button iconEnd={<IconArrowDropDown />}>Dropdown</Button>
+        </Dropdown>
+      </ButtonGroup>
+    </FixedWidthLayout>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/controlled.js
+++ b/src/website/app/demos/ButtonGroup/examples/controlled.js
@@ -1,0 +1,60 @@
+/* @flow */
+import { Component } from 'react';
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import DemoLayout from '../../shared/DemoLayout';
+
+export default {
+  id: 'controlled',
+  title: 'Controlled',
+  description: `Provide the \`checked\` prop and an \`onChange\` handler to
+create a controlled component.`,
+  scope: { Button, ButtonGroup, Component, DemoLayout },
+  source: `
+  () => {
+    class MyForm extends Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {
+          checked: 0
+        };
+
+        this.handleChange = this.handleChange.bind(this);
+        this.resetDefaultSelected = this.resetDefaultSelected.bind(this);
+      }
+
+      handleChange(event) {
+        this.setState({
+          checked: parseInt(event.target.getAttribute('data-index'))
+        });
+      }
+
+      resetDefaultSelected() {
+        this.setState({
+          checked: 0
+        });
+      }
+
+      render() {
+        return (
+          <DemoLayout>
+            <ButtonGroup
+              aria-label="Align text"
+              checked={this.state.checked}
+              onChange={this.handleChange}
+              mode="radio">
+              <Button>Left</Button>
+              <Button>Center</Button>
+              <Button>Right</Button>
+            </ButtonGroup>
+            <Button minimal size="small" onClick={this.resetDefaultSelected}>Reset to Default Alignment</Button>
+          </DemoLayout>
+        );
+      }
+    }
+
+    return <MyForm />;
+  }
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/disabled.js
+++ b/src/website/app/demos/ButtonGroup/examples/disabled.js
@@ -1,0 +1,44 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import DemoLayout from '../../shared/DemoLayout';
+
+export default {
+  id: 'disabled',
+  title: 'Disabled',
+  description: `Use \`disabled\` to indicate that Buttons are not available for
+interaction.  Note that the \`disabled\` prop may be set on the root or on
+individual children.`,
+  scope: { Button, ButtonGroup, DemoLayout },
+  source: `
+    <DemoLayout>
+      <ButtonGroup disabled aria-label="Edit text">
+        <Button>Cut</Button>
+        <Button>Copy</Button>
+        <Button>Paste</Button>
+      </ButtonGroup>
+
+      <ButtonGroup aria-label="Edit text">
+        <Button disabled>Cut</Button>
+        <Button>Copy</Button>
+        <Button>Paste</Button>
+      </ButtonGroup>
+
+      <ButtonGroup
+        disabled
+        aria-label="Align text"
+        defaultChecked={0}
+        mode="radio">
+        <Button>Left</Button>
+        <Button>Center</Button>
+        <Button>Right</Button>
+      </ButtonGroup>
+
+      <ButtonGroup aria-label="Align text" defaultChecked={0} mode="radio">
+        <Button>Left</Button>
+        <Button>Center</Button>
+        <Button disabled>Right</Button>
+      </ButtonGroup>
+    </DemoLayout>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/icons.js
+++ b/src/website/app/demos/ButtonGroup/examples/icons.js
@@ -1,0 +1,64 @@
+/* @flow */
+import IconFormatAlignCenter from 'mineral-ui-icons/IconFormatAlignCenter';
+import IconFormatAlignLeft from 'mineral-ui-icons/IconFormatAlignLeft';
+import IconFormatAlignRight from 'mineral-ui-icons/IconFormatAlignRight';
+import IconFormatBold from 'mineral-ui-icons/IconFormatBold';
+import IconFormatItalic from 'mineral-ui-icons/IconFormatItalic';
+import IconFormatUnderlined from 'mineral-ui-icons/IconFormatUnderlined';
+import IconSentimentSatisfied from 'mineral-ui-icons/IconSentimentSatisfied';
+import IconSentimentNeutral from 'mineral-ui-icons/IconSentimentNeutral';
+import IconSentimentDissatisfied from 'mineral-ui-icons/IconSentimentDissatisfied';
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import DemoLayout from '../../shared/DemoLayout';
+
+export default {
+  id: 'icons',
+  title: 'Icons',
+  description: `Buttons within ButtonGroup can contain [Icons](/components/icon),
+just as they do in [Button](/components/button#icons)`,
+  scope: {
+    Button,
+    ButtonGroup,
+    DemoLayout,
+    IconFormatAlignCenter,
+    IconFormatAlignLeft,
+    IconFormatAlignRight,
+    IconFormatBold,
+    IconFormatItalic,
+    IconFormatUnderlined,
+    IconSentimentDissatisfied,
+    IconSentimentNeutral,
+    IconSentimentSatisfied
+  },
+  source: `
+    <DemoLayout>
+      <ButtonGroup aria-label="Align text" mode="radio">
+        <Button defaultChecked iconStart={<IconFormatAlignLeft />}>Left</Button>
+        <Button iconStart={<IconFormatAlignCenter />}>Center</Button>
+        <Button iconStart={<IconFormatAlignRight />}>Right</Button>
+      </ButtonGroup>
+
+      <ButtonGroup aria-label="Format text" mode="checkbox">
+        <Button iconEnd={<IconFormatBold />} aria-label="Bold" />
+        <Button iconEnd={<IconFormatItalic />} aria-label="Italic" />
+        <Button iconEnd={<IconFormatUnderlined />} aria-label="Underlined" />
+      </ButtonGroup>
+
+      <ButtonGroup aria-label="Sentiments" mode="radio">
+        <Button
+          variant="success"
+          iconEnd={<IconSentimentSatisfied />}
+          aria-label="Satisfied" />
+        <Button
+          variant="warning"
+          iconEnd={<IconSentimentNeutral />}
+          aria-label="Neutral" />
+        <Button
+          variant="danger"
+          iconEnd={<IconSentimentDissatisfied />}
+          aria-label="Unsatisfied" />
+      </ButtonGroup>
+    </DemoLayout>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/importSyntax.js
+++ b/src/website/app/demos/ButtonGroup/examples/importSyntax.js
@@ -1,0 +1,9 @@
+/* @flow */
+export default {
+  id: 'import-syntax',
+  title: 'Import Syntax',
+  description: `\`\`\`
+import ButtonGroup from 'mineral-ui/ButtonGroup';
+\`\`\`
+`
+};

--- a/src/website/app/demos/ButtonGroup/examples/index.js
+++ b/src/website/app/demos/ButtonGroup/examples/index.js
@@ -1,0 +1,26 @@
+/* @flow */
+import basic from './basic';
+import composition from './composition';
+import controlled from './controlled';
+import disabled from './disabled';
+import icons from './icons';
+import importSyntax from './importSyntax';
+import mode from './mode';
+import rtl from './rtl';
+import sizes from './sizes';
+import uncontrolled from './uncontrolled';
+import variants from './variants';
+
+export default [
+  importSyntax,
+  basic,
+  mode,
+  uncontrolled,
+  controlled,
+  sizes,
+  variants,
+  disabled,
+  icons,
+  composition,
+  rtl
+];

--- a/src/website/app/demos/ButtonGroup/examples/mode.js
+++ b/src/website/app/demos/ButtonGroup/examples/mode.js
@@ -1,0 +1,33 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import DemoLayout from '../../shared/DemoLayout';
+
+export default {
+  id: 'mode',
+  title: 'Mode',
+  description: `Use the \`mode\` prop to render toggleable Buttons. A value of
+\`radio\` will cause Buttons to behave like radio buttons and a value of
+\`checkbox\` will cause Buttons to behave like checkboxes.`,
+  scope: { Button, ButtonGroup, DemoLayout },
+  source: `
+    <DemoLayout>
+      <ButtonGroup
+        mode="radio"
+        aria-label="Align text"
+        defaultChecked={0}>
+        <Button>Left</Button>
+        <Button>Center</Button>
+        <Button>Right</Button>
+      </ButtonGroup>
+      <ButtonGroup
+        mode="checkbox"
+        aria-label="Text Decoration"
+        defaultChecked={[0, 1]}>
+        <Button>Bold</Button>
+        <Button>Italic</Button>
+        <Button>Underline</Button>
+      </ButtonGroup>
+    </DemoLayout>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/rtl.js
+++ b/src/website/app/demos/ButtonGroup/examples/rtl.js
@@ -1,0 +1,34 @@
+/* @flow */
+import IconFormatBold from 'mineral-ui-icons/IconFormatBold';
+import IconFormatItalic from 'mineral-ui-icons/IconFormatItalic';
+import IconFormatUnderlined from 'mineral-ui-icons/IconFormatUnderlined';
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import { ThemeProvider } from '../../../../../library/themes';
+
+export default {
+  id: 'rtl',
+  title: 'Bidirectionality',
+  description: `ButtonGroups support right-to-left (RTL) languages. Buttons
+within ButtonGroup behave like [Button](/components/button#rtl) (Icons are
+reversed when the \`direction\` theme variable is set to \`rtl\`. A subset of
+[Icons that convey directionality](/components/icon#rtl) will be reversed).`,
+  scope: {
+    Button,
+    ButtonGroup,
+    IconFormatBold,
+    IconFormatItalic,
+    IconFormatUnderlined,
+    ThemeProvider
+  },
+  source: `
+    <div dir="rtl">
+      <ThemeProvider theme={{ direction: 'rtl' }}>
+        <ButtonGroup aria-label="Format text" mode="checkbox">
+          <Button iconEnd={<IconFormatBold />}>بالخط العريض</Button>
+          <Button iconEnd={<IconFormatItalic />}>مائل</Button>
+          <Button iconEnd={<IconFormatUnderlined />}>أكد</Button>
+        </ButtonGroup>
+      </ThemeProvider>
+    </div>`
+};

--- a/src/website/app/demos/ButtonGroup/examples/sizes.js
+++ b/src/website/app/demos/ButtonGroup/examples/sizes.js
@@ -1,0 +1,38 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import DemoLayout from '../../shared/DemoLayout';
+
+export default {
+  id: 'sizes',
+  title: 'Sizes',
+  description: `To provide hierarchy to actions on your page, change ButtonGroup
+  impact with the \`size\` attribute.
+
+  For a ButtonGroup whose width is defined by its container, use \`fullWidth\`.
+`,
+  scope: { Button, ButtonGroup, DemoLayout },
+  source: `() => {
+    const sizes = ['small', 'medium', 'large', 'jumbo'];
+
+    return (
+      <DemoLayout>
+        {
+          sizes.map((size) => (
+            <ButtonGroup size={size} aria-label="Edit text" key={size}>
+              <Button>Cut</Button>
+              <Button>Copy</Button>
+              <Button>Paste</Button>
+            </ButtonGroup>
+          ))
+        }
+        <ButtonGroup fullWidth aria-label="Edit text">
+          <Button>Cut</Button>
+          <Button>Copy</Button>
+          <Button>Paste</Button>
+        </ButtonGroup>
+      </DemoLayout>
+    );
+  }
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/uncontrolled.js
+++ b/src/website/app/demos/ButtonGroup/examples/uncontrolled.js
@@ -1,0 +1,22 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+
+export default {
+  id: 'uncontrolled',
+  title: 'Uncontrolled',
+  description: `Create an uncontrolled ButtonGroup by using the
+\`defaultChecked\` prop rather than the \`checked\` prop. Note that the
+\`defaultChecked\` prop may be set on the root (where the value may be a number
+representing the index of the Button to check or an array of those indices,
+based on the zero-indexed collection of nested Buttons) or on individual
+children (where the value is a boolean).`,
+  scope: { Button, ButtonGroup },
+  source: `
+    <ButtonGroup aria-label="Align text" mode="radio">
+      <Button defaultChecked>Left</Button>
+      <Button>Center</Button>
+      <Button>Right</Button>
+    </ButtonGroup>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/examples/variants.js
+++ b/src/website/app/demos/ButtonGroup/examples/variants.js
@@ -1,0 +1,28 @@
+/* @flow */
+import Button from '../../../../../library/Button';
+import ButtonGroup from '../../../../../library/ButtonGroup';
+import DemoLayout from '../../shared/DemoLayout';
+
+export default {
+  id: 'variants',
+  title: 'Variants',
+  description: `Use the \`variant\` prop to  to help communicate purpose. Note
+that the \`variant\` prop may be set on the root or on individual children.`,
+  scope: { Button, ButtonGroup, DemoLayout },
+  source: `
+    <DemoLayout>
+      <ButtonGroup variant="success" aria-label="Shopping options">
+        <Button>Donate $5</Button>
+        <Button>Donate $10</Button>
+      </ButtonGroup>
+      <ButtonGroup variant="warning" aria-label="Shopping options">
+        <Button>Revoke Author Permissions</Button>
+        <Button>Revoke Group Permissions</Button>
+      </ButtonGroup>
+      <ButtonGroup variant="danger" aria-label="Shopping options">
+        <Button>Send Storm Watch</Button>
+        <Button>Send Storm Warning</Button>
+      </ButtonGroup>
+    </DemoLayout>
+  `
+};

--- a/src/website/app/demos/ButtonGroup/index.js
+++ b/src/website/app/demos/ButtonGroup/index.js
@@ -1,0 +1,27 @@
+/* @flow */
+import { componentTheme } from '../../../../library/ButtonGroup/ButtonGroup';
+import examples from './examples';
+import bestPractices from './bestPractices';
+
+const doc = require('!!react-docgen-loader!../../../../library/ButtonGroup/ButtonGroup');
+
+export default [
+  {
+    bestPractices,
+    componentTheme,
+    doc,
+    examples,
+    slug: 'button-group',
+    title: 'ButtonGroup',
+    whenHowToUse: `ButtonGroup allows users to stylistically group related
+buttons or to select either a single or multiple options from a group of related
+buttons.
+
+Although ButtonGroups can mimic radio-button and checkbox behaviors, the
+elements do not behave as their HTML counterparts during traditional form
+submission and thus should not be used as replacements for radios and checkboxes
+if that functionality is needed. In such scenarios, [Radio](/components/radio)
+or [Checkbox](/components/checkbox) should be used instead.
+`
+  }
+];

--- a/src/website/app/demos/Link/examples/variants.js
+++ b/src/website/app/demos/Link/examples/variants.js
@@ -22,7 +22,7 @@ export default {
   scope: { DemoLayout, Link },
   source: `
     <DemoLayout>
-      <Link href="http://example.com">Regular</Link>
+      <Link href="http://example.com">Default</Link>
       <Link variant="danger" href="http://example.com">Danger</Link>
       <Link variant="success" href="http://example.com">Success</Link>
       <Link variant="warning" href="http://example.com">Warning</Link>

--- a/src/website/app/demos/index.js
+++ b/src/website/app/demos/index.js
@@ -3,6 +3,7 @@ import flatten from 'lodash/flatten';
 import createKeyMap from '../utils/createKeyMap';
 import avatar from './Avatar';
 import button from './Button';
+import buttonGroup from './ButtonGroup';
 import box from './Box';
 import card from './Card';
 import checkbox from './Checkbox';
@@ -26,6 +27,7 @@ import tooltip from './Tooltip';
 const demos = flatten([
   avatar,
   button,
+  buttonGroup,
   box,
   card,
   checkbox,

--- a/src/website/app/demos/routes.js
+++ b/src/website/app/demos/routes.js
@@ -12,6 +12,12 @@ export default [
     slug: 'button',
     title: 'Button'
   },
+  {
+    description:
+      'ButtonGroup stylistically groups related buttons and provides the capability to select buttons like radios or checkboxes.',
+    slug: 'button-group',
+    title: 'ButtonGroup'
+  },
   [
     {
       description:

--- a/src/website/app/demos/shared/DemoLayout.js
+++ b/src/website/app/demos/shared/DemoLayout.js
@@ -14,7 +14,7 @@ const Root = createStyledComponent(
   ({ includeLastChild, marginRight, marginBottom }) => {
     if (includeLastChild) {
       return {
-        '& > *': {
+        '&[class] > *': {
           marginRight,
           marginBottom
         }

--- a/utils/__tests__/__snapshots__/snapshotSerializer.spec.js.snap
+++ b/utils/__tests__/__snapshots__/snapshotSerializer.spec.js.snap
@@ -19,6 +19,7 @@ exports[`snapshotSerializer Excludes verbose ThemeProvider props from snapshot 1
   display: inline-block;
   font-weight: 600;
   height: 2.5em;
+  margin: 0;
   min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
@@ -88,6 +89,7 @@ exports[`snapshotSerializer Excludes verbose ThemeProvider props from snapshot 1
   -ms-flex-pack: center;
   justify-content: center;
   max-height: 100%;
+  pointer-events: none;
   width: 100%;
 }
 
@@ -116,14 +118,12 @@ exports[`snapshotSerializer Excludes verbose ThemeProvider props from snapshot 1
       element="button"
       size="large"
       type="button"
-      variant="regular"
     >
       <Button
         element="button"
         size="large"
         text="Submit"
         type="button"
-        variant="regular"
       >
         <button
           className="emotion-2"


### PR DESCRIPTION
### Description
* Add new ButtonGroup component
* Remove `regular` variant from Button and Link
* Remove pointer events from Button's inner content
* Clarify naming for the setFromArray utility
* Fix event flow type for Choice components and add display names

### Motivation and context
closes #702
closes #707
Note: This is a duplicate PR due to an issue with Happo builds; original comments can be found [here](https://github.com/mineral-ui/mineral-ui/pull/721).

### Screenshots, videos, or demo, if appropriate

https://702-button-group-deux--mineral-ui.netlify.com/components/button-group

### How to test

1. Open the aforementioned preview or run it locally and review the new ButtonGroup component and other features described above.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change

### How does this PR make you feel?
![The Simpson's clip: Independent Thought Alarm button pushed](https://media.giphy.com/media/3o6UBiAQ9Ws8UWdmqA/giphy.gif)
