### PR TITLE
test(happo): Update to happo.io 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "flow-typed": "2.4.0",
     "fs-extra": "5.0.0",
     "glob": "7.1.2",
-    "happo.io": "1.5.0",
+    "happo.io": "1.5.1",
     "html-webpack-plugin": "3.1.0",
     "husky": "0.14.3",
     "inquirer": "5.2.0",


### PR DESCRIPTION
The only change from 1.5.0 is that there's an additional log message
when fallback authentication is being used. This should help debug why
https://github.com/mineral-ui/mineral-ui/pull/726 is getting 401s from
happo.io.