### PR TITLE
[radio,checkbox]: Add hideLabel prop

### DIFF
--- a/src/library/Checkbox/Checkbox.js
+++ b/src/library/Checkbox/Checkbox.js
@@ -23,8 +23,8 @@ type Props = {
   defaultChecked?: boolean,
   /** Disables the checkbox */
   disabled?: boolean,
-  /** Maximize the distance between the label and the control */
-  justify?: boolean,
+  /** Visually hide label, but keep available for [assistive technologies](https://webaccess.berkeley.edu/resources/assistive-technology) */
+  hideLabel?: boolean,
   /**
    * Indicates a state in which it cannot be determined if the input is checked
    * or not
@@ -32,10 +32,10 @@ type Props = {
   indeterminate?: boolean,
   /** Ref for the checkbox */
   inputRef?: (node: ?React$Component<*, *>) => void,
-  /** Props to be applied directly to the root element rather than the input */
-  rootProps?: Object,
   /** Indicates that the value of the input is invalid */
   invalid?: boolean,
+  /** Maximize the distance between the label and the control */
+  justify?: boolean,
   /** Label associated with the input element */
   label: string | React$Element<*>,
   /** Determines the position of the label relative to the control */
@@ -46,6 +46,8 @@ type Props = {
   onChange?: (event: SyntheticInputEvent<>) => void,
   /** Indicates that the user must select an option before submitting a form */
   required?: boolean,
+  /** Props to be applied directly to the root element rather than the input */
+  rootProps?: Object,
   /** Available sizes */
   size?: 'small' | 'medium' | 'large' | 'jumbo',
   /** The value of the checkbox */

--- a/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -102,8 +102,6 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -123,6 +121,8 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <Component>
@@ -199,6 +199,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -223,7 +224,6 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -340,6 +340,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -364,7 +365,6 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -481,6 +481,7 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -505,7 +506,6 @@ exports[`Checkbox demo examples Snapshots: controlled 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -667,8 +667,6 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -688,6 +686,8 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-15 {
@@ -918,6 +918,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -942,7 +943,6 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -1060,6 +1060,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -1084,7 +1085,6 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -1202,6 +1202,7 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -1226,7 +1227,6 @@ exports[`Checkbox demo examples Snapshots: controlled 2`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -1396,8 +1396,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -1417,6 +1415,8 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-16 {
@@ -1643,6 +1643,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1665,7 +1666,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1779,6 +1779,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1801,7 +1802,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1915,6 +1915,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1937,7 +1938,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -2126,6 +2126,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -2148,7 +2149,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -2262,6 +2262,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -2284,7 +2285,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -2398,6 +2398,7 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -2420,7 +2421,6 @@ exports[`Checkbox demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -2590,8 +2590,6 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -2604,6 +2602,8 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
 .emotion-3 {
   color: #afbacc;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -2671,6 +2671,7 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                   <Choice
                     disabled={true}
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -2692,7 +2693,6 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                       </Styled(input)>
                       <Control
                         disabled={true}
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -2807,6 +2807,7 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                   <Choice
                     disabled={true}
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -2830,7 +2831,6 @@ exports[`Checkbox demo examples Snapshots: disabled 1`] = `
                       </Styled(input)>
                       <Control
                         disabled={true}
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -2991,8 +2991,6 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -3012,6 +3010,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
 .emotion-5 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-27 {
@@ -3140,13 +3140,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
           >
             <div>
               <Styled(div)
-                key="formField-95-textWrapper"
+                key="formField-97-textWrapper"
               >
                 <div
                   className="emotion-1"
                 >
                   <span
-                    id="formField-95-labelText"
+                    id="formField-97-labelText"
                   >
                     What are the primary characteristics of a mineral?
                   </span>
@@ -3160,7 +3160,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                 </div>
               </Styled(div)>
               <CheckboxGroup
-                aria-describedby="formField-95-caption"
+                aria-describedby="formField-97-caption"
                 data={
                   Array [
                     Object {
@@ -3185,19 +3185,19 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                     },
                   ]
                 }
-                key="formField-95-control"
+                key="formField-97-control"
                 name="contact"
                 required={true}
                 rootProps={
                   Object {
-                    "aria-describedby": "formField-95-caption",
-                    "aria-labelledby": "formField-95-labelText",
+                    "aria-describedby": "formField-97-caption",
+                    "aria-labelledby": "formField-97-labelText",
                   }
                 }
                 variant="success"
               >
                 <WithTheme(Themed(ChoiceGroup))
-                  aria-describedby="formField-95-caption"
+                  aria-describedby="formField-97-caption"
                   data={
                     Array [
                       Object {
@@ -3227,15 +3227,15 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                   required={true}
                   rootProps={
                     Object {
-                      "aria-describedby": "formField-95-caption",
-                      "aria-labelledby": "formField-95-labelText",
+                      "aria-describedby": "formField-97-caption",
+                      "aria-labelledby": "formField-97-labelText",
                     }
                   }
                   type="checkbox"
                   variant="success"
                 >
                   <Themed(ChoiceGroup)
-                    aria-describedby="formField-95-caption"
+                    aria-describedby="formField-97-caption"
                     data={
                       Array [
                         Object {
@@ -3265,8 +3265,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                     required={true}
                     rootProps={
                       Object {
-                        "aria-describedby": "formField-95-caption",
-                        "aria-labelledby": "formField-95-labelText",
+                        "aria-describedby": "formField-97-caption",
+                        "aria-labelledby": "formField-97-labelText",
                       }
                     }
                     type="checkbox"
@@ -3275,7 +3275,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                     <ThemeProvider>
                       <ThemeProvider>
                         <ChoiceGroup
-                          aria-describedby="formField-95-caption"
+                          aria-describedby="formField-97-caption"
                           data={
                             Array [
                               Object {
@@ -3306,8 +3306,8 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                           role="group"
                           rootProps={
                             Object {
-                              "aria-describedby": "formField-95-caption",
-                              "aria-labelledby": "formField-95-labelText",
+                              "aria-describedby": "formField-97-caption",
+                              "aria-labelledby": "formField-97-labelText",
                             }
                           }
                           size="large"
@@ -3315,19 +3315,19 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                           variant="success"
                         >
                           <ChoiceGroup
-                            aria-describedby="formField-95-caption"
-                            aria-labelledby="formField-95-labelText"
+                            aria-describedby="formField-97-caption"
+                            aria-labelledby="formField-97-labelText"
                             role="group"
                             size="large"
                           >
                             <div
-                              aria-describedby="formField-95-caption"
-                              aria-labelledby="formField-95-labelText"
+                              aria-describedby="formField-97-caption"
+                              aria-labelledby="formField-97-labelText"
                               className="emotion-27"
                               role="group"
                             >
                               <Checkbox
-                                aria-describedby="formField-95-caption"
+                                aria-describedby="formField-97-caption"
                                 key="0"
                                 label="Naturally occurring"
                                 labelPosition="end"
@@ -3337,7 +3337,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 variant="success"
                               >
                                 <WithTheme(Themed(Choice))
-                                  aria-describedby="formField-95-caption"
+                                  aria-describedby="formField-97-caption"
                                   iconChecked={<IconCheckBoxCheck />}
                                   inputRef={[Function]}
                                   label="Naturally occurring"
@@ -3354,7 +3354,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                   variant="success"
                                 >
                                   <Themed(Choice)
-                                    aria-describedby="formField-95-caption"
+                                    aria-describedby="formField-97-caption"
                                     iconChecked={<IconCheckBoxCheck />}
                                     inputRef={[Function]}
                                     label="Naturally occurring"
@@ -3373,7 +3373,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                     <ThemeProvider>
                                       <ThemeProvider>
                                         <Choice
-                                          aria-describedby="formField-95-caption"
+                                          aria-describedby="formField-97-caption"
                                           iconChecked={<IconCheckBoxCheck />}
                                           inputRef={[Function]}
                                           label="Naturally occurring"
@@ -3391,12 +3391,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
                                             >
                                               <Styled(input)
-                                                aria-describedby="formField-95-caption"
+                                                aria-describedby="formField-97-caption"
                                                 innerRef={[Function]}
                                                 name="contact"
                                                 size="large"
@@ -3405,7 +3406,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 variant="success"
                                               >
                                                 <input
-                                                  aria-describedby="formField-95-caption"
+                                                  aria-describedby="formField-97-caption"
                                                   className="emotion-2"
                                                   name="contact"
                                                   size="large"
@@ -3414,7 +3415,6 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -3468,7 +3468,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 </WithTheme(Themed(Choice))>
                               </Checkbox>
                               <Checkbox
-                                aria-describedby="formField-95-caption"
+                                aria-describedby="formField-97-caption"
                                 key="1"
                                 label="Inorganic"
                                 labelPosition="end"
@@ -3478,7 +3478,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 variant="success"
                               >
                                 <WithTheme(Themed(Choice))
-                                  aria-describedby="formField-95-caption"
+                                  aria-describedby="formField-97-caption"
                                   iconChecked={<IconCheckBoxCheck />}
                                   inputRef={[Function]}
                                   label="Inorganic"
@@ -3495,7 +3495,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                   variant="success"
                                 >
                                   <Themed(Choice)
-                                    aria-describedby="formField-95-caption"
+                                    aria-describedby="formField-97-caption"
                                     iconChecked={<IconCheckBoxCheck />}
                                     inputRef={[Function]}
                                     label="Inorganic"
@@ -3514,7 +3514,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                     <ThemeProvider>
                                       <ThemeProvider>
                                         <Choice
-                                          aria-describedby="formField-95-caption"
+                                          aria-describedby="formField-97-caption"
                                           iconChecked={<IconCheckBoxCheck />}
                                           inputRef={[Function]}
                                           label="Inorganic"
@@ -3532,12 +3532,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
                                             >
                                               <Styled(input)
-                                                aria-describedby="formField-95-caption"
+                                                aria-describedby="formField-97-caption"
                                                 innerRef={[Function]}
                                                 name="contact"
                                                 size="large"
@@ -3546,7 +3547,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 variant="success"
                                               >
                                                 <input
-                                                  aria-describedby="formField-95-caption"
+                                                  aria-describedby="formField-97-caption"
                                                   className="emotion-2"
                                                   name="contact"
                                                   size="large"
@@ -3555,7 +3556,6 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -3609,7 +3609,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 </WithTheme(Themed(Choice))>
                               </Checkbox>
                               <Checkbox
-                                aria-describedby="formField-95-caption"
+                                aria-describedby="formField-97-caption"
                                 key="2"
                                 label="Solid"
                                 labelPosition="end"
@@ -3619,7 +3619,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 variant="success"
                               >
                                 <WithTheme(Themed(Choice))
-                                  aria-describedby="formField-95-caption"
+                                  aria-describedby="formField-97-caption"
                                   iconChecked={<IconCheckBoxCheck />}
                                   inputRef={[Function]}
                                   label="Solid"
@@ -3636,7 +3636,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                   variant="success"
                                 >
                                   <Themed(Choice)
-                                    aria-describedby="formField-95-caption"
+                                    aria-describedby="formField-97-caption"
                                     iconChecked={<IconCheckBoxCheck />}
                                     inputRef={[Function]}
                                     label="Solid"
@@ -3655,7 +3655,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                     <ThemeProvider>
                                       <ThemeProvider>
                                         <Choice
-                                          aria-describedby="formField-95-caption"
+                                          aria-describedby="formField-97-caption"
                                           iconChecked={<IconCheckBoxCheck />}
                                           inputRef={[Function]}
                                           label="Solid"
@@ -3673,12 +3673,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
                                             >
                                               <Styled(input)
-                                                aria-describedby="formField-95-caption"
+                                                aria-describedby="formField-97-caption"
                                                 innerRef={[Function]}
                                                 name="contact"
                                                 size="large"
@@ -3687,7 +3688,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 variant="success"
                                               >
                                                 <input
-                                                  aria-describedby="formField-95-caption"
+                                                  aria-describedby="formField-97-caption"
                                                   className="emotion-2"
                                                   name="contact"
                                                   size="large"
@@ -3696,7 +3697,6 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -3750,7 +3750,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 </WithTheme(Themed(Choice))>
                               </Checkbox>
                               <Checkbox
-                                aria-describedby="formField-95-caption"
+                                aria-describedby="formField-97-caption"
                                 key="3"
                                 label="Definite chemical composition"
                                 labelPosition="end"
@@ -3760,7 +3760,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 variant="success"
                               >
                                 <WithTheme(Themed(Choice))
-                                  aria-describedby="formField-95-caption"
+                                  aria-describedby="formField-97-caption"
                                   iconChecked={<IconCheckBoxCheck />}
                                   inputRef={[Function]}
                                   label="Definite chemical composition"
@@ -3777,7 +3777,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                   variant="success"
                                 >
                                   <Themed(Choice)
-                                    aria-describedby="formField-95-caption"
+                                    aria-describedby="formField-97-caption"
                                     iconChecked={<IconCheckBoxCheck />}
                                     inputRef={[Function]}
                                     label="Definite chemical composition"
@@ -3796,7 +3796,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                     <ThemeProvider>
                                       <ThemeProvider>
                                         <Choice
-                                          aria-describedby="formField-95-caption"
+                                          aria-describedby="formField-97-caption"
                                           iconChecked={<IconCheckBoxCheck />}
                                           inputRef={[Function]}
                                           label="Definite chemical composition"
@@ -3814,12 +3814,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
                                             >
                                               <Styled(input)
-                                                aria-describedby="formField-95-caption"
+                                                aria-describedby="formField-97-caption"
                                                 innerRef={[Function]}
                                                 name="contact"
                                                 size="large"
@@ -3828,7 +3829,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 variant="success"
                                               >
                                                 <input
-                                                  aria-describedby="formField-95-caption"
+                                                  aria-describedby="formField-97-caption"
                                                   className="emotion-2"
                                                   name="contact"
                                                   size="large"
@@ -3837,7 +3838,6 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -3891,7 +3891,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 </WithTheme(Themed(Choice))>
                               </Checkbox>
                               <Checkbox
-                                aria-describedby="formField-95-caption"
+                                aria-describedby="formField-97-caption"
                                 key="4"
                                 label="Crystalline structure"
                                 labelPosition="end"
@@ -3901,7 +3901,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                 variant="success"
                               >
                                 <WithTheme(Themed(Choice))
-                                  aria-describedby="formField-95-caption"
+                                  aria-describedby="formField-97-caption"
                                   iconChecked={<IconCheckBoxCheck />}
                                   inputRef={[Function]}
                                   label="Crystalline structure"
@@ -3918,7 +3918,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                   variant="success"
                                 >
                                   <Themed(Choice)
-                                    aria-describedby="formField-95-caption"
+                                    aria-describedby="formField-97-caption"
                                     iconChecked={<IconCheckBoxCheck />}
                                     inputRef={[Function]}
                                     label="Crystalline structure"
@@ -3937,7 +3937,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                     <ThemeProvider>
                                       <ThemeProvider>
                                         <Choice
-                                          aria-describedby="formField-95-caption"
+                                          aria-describedby="formField-97-caption"
                                           iconChecked={<IconCheckBoxCheck />}
                                           inputRef={[Function]}
                                           label="Crystalline structure"
@@ -3955,12 +3955,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
                                             >
                                               <Styled(input)
-                                                aria-describedby="formField-95-caption"
+                                                aria-describedby="formField-97-caption"
                                                 innerRef={[Function]}
                                                 name="contact"
                                                 size="large"
@@ -3969,7 +3970,7 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 variant="success"
                                               >
                                                 <input
-                                                  aria-describedby="formField-95-caption"
+                                                  aria-describedby="formField-97-caption"
                                                   className="emotion-2"
                                                   name="contact"
                                                   size="large"
@@ -3978,7 +3979,6 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -4042,13 +4042,13 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
             </div>
             <Styled(div)
               caption="Hint: All of the above"
-              id="formField-95-caption"
+              id="formField-97-caption"
               isGroup={true}
               variant="success"
             >
               <div
                 className="emotion-28"
-                id="formField-95-caption"
+                id="formField-97-caption"
               >
                 Hint: All of the above
               </div>
@@ -4056,6 +4056,286 @@ exports[`Checkbox demo examples Snapshots: form-field 1`] = `
           </div>
         </FormField>
       </FormField>
+    </form>
+  </Styled(form)>
+</DemoForm>
+`;
+
+exports[`Checkbox demo examples Snapshots: hide-label 1`] = `
+.emotion-5 > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-0:focus + span {
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-0:checked + span,
+.emotion-0[type="checkbox"]:indeterminate + span {
+  background-color: #3272d9;
+  border-color: #3272d9;
+}
+
+.emotion-0:checked:hover + span,
+.emotion-0[type="checkbox"]:indeterminate:hover + span {
+  background-color: #5691f0;
+  border-color: #5691f0;
+}
+
+.emotion-0:checked:disabled + span,
+.emotion-0[type="checkbox"]:indeterminate:disabled + span {
+  background-color: #c8d1e0;
+  border-color: #c8d1e0;
+  color: #ffffff;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #ffffff;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  color: #ffffff;
+  content: "";
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  height: 1em;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 1em;
+}
+
+.emotion-2 svg {
+  fill: currentColor;
+  height: auto;
+  width: 100%;
+}
+
+.emotion-1 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1em;
+  width: 1em;
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.emotion-4 *,
+.emotion-4 *::before,
+.emotion-4 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-4:hover span:first-of-type {
+  border-color: #5691f0;
+}
+
+.emotion-4::after {
+  content: '.';
+  font-size: 0.875em;
+  visibility: hidden;
+  width: 0.1px;
+}
+
+.emotion-3 {
+  color: #333840;
+  font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<DemoForm>
+  <Styled(form)
+    onSubmit={[Function]}
+  >
+    <form
+      className="emotion-5"
+      onSubmit={[Function]}
+    >
+      <Checkbox
+        hideLabel={true}
+        label="Select All"
+        labelPosition="end"
+        size="large"
+      >
+        <WithTheme(Themed(Choice))
+          hideLabel={true}
+          iconChecked={<IconCheckBoxCheck />}
+          inputRef={[Function]}
+          label="Select All"
+          labelPosition="end"
+          rootProps={
+            Object {
+              "className": undefined,
+            }
+          }
+          size="large"
+          type="checkbox"
+        >
+          <Themed(Choice)
+            hideLabel={true}
+            iconChecked={<IconCheckBoxCheck />}
+            inputRef={[Function]}
+            label="Select All"
+            labelPosition="end"
+            rootProps={
+              Object {
+                "className": undefined,
+              }
+            }
+            size="large"
+            type="checkbox"
+          >
+            <ThemeProvider>
+              <ThemeProvider>
+                <Choice
+                  hideLabel={true}
+                  iconChecked={<IconCheckBoxCheck />}
+                  inputRef={[Function]}
+                  label="Select All"
+                  labelPosition="end"
+                  rootProps={
+                    Object {
+                      "className": undefined,
+                    }
+                  }
+                  size="large"
+                  type="checkbox"
+                >
+                  <Choice
+                    hideLabel={true}
+                    labelPosition="end"
+                    size="large"
+                  >
+                    <label
+                      className="emotion-4"
+                    >
+                      <Styled(input)
+                        innerRef={[Function]}
+                        size="large"
+                        type="checkbox"
+                      >
+                        <input
+                          className="emotion-0"
+                          size="large"
+                          type="checkbox"
+                        />
+                      </Styled(input)>
+                      <Control
+                        size="large"
+                      >
+                        <span
+                          className="emotion-2"
+                        >
+                          <IconCheckBoxCheck>
+                            <Icon
+                              rtl={false}
+                              size="medium"
+                            >
+                              <Styled(svg)
+                                aria-hidden={true}
+                                role="img"
+                                rtl={false}
+                                size="medium"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="emotion-1"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <g>
+                                    <path
+                                      d="M8.8 14.8l-4.2-4.1L2.1 13l6.7 6.7 13-13-2.4-2.6L8.8 14.8z"
+                                    />
+                                  </g>
+                                </svg>
+                              </Styled(svg)>
+                            </Icon>
+                          </IconCheckBoxCheck>
+                        </span>
+                      </Control>
+                      <Text
+                        hideLabel={true}
+                        labelPosition="end"
+                        size="large"
+                      >
+                        <span
+                          className="emotion-3"
+                        >
+                          Select All
+                        </span>
+                      </Text>
+                    </label>
+                  </Choice>
+                </Choice>
+              </ThemeProvider>
+            </ThemeProvider>
+          </Themed(Choice)>
+        </WithTheme(Themed(Choice))>
+      </Checkbox>
     </form>
   </Styled(form)>
 </DemoForm>
@@ -4163,8 +4443,6 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -4184,6 +4462,8 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-15 {
@@ -4410,6 +4690,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4432,7 +4713,6 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4546,6 +4826,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4568,7 +4849,6 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4682,6 +4962,7 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4704,7 +4985,6 @@ exports[`Checkbox demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4868,8 +5148,6 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -4889,6 +5167,8 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-8[class] > *:not(:last-child) {
@@ -5068,6 +5348,7 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -5086,7 +5367,6 @@ exports[`Checkbox demo examples Snapshots: input-ref 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -5284,8 +5564,6 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -5305,6 +5583,8 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -5379,6 +5659,7 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -5403,7 +5684,6 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -5516,6 +5796,7 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -5538,7 +5819,6 @@ exports[`Checkbox demo examples Snapshots: invalid 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -5698,8 +5978,6 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -5719,6 +5997,8 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-5 {
@@ -5765,39 +6045,11 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
   border-color: #5691f0;
 }
 
-.emotion-8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #ffffff;
-  border-color: #c8d1e0;
-  border-radius: 0.1875em;
-  border-style: solid;
-  border-width: 1px;
-  color: #ffffff;
-  content: "";
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  height: 1em;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: 1em;
-  margin-right: 0;
-  width: 1em;
-}
-
-.emotion-8 svg {
-  fill: currentColor;
-  height: auto;
-  width: 100%;
+.emotion-9 {
+  color: #333840;
+  font-size: 0.875em;
+  margin-left: 0;
+  margin-right: 1.1428571428571428em;
 }
 
 .emotion-16 {
@@ -5943,6 +6195,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -5963,7 +6216,6 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -6082,6 +6334,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                 >
                   <Choice
                     labelPosition="start"
+                    size="large"
                   >
                     <label
                       className="emotion-10"
@@ -6102,11 +6355,10 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="start"
                         size="large"
                       >
                         <span
-                          className="emotion-8"
+                          className="emotion-2"
                         >
                           <IconCheckBoxCheck>
                             <Icon
@@ -6142,7 +6394,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         size="large"
                       >
                         <span
-                          className="emotion-3"
+                          className="emotion-9"
                         >
                           Magnetite
                         </span>
@@ -6226,6 +6478,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                   <Choice
                     justify={true}
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-16"
@@ -6246,7 +6499,6 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -6371,6 +6623,7 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                   <Choice
                     justify={true}
                     labelPosition="start"
+                    size="large"
                   >
                     <label
                       className="emotion-22"
@@ -6391,11 +6644,10 @@ exports[`Checkbox demo examples Snapshots: label-position-and-justification 1`] 
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="start"
                         size="large"
                       >
                         <span
-                          className="emotion-8"
+                          className="emotion-2"
                         >
                           <IconCheckBoxCheck>
                             <Icon
@@ -6552,8 +6804,6 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -6573,6 +6823,8 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -6639,6 +6891,7 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -6659,7 +6912,6 @@ exports[`Checkbox demo examples Snapshots: label-wrapping 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -6815,8 +7067,6 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -6836,11 +7086,15 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
 .emotion-16 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-3 {
   color: #333840;
   font-size: 0.75em;
+  margin-left: 1.3333333333333333em;
+  margin-right: 0;
 }
 
 .emotion-41 {
@@ -6867,8 +7121,6 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1.5em;
 }
 
@@ -7741,6 +7993,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="small"
                       >
                         <label
                           className="emotion-4"
@@ -7759,7 +8012,6 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="small"
                           >
                             <span
@@ -7979,6 +8231,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="medium"
                       >
                         <label
                           className="emotion-4"
@@ -7997,7 +8250,6 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="medium"
                           >
                             <span
@@ -8217,6 +8469,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -8235,7 +8488,6 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -8455,6 +8707,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="jumbo"
                       >
                         <label
                           className="emotion-4"
@@ -8473,7 +8726,6 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="jumbo"
                           >
                             <span
@@ -8748,8 +9000,6 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -8769,6 +9019,8 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -8843,6 +9095,7 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -8869,7 +9122,6 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -8982,6 +9234,7 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -9006,7 +9259,6 @@ exports[`Checkbox demo examples Snapshots: required 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -9142,7 +9394,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
   color: #ffffff;
 }
 
-.emotion-7 {
+.emotion-2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9166,12 +9418,10 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
-.emotion-7 svg {
+.emotion-2 svg {
   fill: currentColor;
   height: auto;
   width: 100%;
@@ -9184,9 +9434,11 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
   width: 1em;
 }
 
-.emotion-3 {
+.emotion-8 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-10 {
@@ -9233,39 +9485,11 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
   border-color: #5691f0;
 }
 
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #ffffff;
-  border-color: #c8d1e0;
-  border-radius: 0.1875em;
-  border-style: solid;
-  border-width: 1px;
-  color: #ffffff;
-  content: "";
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  height: 1em;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: 1em;
-  margin-right: 0;
-  width: 1em;
-}
-
-.emotion-2 svg {
-  fill: currentColor;
-  height: auto;
-  width: 100%;
+.emotion-3 {
+  color: #333840;
+  font-size: 0.875em;
+  margin-left: 0;
+  margin-right: 1.1428571428571428em;
 }
 
 .emotion-15 {
@@ -9412,6 +9636,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                       >
                         <Choice
                           labelPosition="end"
+                          size="large"
                         >
                           <label
                             className="emotion-4"
@@ -9430,7 +9655,6 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="end"
                               size="large"
                             >
                               <span
@@ -9535,6 +9759,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                       >
                         <Choice
                           labelPosition="start"
+                          size="large"
                         >
                           <label
                             className="emotion-9"
@@ -9553,11 +9778,10 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="start"
                               size="large"
                             >
                               <span
-                                className="emotion-7"
+                                className="emotion-2"
                               >
                                 <IconCheckBoxCheck>
                                   <Icon
@@ -9593,7 +9817,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               size="large"
                             >
                               <span
-                                className="emotion-3"
+                                className="emotion-8"
                               >
                                 مرحبا بالعالم
                               </span>
@@ -9673,6 +9897,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                         <Choice
                           justify={true}
                           labelPosition="end"
+                          size="large"
                         >
                           <label
                             className="emotion-15"
@@ -9691,7 +9916,6 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="end"
                               size="large"
                             >
                               <span
@@ -9802,6 +10026,7 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                         <Choice
                           justify={true}
                           labelPosition="start"
+                          size="large"
                         >
                           <label
                             className="emotion-20"
@@ -9820,11 +10045,10 @@ exports[`Checkbox demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="start"
                               size="large"
                             >
                               <span
-                                className="emotion-7"
+                                className="emotion-2"
                               >
                                 <IconCheckBoxCheck>
                                   <Icon
@@ -9984,8 +10208,6 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -10005,11 +10227,15 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
 .emotion-8 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-3 {
   color: #333840;
   font-size: 0.75em;
+  margin-left: 1.3333333333333333em;
+  margin-right: 0;
 }
 
 .emotion-17 {
@@ -10036,8 +10262,6 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1.5em;
 }
 
@@ -10111,6 +10335,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="small"
                   >
                     <label
                       className="emotion-4"
@@ -10131,7 +10356,6 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="small"
                       >
                         <span
@@ -10240,6 +10464,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="medium"
                   >
                     <label
                       className="emotion-4"
@@ -10260,7 +10485,6 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="medium"
                       >
                         <span
@@ -10373,6 +10597,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -10395,7 +10620,6 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -10504,6 +10728,7 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="jumbo"
                   >
                     <label
                       className="emotion-4"
@@ -10524,7 +10749,6 @@ exports[`Checkbox demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="jumbo"
                       >
                         <span
@@ -10684,8 +10908,6 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -10705,6 +10927,8 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -10771,6 +10995,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -10791,7 +11016,6 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -10904,6 +11128,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -10926,7 +11151,6 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -11040,6 +11264,7 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -11062,7 +11287,6 @@ exports[`Checkbox demo examples Snapshots: tri-state 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -11222,8 +11446,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -11243,6 +11465,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -11313,6 +11537,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -11335,7 +11560,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -11444,6 +11668,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -11464,7 +11689,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -11624,8 +11848,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -11645,6 +11867,8 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-15 {
@@ -11865,6 +12089,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -11887,7 +12112,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -12001,6 +12225,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -12023,7 +12248,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -12137,6 +12361,7 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -12159,7 +12384,6 @@ exports[`Checkbox demo examples Snapshots: uncontrolled 2`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span

--- a/src/library/Checkbox/__tests__/__snapshots__/CheckboxGroup.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/CheckboxGroup.spec.js.snap
@@ -130,8 +130,6 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -151,6 +149,8 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <Component>
@@ -353,6 +353,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -377,7 +378,6 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -495,6 +495,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -519,7 +520,6 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -637,6 +637,7 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -661,7 +662,6 @@ exports[`CheckboxGroup demo examples Snapshots: controlled 1`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -859,8 +859,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -880,6 +878,8 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-16 {
@@ -1078,6 +1078,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1100,7 +1101,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1214,6 +1214,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1236,7 +1237,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1350,6 +1350,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1372,7 +1373,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1561,6 +1561,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1583,7 +1584,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1697,6 +1697,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1719,7 +1720,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1833,6 +1833,7 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1855,7 +1856,6 @@ exports[`CheckboxGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -2051,8 +2051,6 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -2072,6 +2070,8 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
 .emotion-5 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-29 {
@@ -2423,6 +2423,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2446,7 +2447,6 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2564,6 +2564,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2587,7 +2588,6 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2705,6 +2705,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2728,7 +2729,6 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2846,6 +2846,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2869,7 +2870,6 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2987,6 +2987,7 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -3010,7 +3011,6 @@ exports[`CheckboxGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -3195,8 +3195,6 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -3216,6 +3214,8 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-15 {
@@ -3442,6 +3442,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -3464,7 +3465,6 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -3578,6 +3578,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -3600,7 +3601,6 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -3714,6 +3714,7 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -3736,7 +3737,6 @@ exports[`CheckboxGroup demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -3932,8 +3932,6 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -3953,6 +3951,8 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -4145,6 +4145,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4167,7 +4168,6 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4281,6 +4281,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4303,7 +4304,6 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4417,6 +4417,7 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4439,7 +4440,6 @@ exports[`CheckboxGroup demo examples Snapshots: uncontrolled 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span

--- a/src/library/Radio/Radio.js
+++ b/src/library/Radio/Radio.js
@@ -22,14 +22,14 @@ type Props = {
   defaultChecked?: boolean,
   /** Disables the radio button */
   disabled?: boolean,
-  /** Maximize the distance between the label and the control */
-  justify?: boolean,
+  /** Visually hide label, but keep available for [assistive technologies](https://webaccess.berkeley.edu/resources/assistive-technology) */
+  hideLabel?: boolean,
   /** Ref for the radio button */
   inputRef?: (node: ?React$Component<*, *>) => void,
-  /** Props to be applied directly to the root element rather than the input */
-  rootProps?: Object,
   /** Indicates that the value of the input is invalid */
   invalid?: boolean,
+  /** Maximize the distance between the label and the control */
+  justify?: boolean,
   /** Label associated with the input element */
   label: string | React$Element<*>,
   /** Determines the position of the label relative to the control */
@@ -40,6 +40,8 @@ type Props = {
   onChange?: (event: SyntheticInputEvent<>) => void,
   /** Indicates that the user must select an option before submitting a form */
   required?: boolean,
+  /** Props to be applied directly to the root element rather than the input */
+  rootProps?: Object,
   /** Available sizes */
   size?: 'small' | 'medium' | 'large' | 'jumbo',
   /** The value of the radio button */

--- a/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
@@ -102,8 +102,6 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -123,6 +121,8 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <Component>
@@ -199,6 +199,7 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -223,7 +224,6 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -342,6 +342,7 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -366,7 +367,6 @@ exports[`Radio demo examples Snapshots: controlled 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -532,8 +532,6 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -546,6 +544,8 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
 .emotion-3 {
   color: #afbacc;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -613,6 +613,7 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                   <Choice
                     disabled={true}
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -634,7 +635,6 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                       </Styled(input)>
                       <Control
                         disabled={true}
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -751,6 +751,7 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                   <Choice
                     disabled={true}
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -774,7 +775,6 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                       </Styled(input)>
                       <Control
                         disabled={true}
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -820,6 +820,288 @@ exports[`Radio demo examples Snapshots: disabled 1`] = `
                           className="emotion-3"
                         >
                           Magnetite
+                        </span>
+                      </Text>
+                    </label>
+                  </Choice>
+                </Choice>
+              </ThemeProvider>
+            </ThemeProvider>
+          </Themed(Choice)>
+        </WithTheme(Themed(Choice))>
+      </Radio>
+    </form>
+  </Styled(form)>
+</DemoForm>
+`;
+
+exports[`Radio demo examples Snapshots: hide-label 1`] = `
+.emotion-5 > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-0 {
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-0:focus + span {
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-0:checked + span,
+.emotion-0[type="checkbox"]:indeterminate + span {
+  background-color: #3272d9;
+  border-color: #3272d9;
+}
+
+.emotion-0:checked:hover + span,
+.emotion-0[type="checkbox"]:indeterminate:hover + span {
+  background-color: #5691f0;
+  border-color: #5691f0;
+}
+
+.emotion-0:checked:disabled + span,
+.emotion-0[type="checkbox"]:indeterminate:disabled + span {
+  background-color: #c8d1e0;
+  border-color: #c8d1e0;
+  color: #ffffff;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #ffffff;
+  border-color: #c8d1e0;
+  border-radius: 100%;
+  border-style: solid;
+  border-width: 1px;
+  color: #ffffff;
+  content: "";
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  height: 1em;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 1em;
+}
+
+.emotion-2 svg {
+  fill: currentColor;
+  height: auto;
+  width: 100%;
+}
+
+.emotion-1 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1em;
+  width: 1em;
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.emotion-4 *,
+.emotion-4 *::before,
+.emotion-4 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-4:hover span:first-of-type {
+  border-color: #5691f0;
+}
+
+.emotion-4::after {
+  content: '.';
+  font-size: 0.875em;
+  visibility: hidden;
+  width: 0.1px;
+}
+
+.emotion-3 {
+  color: #333840;
+  font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
+  border: 0px;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<DemoForm>
+  <Styled(form)
+    onSubmit={[Function]}
+  >
+    <form
+      className="emotion-5"
+      onSubmit={[Function]}
+    >
+      <Radio
+        hideLabel={true}
+        label="Select All"
+        labelPosition="end"
+        size="large"
+      >
+        <WithTheme(Themed(Choice))
+          hideLabel={true}
+          iconChecked={<IconRadioButtonCheck />}
+          inputRef={[Function]}
+          label="Select All"
+          labelPosition="end"
+          rootProps={
+            Object {
+              "className": undefined,
+            }
+          }
+          size="large"
+          type="radio"
+        >
+          <Themed(Choice)
+            hideLabel={true}
+            iconChecked={<IconRadioButtonCheck />}
+            inputRef={[Function]}
+            label="Select All"
+            labelPosition="end"
+            rootProps={
+              Object {
+                "className": undefined,
+              }
+            }
+            size="large"
+            type="radio"
+          >
+            <ThemeProvider>
+              <ThemeProvider>
+                <Choice
+                  hideLabel={true}
+                  iconChecked={<IconRadioButtonCheck />}
+                  inputRef={[Function]}
+                  label="Select All"
+                  labelPosition="end"
+                  rootProps={
+                    Object {
+                      "className": undefined,
+                    }
+                  }
+                  size="large"
+                  type="radio"
+                >
+                  <Choice
+                    hideLabel={true}
+                    labelPosition="end"
+                    size="large"
+                  >
+                    <label
+                      className="emotion-4"
+                    >
+                      <Styled(input)
+                        innerRef={[Function]}
+                        size="large"
+                        type="radio"
+                      >
+                        <input
+                          className="emotion-0"
+                          size="large"
+                          type="radio"
+                        />
+                      </Styled(input)>
+                      <Control
+                        size="large"
+                      >
+                        <span
+                          className="emotion-2"
+                        >
+                          <IconRadioButtonCheck>
+                            <Icon
+                              rtl={false}
+                              size="medium"
+                            >
+                              <Styled(svg)
+                                aria-hidden={true}
+                                role="img"
+                                rtl={false}
+                                size="medium"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="emotion-1"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <g>
+                                    <circle
+                                      cx="12"
+                                      cy="12"
+                                      r="3.43"
+                                    />
+                                  </g>
+                                </svg>
+                              </Styled(svg)>
+                            </Icon>
+                          </IconRadioButtonCheck>
+                        </span>
+                      </Control>
+                      <Text
+                        hideLabel={true}
+                        labelPosition="end"
+                        size="large"
+                      >
+                        <span
+                          className="emotion-3"
+                        >
+                          Select All
                         </span>
                       </Text>
                     </label>
@@ -933,8 +1215,6 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -954,6 +1234,8 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-8[class] > *:not(:last-child) {
@@ -1133,6 +1415,7 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -1151,7 +1434,6 @@ exports[`Radio demo examples Snapshots: input-ref 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -1351,8 +1633,6 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -1372,6 +1652,8 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -1446,6 +1728,7 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -1470,7 +1753,6 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -1585,6 +1867,7 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -1607,7 +1890,6 @@ exports[`Radio demo examples Snapshots: invalid 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -1769,8 +2051,6 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -1790,6 +2070,8 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-5 {
@@ -1836,39 +2118,11 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
   border-color: #5691f0;
 }
 
-.emotion-8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #ffffff;
-  border-color: #c8d1e0;
-  border-radius: 100%;
-  border-style: solid;
-  border-width: 1px;
-  color: #ffffff;
-  content: "";
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  height: 1em;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: 1em;
-  margin-right: 0;
-  width: 1em;
-}
-
-.emotion-8 svg {
-  fill: currentColor;
-  height: auto;
-  width: 100%;
+.emotion-9 {
+  color: #333840;
+  font-size: 0.875em;
+  margin-left: 0;
+  margin-right: 1.1428571428571428em;
 }
 
 .emotion-16 {
@@ -2014,6 +2268,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -2034,7 +2289,6 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -2155,6 +2409,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                 >
                   <Choice
                     labelPosition="start"
+                    size="large"
                   >
                     <label
                       className="emotion-10"
@@ -2175,11 +2430,10 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="start"
                         size="large"
                       >
                         <span
-                          className="emotion-8"
+                          className="emotion-2"
                         >
                           <IconRadioButtonCheck>
                             <Icon
@@ -2217,7 +2471,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         size="large"
                       >
                         <span
-                          className="emotion-3"
+                          className="emotion-9"
                         >
                           Magnetite
                         </span>
@@ -2301,6 +2555,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                   <Choice
                     justify={true}
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-16"
@@ -2321,7 +2576,6 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -2448,6 +2702,7 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                   <Choice
                     justify={true}
                     labelPosition="start"
+                    size="large"
                   >
                     <label
                       className="emotion-22"
@@ -2468,11 +2723,10 @@ exports[`Radio demo examples Snapshots: label-position-and-justification 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="start"
                         size="large"
                       >
                         <span
-                          className="emotion-8"
+                          className="emotion-2"
                         >
                           <IconRadioButtonCheck>
                             <Icon
@@ -2631,8 +2885,6 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -2652,6 +2904,8 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -2718,6 +2972,7 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -2738,7 +2993,6 @@ exports[`Radio demo examples Snapshots: label-wrapping 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -2896,8 +3150,6 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -2917,11 +3169,15 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
 .emotion-16 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-3 {
   color: #333840;
   font-size: 0.75em;
+  margin-left: 1.3333333333333333em;
+  margin-right: 0;
 }
 
 .emotion-41 {
@@ -2948,8 +3204,6 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1.5em;
 }
 
@@ -3822,6 +4076,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="small"
                       >
                         <label
                           className="emotion-4"
@@ -3840,7 +4095,6 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="small"
                           >
                             <span
@@ -4062,6 +4316,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="medium"
                       >
                         <label
                           className="emotion-4"
@@ -4080,7 +4335,6 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="medium"
                           >
                             <span
@@ -4302,6 +4556,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="large"
                       >
                         <label
                           className="emotion-4"
@@ -4320,7 +4575,6 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="large"
                           >
                             <span
@@ -4542,6 +4796,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     >
                       <Choice
                         labelPosition="end"
+                        size="jumbo"
                       >
                         <label
                           className="emotion-4"
@@ -4560,7 +4815,6 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             />
                           </Styled(input)>
                           <Control
-                            labelPosition="end"
                             size="jumbo"
                           >
                             <span
@@ -4837,8 +5091,6 @@ exports[`Radio demo examples Snapshots: required 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -4858,6 +5110,8 @@ exports[`Radio demo examples Snapshots: required 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -4932,6 +5186,7 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -4958,7 +5213,6 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -5073,6 +5327,7 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -5097,7 +5352,6 @@ exports[`Radio demo examples Snapshots: required 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -5235,7 +5489,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
   color: #ffffff;
 }
 
-.emotion-7 {
+.emotion-2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5259,12 +5513,10 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
-.emotion-7 svg {
+.emotion-2 svg {
   fill: currentColor;
   height: auto;
   width: 100%;
@@ -5277,9 +5529,11 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
   width: 1em;
 }
 
-.emotion-3 {
+.emotion-8 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-10 {
@@ -5326,39 +5580,11 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
   border-color: #5691f0;
 }
 
-.emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #ffffff;
-  border-color: #c8d1e0;
-  border-radius: 100%;
-  border-style: solid;
-  border-width: 1px;
-  color: #ffffff;
-  content: "";
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  height: 1em;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: 1em;
-  margin-right: 0;
-  width: 1em;
-}
-
-.emotion-2 svg {
-  fill: currentColor;
-  height: auto;
-  width: 100%;
+.emotion-3 {
+  color: #333840;
+  font-size: 0.875em;
+  margin-left: 0;
+  margin-right: 1.1428571428571428em;
 }
 
 .emotion-15 {
@@ -5505,6 +5731,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                       >
                         <Choice
                           labelPosition="end"
+                          size="large"
                         >
                           <label
                             className="emotion-4"
@@ -5523,7 +5750,6 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="end"
                               size="large"
                             >
                               <span
@@ -5630,6 +5856,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                       >
                         <Choice
                           labelPosition="start"
+                          size="large"
                         >
                           <label
                             className="emotion-9"
@@ -5648,11 +5875,10 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="start"
                               size="large"
                             >
                               <span
-                                className="emotion-7"
+                                className="emotion-2"
                               >
                                 <IconRadioButtonCheck>
                                   <Icon
@@ -5690,7 +5916,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               size="large"
                             >
                               <span
-                                className="emotion-3"
+                                className="emotion-8"
                               >
                                 مرحبا بالعالم
                               </span>
@@ -5770,6 +5996,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                         <Choice
                           justify={true}
                           labelPosition="end"
+                          size="large"
                         >
                           <label
                             className="emotion-15"
@@ -5788,7 +6015,6 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="end"
                               size="large"
                             >
                               <span
@@ -5901,6 +6127,7 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                         <Choice
                           justify={true}
                           labelPosition="start"
+                          size="large"
                         >
                           <label
                             className="emotion-20"
@@ -5919,11 +6146,10 @@ exports[`Radio demo examples Snapshots: rtl 1`] = `
                               />
                             </Styled(input)>
                             <Control
-                              labelPosition="start"
                               size="large"
                             >
                               <span
-                                className="emotion-7"
+                                className="emotion-2"
                               >
                                 <IconRadioButtonCheck>
                                   <Icon
@@ -6085,8 +6311,6 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -6106,11 +6330,15 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
 .emotion-8 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-3 {
   color: #333840;
   font-size: 0.75em;
+  margin-left: 1.3333333333333333em;
+  margin-right: 0;
 }
 
 .emotion-17 {
@@ -6137,8 +6365,6 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1.5em;
 }
 
@@ -6212,6 +6438,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="small"
                   >
                     <label
                       className="emotion-4"
@@ -6232,7 +6459,6 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="small"
                       >
                         <span
@@ -6343,6 +6569,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="medium"
                   >
                     <label
                       className="emotion-4"
@@ -6363,7 +6590,6 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="medium"
                       >
                         <span
@@ -6478,6 +6704,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -6500,7 +6727,6 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -6611,6 +6837,7 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="jumbo"
                   >
                     <label
                       className="emotion-4"
@@ -6631,7 +6858,6 @@ exports[`Radio demo examples Snapshots: sizes 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="jumbo"
                       >
                         <span
@@ -6793,8 +7019,6 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -6814,6 +7038,8 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -6884,6 +7110,7 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -6906,7 +7133,6 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span
@@ -7017,6 +7243,7 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                 >
                   <Choice
                     labelPosition="end"
+                    size="large"
                   >
                     <label
                       className="emotion-4"
@@ -7037,7 +7264,6 @@ exports[`Radio demo examples Snapshots: uncontrolled 1`] = `
                         />
                       </Styled(input)>
                       <Control
-                        labelPosition="end"
                         size="large"
                       >
                         <span

--- a/src/library/Radio/__tests__/__snapshots__/RadioGroup.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/RadioGroup.spec.js.snap
@@ -130,8 +130,6 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -151,6 +149,8 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <Component>
@@ -345,6 +345,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -369,7 +370,6 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -489,6 +489,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -513,7 +514,6 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -633,6 +633,7 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                     >
                                       <Choice
                                         labelPosition="end"
+                                        size="large"
                                       >
                                         <label
                                           className="emotion-4"
@@ -657,7 +658,6 @@ exports[`RadioGroup demo examples Snapshots: controlled 1`] = `
                                             />
                                           </Styled(input)>
                                           <Control
-                                            labelPosition="end"
                                             size="large"
                                           >
                                             <span
@@ -857,8 +857,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -878,6 +876,8 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-16 {
@@ -1068,6 +1068,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1090,7 +1091,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1206,6 +1206,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1228,7 +1229,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1344,6 +1344,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1366,7 +1367,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1549,6 +1549,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1571,7 +1572,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1687,6 +1687,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1709,7 +1710,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -1825,6 +1825,7 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -1847,7 +1848,6 @@ exports[`RadioGroup demo examples Snapshots: data-vs-children 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -2045,8 +2045,6 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -2066,6 +2064,8 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
 .emotion-5 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-24 {
@@ -2404,6 +2404,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2432,7 +2433,6 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2556,6 +2556,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2584,7 +2585,6 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2708,6 +2708,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2736,7 +2737,6 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -2860,6 +2860,7 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                         >
                                           <Choice
                                             labelPosition="end"
+                                            size="large"
                                           >
                                             <label
                                               className="emotion-6"
@@ -2888,7 +2889,6 @@ exports[`RadioGroup demo examples Snapshots: form-field 1`] = `
                                                 />
                                               </Styled(input)>
                                               <Control
-                                                labelPosition="end"
                                                 size="large"
                                               >
                                                 <span
@@ -3074,8 +3074,6 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -3095,6 +3093,8 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 .emotion-15 {
@@ -3313,6 +3313,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -3335,7 +3336,6 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -3451,6 +3451,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -3473,7 +3474,6 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -3589,6 +3589,7 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -3611,7 +3612,6 @@ exports[`RadioGroup demo examples Snapshots: inline 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -3809,8 +3809,6 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-left: 0;
-  margin-right: 1em;
   width: 1em;
 }
 
@@ -3830,6 +3828,8 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
 .emotion-3 {
   color: #333840;
   font-size: 0.875em;
+  margin-left: 1.1428571428571428em;
+  margin-right: 0;
 }
 
 <DemoForm>
@@ -4014,6 +4014,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4036,7 +4037,6 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4152,6 +4152,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4174,7 +4175,6 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span
@@ -4290,6 +4290,7 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                 >
                                   <Choice
                                     labelPosition="end"
+                                    size="large"
                                   >
                                     <label
                                       className="emotion-4"
@@ -4312,7 +4313,6 @@ exports[`RadioGroup demo examples Snapshots: uncontrolled 1`] = `
                                         />
                                       </Styled(input)>
                                       <Control
-                                        labelPosition="end"
                                         size="large"
                                       >
                                         <span

--- a/src/website/app/demos/Checkbox/examples/Checkbox/hideLabel.js
+++ b/src/website/app/demos/Checkbox/examples/Checkbox/hideLabel.js
@@ -1,0 +1,17 @@
+/* @flow */
+import DemoForm from '../../components/DemoForm';
+import Checkbox from '../../../../../../library/Checkbox';
+
+export default {
+  id: 'hide-label',
+  title: 'Visually Hidden Label',
+  description: `If the purpose of a Checkbox is obvious from context and adding
+a label would negatively affect the design, you can use \`hideLabel\` to
+visually hide the label while retaining accessibility.`,
+  scope: { DemoForm, Checkbox },
+  source: `
+    <DemoForm>
+      <Checkbox label="Select All" hideLabel />
+    </DemoForm>
+  `
+};

--- a/src/website/app/demos/Checkbox/examples/Checkbox/index.js
+++ b/src/website/app/demos/Checkbox/examples/Checkbox/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import controlled from './controlled';
 import disabled from './disabled';
+import hideLabel from './hideLabel';
 import importSyntax from './importSyntax';
 import inputRef from './inputRef';
 import invalid from './invalid';
@@ -24,6 +25,7 @@ export default [
   sizes,
   labelPositionAndJustification,
   labelWrapping,
+  hideLabel,
   inputRef,
   rtl,
   nextToOtherInputs

--- a/src/website/app/demos/Radio/examples/Radio/hideLabel.js
+++ b/src/website/app/demos/Radio/examples/Radio/hideLabel.js
@@ -1,0 +1,17 @@
+/* @flow */
+import DemoForm from '../../components/DemoForm';
+import Radio from '../../../../../../library/Radio';
+
+export default {
+  id: 'hide-label',
+  title: 'Visually Hidden Label',
+  description: `If the purpose of a Radio is obvious from context and adding
+a label would negatively affect the design, you can use \`hideLabel\` to
+visually hide the label while retaining accessibility.`,
+  scope: { DemoForm, Radio },
+  source: `
+    <DemoForm>
+      <Radio label="Select All" hideLabel />
+    </DemoForm>
+  `
+};

--- a/src/website/app/demos/Radio/examples/Radio/index.js
+++ b/src/website/app/demos/Radio/examples/Radio/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import controlled from './controlled';
 import disabled from './disabled';
+import hideLabel from './hideLabel';
 import importSyntax from './importSyntax';
 import inputRef from './inputRef';
 import invalid from './invalid';
@@ -22,6 +23,7 @@ export default [
   sizes,
   labelPositionAndJustification,
   labelWrapping,
+  hideLabel,
   inputRef,
   rtl,
   nextToOtherInputs


### PR DESCRIPTION
### Description

Adds a `hideLabel` prop to accessibly hide the label on Radios and Checkboxes

### Motivation and context

We needed this capability when developing selectable rows in the new Table component.  Agile Central needs this capability for use within their DataTable too.

### Screenshots, videos, or demo, if appropriate

https://choice-hide-label--mineral-ui.netlify.com/components/checkbox#hide-label

### How to test

1. Add the `hideLabel` prop to any of the examples in Checkbox, CheckboxGroup, Radio, RadioGroup
2. Ensure that the component size/layout does not shift
3. Try it with a screenreader and verify that the label is announced properly

### Types of changes

- New feature (non-breaking change which adds functionality)

**BREAKING CHANGES**: Rename theme variables `RadioControl_marginHorizontal`
to `RadioText_marginHorizontal` and `CheckboxControl_marginHorizontal` to
`CheckboxText_marginHorizontal`


### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - **[n/a]**" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - nope
