### PR TITLE
fix(select,textarea,textinput): Support component-level theme variables

### DIFF
--- a/src/library/Checkbox/Checkbox.js
+++ b/src/library/Checkbox/Checkbox.js
@@ -64,37 +64,32 @@ type Props = {
   value?: string
 };
 
-export const componentTheme = (baseTheme: Object) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'Choice',
-        theme: choiceComponentTheme(baseTheme)
-      },
-      {
-        name: 'Checkbox',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-};
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
+    {
+      name: 'Choice',
+      theme: choiceComponentTheme(baseTheme)
+    },
+    {
+      name: 'Checkbox',
+      theme: {}
+    },
+    baseTheme
+  );
 
-const Root = createThemedComponent(Choice, ({ theme: baseTheme }) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'Checkbox',
-        theme: componentTheme(baseTheme)
-      },
-      {
-        name: 'Choice',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-});
+const Root = createThemedComponent(Choice, ({ theme: baseTheme }) =>
+  mapComponentThemes(
+    {
+      name: 'Checkbox',
+      theme: componentTheme(baseTheme)
+    },
+    {
+      name: 'Choice',
+      theme: {}
+    },
+    baseTheme
+  )
+);
 
 // Detect if browser triggers change event when click indeterminate checkbox
 // IE/Edge/other? do not

--- a/src/library/Checkbox/CheckboxGroup.js
+++ b/src/library/Checkbox/CheckboxGroup.js
@@ -32,37 +32,32 @@ type Props = {
   rootProps?: Object
 };
 
-export const componentTheme = (baseTheme: Object) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'ChoiceGroup',
-        theme: choiceGroupComponentTheme(baseTheme)
-      },
-      {
-        name: 'CheckboxGroup',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-};
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
+    {
+      name: 'ChoiceGroup',
+      theme: choiceGroupComponentTheme(baseTheme)
+    },
+    {
+      name: 'CheckboxGroup',
+      theme: {}
+    },
+    baseTheme
+  );
 
-const Root = createThemedComponent(ChoiceGroup, ({ theme: baseTheme }) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'CheckboxGroup',
-        theme: componentTheme(baseTheme)
-      },
-      {
-        name: 'ChoiceGroup',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-});
+const Root = createThemedComponent(ChoiceGroup, ({ theme: baseTheme }) =>
+  mapComponentThemes(
+    {
+      name: 'CheckboxGroup',
+      theme: componentTheme(baseTheme)
+    },
+    {
+      name: 'ChoiceGroup',
+      theme: {}
+    },
+    baseTheme
+  )
+);
 
 /**
  * CheckboxGroup allows authors to construct a group of

--- a/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -7585,7 +7585,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   width: 1em;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #333840;
   font-size: 0.875em;
   margin-left: 1.1428571428571428em;
@@ -7599,7 +7599,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   margin-right: 0;
 }
 
-.emotion-41 {
+.emotion-47 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7626,13 +7626,13 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   width: 1.5em;
 }
 
-.emotion-41 svg {
+.emotion-47 svg {
   fill: currentColor;
   height: auto;
   width: 100%;
 }
 
-.emotion-38 {
+.emotion-44 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -7658,13 +7658,13 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-38 *,
-.emotion-38 *::before,
-.emotion-38 *::after {
+.emotion-44 *,
+.emotion-44 *::before,
+.emotion-44 *::after {
   box-sizing: inherit;
 }
 
-.emotion-38:focus {
+.emotion-44:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -7672,41 +7672,41 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-38:hover {
+.emotion-44:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-38:active {
+.emotion-44:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-38::-moz-focus-inner {
+.emotion-44::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-38 [role="img"] {
+.emotion-44 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-38 [role="img"]:first-child {
+.emotion-44 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-38 [role="img"]:last-child {
+.emotion-44 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-38 [role="img"]:only-child {
+.emotion-44 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-11 {
+.emotion-13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7724,7 +7724,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   width: 100%;
 }
 
-.emotion-36 {
+.emotion-42 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -7735,15 +7735,15 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-36:first-child {
+.emotion-42:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-36:last-child {
+.emotion-42:last-child {
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-53 > * {
+.emotion-61 > * {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7754,18 +7754,18 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   display: flex;
 }
 
-.emotion-53 > * > * {
+.emotion-61 > * > * {
   -webkit-flex: 0 0 8rem;
   -ms-flex: 0 0 8rem;
   flex: 0 0 8rem;
   margin-right: 0.5rem;
 }
 
-.emotion-52 > *:not(:last-child) {
+.emotion-60 > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-52 > * {
+.emotion-60 > * {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7776,7 +7776,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   display: flex;
 }
 
-.emotion-52 > * > * {
+.emotion-60 > * > * {
   -webkit-flex: 0 0 8rem;
   -ms-flex: 0 0 8rem;
   flex: 0 0 8rem;
@@ -7951,7 +7951,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   z-index: -1;
 }
 
-.emotion-12 {
+.emotion-14 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -7977,13 +7977,13 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12:focus {
+.emotion-14:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -7991,41 +7991,41 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-12:hover {
+.emotion-14:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-12:active {
+.emotion-14:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-12::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-12 [role="img"] {
+.emotion-14 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-12 [role="img"]:first-child {
+.emotion-14 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-12 [role="img"]:last-child {
+.emotion-14 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-12 [role="img"]:only-child {
+.emotion-14 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -8036,7 +8036,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 2em;
 }
 
-.emotion-18 {
+.emotion-20 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -8055,60 +8055,60 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-18[type="search"] {
+.emotion-20[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-18[type="search"]::-webkit-search-decoration {
+.emotion-20[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-20::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-20::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-20:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::placeholder {
+.emotion-20::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-20::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-20:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-clear {
+.emotion-20::-ms-clear {
   display: none;
 }
 
-.emotion-18:focus ~ div:last-child {
+.emotion-20:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-25 {
+.emotion-29 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -8134,13 +8134,13 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-25 *,
-.emotion-25 *::before,
-.emotion-25 *::after {
+.emotion-29 *,
+.emotion-29 *::before,
+.emotion-29 *::after {
   box-sizing: inherit;
 }
 
-.emotion-25:focus {
+.emotion-29:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -8148,41 +8148,41 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-25:hover {
+.emotion-29:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-29:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-25::-moz-focus-inner {
+.emotion-29::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-25 [role="img"] {
+.emotion-29 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-25 [role="img"]:first-child {
+.emotion-29 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-25 [role="img"]:last-child {
+.emotion-29 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-25 [role="img"]:only-child {
+.emotion-29 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-23 {
+.emotion-27 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -8193,7 +8193,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 2.2857142857142856em;
 }
 
-.emotion-31 {
+.emotion-35 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -8212,60 +8212,60 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-31[type="search"] {
+.emotion-35[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-31[type="search"]::-webkit-search-decoration {
+.emotion-35[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-31::-webkit-input-placeholder {
+.emotion-35::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::-moz-placeholder {
+.emotion-35::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31:-ms-input-placeholder {
+.emotion-35:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::placeholder {
+.emotion-35::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::-ms-input-placeholder {
+.emotion-35::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31:-ms-input-placeholder {
+.emotion-35:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::-ms-clear {
+.emotion-35::-ms-clear {
   display: none;
 }
 
-.emotion-31:focus ~ div:last-child {
+.emotion-35:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-44 {
+.emotion-50 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -8284,60 +8284,60 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-44[type="search"] {
+.emotion-50[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-44[type="search"]::-webkit-search-decoration {
+.emotion-50[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-44::-webkit-input-placeholder {
+.emotion-50::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::-moz-placeholder {
+.emotion-50::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44:-ms-input-placeholder {
+.emotion-50:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::placeholder {
+.emotion-50::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::-ms-input-placeholder {
+.emotion-50::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44:-ms-input-placeholder {
+.emotion-50:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::-ms-clear {
+.emotion-50::-ms-clear {
   display: none;
 }
 
-.emotion-44:focus ~ div:last-child {
+.emotion-50:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-51 {
+.emotion-59 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -8363,13 +8363,13 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-51 *,
-.emotion-51 *::before,
-.emotion-51 *::after {
+.emotion-59 *,
+.emotion-59 *::before,
+.emotion-59 *::after {
   box-sizing: inherit;
 }
 
-.emotion-51:focus {
+.emotion-59:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -8377,41 +8377,41 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-51:hover {
+.emotion-59:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-51:active {
+.emotion-59:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-51::-moz-focus-inner {
+.emotion-59::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-51 [role="img"] {
+.emotion-59 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-51 [role="img"]:first-child {
+.emotion-59 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-51 [role="img"]:last-child {
+.emotion-59 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-51 [role="img"]:only-child {
+.emotion-59 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-49 {
+.emotion-57 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -8422,24 +8422,24 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 3.7142857142857144em;
 }
 
-.emotion-49:first-child {
+.emotion-57:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-49:last-child {
+.emotion-57:last-child {
   padding-right: 0.5714285714285714em;
 }
 
 <Styled(DemoForm)>
   <DemoForm
-    className="emotion-53"
+    className="emotion-61"
   >
     <Styled(form)
-      className="emotion-53"
+      className="emotion-61"
       onSubmit={[Function]}
     >
       <form
-        className="emotion-52"
+        className="emotion-60"
         onSubmit={[Function]}
       >
         <div>
@@ -8611,45 +8611,85 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="small"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Small",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="small"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Small",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Small",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Small"
-                      key="control"
-                      size="small"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-5"
-                        defaultValue="Small"
                         size="small"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Small",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Small"
+                              key="control"
+                              size="small"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-5"
+                                defaultValue="Small"
+                                size="small"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -8665,18 +8705,18 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-12"
+                className="emotion-14"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="small"
                     >
                       <span
-                        className="emotion-10"
+                        className="emotion-12"
                       >
                         Small
                       </span>
@@ -8805,7 +8845,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="medium"
                           >
                             <span
-                              className="emotion-16"
+                              className="emotion-18"
                             >
                               Medium
                             </span>
@@ -8856,45 +8896,85 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="medium"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Medium",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="medium"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Medium",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Medium",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Medium"
-                      key="control"
-                      size="medium"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-18"
-                        defaultValue="Medium"
                         size="medium"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Medium",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Medium"
+                              key="control"
+                              size="medium"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-20"
+                                defaultValue="Medium"
+                                size="medium"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -8910,18 +8990,18 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-25"
+                className="emotion-29"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="medium"
                     >
                       <span
-                        className="emotion-23"
+                        className="emotion-27"
                       >
                         Medium
                       </span>
@@ -9050,7 +9130,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="large"
                           >
                             <span
-                              className="emotion-16"
+                              className="emotion-18"
                             >
                               Large
                             </span>
@@ -9101,45 +9181,85 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Large",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="large"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Large",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Large",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Large"
-                      key="control"
-                      size="large"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-31"
-                        defaultValue="Large"
                         size="large"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Large",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Large"
+                              key="control"
+                              size="large"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-35"
+                                defaultValue="Large"
+                                size="large"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -9155,18 +9275,18 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-38"
+                className="emotion-44"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-36"
+                        className="emotion-42"
                       >
                         Large
                       </span>
@@ -9257,7 +9377,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="jumbo"
                           >
                             <span
-                              className="emotion-41"
+                              className="emotion-47"
                             >
                               <IconCheckBoxCheck>
                                 <Icon
@@ -9295,7 +9415,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="jumbo"
                           >
                             <span
-                              className="emotion-16"
+                              className="emotion-18"
                             >
                               Jumbo
                             </span>
@@ -9346,45 +9466,85 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="jumbo"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Jumbo",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="jumbo"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Jumbo",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Jumbo",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Jumbo"
-                      key="control"
-                      size="jumbo"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-44"
-                        defaultValue="Jumbo"
                         size="jumbo"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Jumbo",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Jumbo"
+                              key="control"
+                              size="jumbo"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-50"
+                                defaultValue="Jumbo"
+                                size="jumbo"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -9400,18 +9560,18 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-51"
+                className="emotion-59"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="jumbo"
                     >
                       <span
-                        className="emotion-49"
+                        className="emotion-57"
                       >
                         Jumbo
                       </span>

--- a/src/library/Form/__tests__/__snapshots__/FormField.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormField.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormField demo examples Snapshots: basic 1`] = `
-.emotion-14[class] > *:not(:last-child) {
+.emotion-18[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-6 {
+.emotion-8 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -16,9 +16,9 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
+.emotion-8 *,
+.emotion-8 *::before,
+.emotion-8 *::after {
   box-sizing: inherit;
 }
 
@@ -212,7 +212,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
   z-index: -1;
 }
 
-.emotion-11 {
+.emotion-13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -225,7 +225,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -248,27 +248,27 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
   width: 100%;
 }
 
-.emotion-10 *,
-.emotion-10 *::before,
-.emotion-10 *::after {
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
   box-sizing: inherit;
 }
 
-.emotion-10:hover > div:last-child {
+.emotion-12:hover > div:last-child {
   border-color: #5691f0;
 }
 
-.emotion-10:focus > div:last-child {
+.emotion-12:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-10:active > div:last-child {
+.emotion-12:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-8 {
+.emotion-10 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -293,47 +293,47 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-8::-webkit-input-placeholder {
+.emotion-10::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::-moz-placeholder {
+.emotion-10::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8:-ms-input-placeholder {
+.emotion-10:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::placeholder {
+.emotion-10::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::-ms-input-placeholder {
+.emotion-10::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8:-ms-input-placeholder {
+.emotion-10:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::-ms-clear {
+.emotion-10::-ms-clear {
   display: none;
 }
 
-.emotion-8:focus ~ div:last-child {
+.emotion-10:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -343,7 +343,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-14"
+      className="emotion-18"
     >
       <FormField
         input={[Function]}
@@ -352,7 +352,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -406,43 +406,83 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-4"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-3"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            className="emotion-1"
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-4"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-3"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    className="emotion-1"
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -456,7 +496,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -496,8 +536,8 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                   iconEnd={null}
                   size="large"
                 >
-                  <TextInput
-                    className="emotion-11"
+                  <TextArea
+                    className="emotion-13"
                     control={[Function]}
                     controlProps={
                       Object {
@@ -518,53 +558,103 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                     iconEnd={null}
                     size="large"
                   >
-                    <FauxControl
-                      className="emotion-11"
+                    <Themed(FauxControl)
+                      className="emotion-13"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "autoSize": undefined,
+                          "controlRef": [Function],
+                          "disabled": undefined,
+                          "onInput": [Function],
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "resizeable": true,
+                          "rows": 8,
+                          "size": "large",
+                        }
+                      }
+                      iconEnd={null}
+                      size="large"
                     >
-                      <div
-                        className="emotion-10"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "autoSize": undefined,
-                              "controlRef": [Function],
-                              "disabled": undefined,
-                              "onInput": [Function],
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "resizeable": true,
-                              "rows": 8,
-                              "size": "large",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-13"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "autoSize": undefined,
+                                "controlRef": [Function],
+                                "disabled": undefined,
+                                "onInput": [Function],
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "resizeable": true,
+                                "rows": 8,
+                                "size": "large",
+                              }
                             }
-                          }
-                          controlRef={[Function]}
-                          iconEnd={null}
-                          innerRef={[Function]}
-                          key="control"
-                          onInput={[Function]}
-                          resizeable={true}
-                          rows={8}
-                          size="large"
-                        >
-                          <textarea
-                            className="emotion-8"
-                            onInput={[Function]}
-                            rows={8}
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
-                  </TextInput>
+                            iconEnd={null}
+                            size="large"
+                          >
+                            <FauxControl
+                              className="emotion-13"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-12"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "autoSize": undefined,
+                                      "controlRef": [Function],
+                                      "disabled": undefined,
+                                      "onInput": [Function],
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "resizeable": true,
+                                      "rows": 8,
+                                      "size": "large",
+                                    }
+                                  }
+                                  controlRef={[Function]}
+                                  iconEnd={null}
+                                  innerRef={[Function]}
+                                  key="control"
+                                  onInput={[Function]}
+                                  resizeable={true}
+                                  rows={8}
+                                  size="large"
+                                >
+                                  <textarea
+                                    className="emotion-10"
+                                    onInput={[Function]}
+                                    rows={8}
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
+                  </TextArea>
                 </TextArea>
               </TextArea>
             </label>
@@ -577,7 +667,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: caption 1`] = `
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -588,9 +678,9 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
@@ -784,7 +874,7 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
   z-index: -1;
 }
 
-.emotion-6 {
+.emotion-8 {
   color: #58606e;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
@@ -798,7 +888,7 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
 >
   <FormField>
     <div
-      className="emotion-7"
+      className="emotion-9"
     >
       <label>
         <Styled(div)
@@ -853,45 +943,85 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
               }
               size="large"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-4"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-describedby": "formField-11-caption",
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "text",
+                  }
+                }
+                size="large"
               >
-                <div
-                  className="emotion-3"
-                >
-                  <Control
-                    aria-describedby="formField-11-caption"
-                    controlPropsIn={
-                      Object {
-                        "aria-describedby": "formField-11-caption",
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "text",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": "formField-11-caption",
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
                       }
-                    }
-                    key="control"
-                    size="large"
-                    type="text"
-                  >
-                    <input
-                      aria-describedby="formField-11-caption"
-                      className="emotion-1"
                       size="large"
-                      type="text"
-                    />
-                  </Control>
-                  <Underlay>
-                    <div
-                      className="emotion-2"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                    >
+                      <FauxControl
+                        className="emotion-4"
+                        control={[Function]}
+                      >
+                        <div
+                          className="emotion-3"
+                        >
+                          <Control
+                            aria-describedby="formField-11-caption"
+                            controlPropsIn={
+                              Object {
+                                "aria-describedby": "formField-11-caption",
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
+                            }
+                            key="control"
+                            size="large"
+                            type="text"
+                          >
+                            <input
+                              aria-describedby="formField-11-caption"
+                              className="emotion-1"
+                              size="large"
+                              type="text"
+                            />
+                          </Control>
+                          <Underlay>
+                            <div
+                              className="emotion-2"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -901,7 +1031,7 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
         id="formField-11-caption"
       >
         <div
-          className="emotion-6"
+          className="emotion-8"
           id="formField-11-caption"
         >
           This is help text
@@ -913,11 +1043,11 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: hide-label 1`] = `
-.emotion-14[class] > *:not(:last-child) {
+.emotion-18[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-6 {
+.emotion-8 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -928,9 +1058,9 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
+.emotion-8 *,
+.emotion-8 *::before,
+.emotion-8 *::after {
   box-sizing: inherit;
 }
 
@@ -1124,7 +1254,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
   z-index: -1;
 }
 
-.emotion-7 {
+.emotion-9 {
   color: #58606e;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1151,7 +1281,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
   width: 1px;
 }
 
-.emotion-7 > * {
+.emotion-9 > * {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -1163,7 +1293,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-14"
+      className="emotion-18"
     >
       <FormField
         input={[Function]}
@@ -1173,7 +1303,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -1230,46 +1360,88 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-4"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "placeholder": "1234 Main St",
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-3"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "placeholder": "1234 Main St",
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "placeholder": "1234 Main St",
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          placeholder="1234 Main St"
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            className="emotion-1"
-                            placeholder="1234 Main St"
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-4"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-3"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "placeholder": "1234 Main St",
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  placeholder="1234 Main St"
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    className="emotion-1"
+                                    placeholder="1234 Main St"
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -1286,7 +1458,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -1294,7 +1466,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                 key="formField-26-textWrapper"
               >
                 <div
-                  className="emotion-7"
+                  className="emotion-9"
                 >
                   <span
                     id="formField-26-labelText"
@@ -1344,46 +1516,88 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-4"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "placeholder": "Apt 101",
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-3"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "placeholder": "Apt 101",
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "placeholder": "Apt 101",
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          placeholder="Apt 101"
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            className="emotion-1"
-                            placeholder="Apt 101"
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-4"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-3"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "placeholder": "Apt 101",
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  placeholder="Apt 101"
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    className="emotion-1"
+                                    placeholder="Apt 101"
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -1397,11 +1611,11 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: required 1`] = `
-.emotion-16[class] > *:not(:last-child) {
+.emotion-20[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -1412,9 +1626,9 @@ exports[`FormField demo examples Snapshots: required 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
@@ -1619,7 +1833,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-16"
+      className="emotion-20"
     >
       <FormField
         input={[Function]}
@@ -1629,7 +1843,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
       >
         <FormField>
           <div
-            className="emotion-7"
+            className="emotion-9"
           >
             <label>
               <Styled(div)
@@ -1691,47 +1905,87 @@ exports[`FormField demo examples Snapshots: required 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-5"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": true,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": true,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-4"
-                      >
-                        <Control
-                          aria-required={true}
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": true,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": true,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-5"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": true,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": true,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          required={true}
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            aria-required={true}
-                            className="emotion-2"
-                            required={true}
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-3"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-5"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-4"
+                              >
+                                <Control
+                                  aria-required={true}
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": true,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": true,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  required={true}
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    aria-required={true}
+                                    className="emotion-2"
+                                    required={true}
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-3"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -1747,7 +2001,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
       >
         <FormField>
           <div
-            className="emotion-7"
+            className="emotion-9"
           >
             <label>
               <Styled(div)
@@ -1809,47 +2063,87 @@ exports[`FormField demo examples Snapshots: required 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-5"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": true,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": true,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-4"
-                      >
-                        <Control
-                          aria-required={true}
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": true,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": true,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-5"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": true,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": true,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          required={true}
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            aria-required={true}
-                            className="emotion-2"
-                            required={true}
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-3"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-5"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-4"
+                              >
+                                <Control
+                                  aria-required={true}
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": true,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": true,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  required={true}
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    aria-required={true}
+                                    className="emotion-2"
+                                    required={true}
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-3"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -1863,7 +2157,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: rtl 1`] = `
-.emotion-8 {
+.emotion-10 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -1874,9 +2168,9 @@ exports[`FormField demo examples Snapshots: rtl 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-8 *,
-.emotion-8 *::before,
-.emotion-8 *::after {
+.emotion-10 *,
+.emotion-10 *::before,
+.emotion-10 *::after {
   box-sizing: inherit;
 }
 
@@ -2101,7 +2395,7 @@ exports[`FormField demo examples Snapshots: rtl 1`] = `
       >
         <FormField>
           <div
-            className="emotion-8"
+            className="emotion-10"
           >
             <label>
               <Styled(div)
@@ -2169,83 +2463,127 @@ exports[`FormField demo examples Snapshots: rtl 1`] = `
                     iconStart={<IconBackspace />}
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-6"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": true,
+                          "controlRef": undefined,
+                          "defaultValue": "مرحبا بالعالم",
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": true,
+                          "type": "text",
+                        }
+                      }
+                      iconStart={<IconBackspace />}
+                      size="large"
                     >
-                      <div
-                        className="emotion-5"
-                      >
-                        <IconBackspace
-                          key="iconStart"
-                          size="1.5em"
-                        >
-                          <Icon
-                            rtl={true}
-                            size="1.5em"
-                          >
-                            <Styled(svg)
-                              aria-hidden={true}
-                              focusable="false"
-                              role="img"
-                              rtl={true}
-                              size="1.5em"
-                              viewBox="0 0 24 24"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="emotion-2"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 24 24"
-                              >
-                                <g>
-                                  <path
-                                    d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
-                                  />
-                                </g>
-                              </svg>
-                            </Styled(svg)>
-                          </Icon>
-                        </IconBackspace>
-                        <Control
-                          aria-required={true}
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": true,
-                              "controlRef": undefined,
-                              "defaultValue": "مرحبا بالعالم",
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": true,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-6"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": true,
+                                "controlRef": undefined,
+                                "defaultValue": "مرحبا بالعالم",
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": true,
+                                "type": "text",
+                              }
                             }
-                          }
-                          defaultValue="مرحبا بالعالم"
-                          iconStart={<IconBackspace />}
-                          key="control"
-                          required={true}
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            aria-required={true}
-                            className="emotion-3"
-                            defaultValue="مرحبا بالعالم"
-                            required={true}
+                            iconStart={<IconBackspace />}
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-4"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-6"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-5"
+                              >
+                                <IconBackspace
+                                  key="iconStart"
+                                  size="1.5em"
+                                >
+                                  <Icon
+                                    rtl={true}
+                                    size="1.5em"
+                                  >
+                                    <Styled(svg)
+                                      aria-hidden={true}
+                                      focusable="false"
+                                      role="img"
+                                      rtl={true}
+                                      size="1.5em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="emotion-2"
+                                        focusable="false"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <g>
+                                          <path
+                                            d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </Styled(svg)>
+                                  </Icon>
+                                </IconBackspace>
+                                <Control
+                                  aria-required={true}
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": true,
+                                      "controlRef": undefined,
+                                      "defaultValue": "مرحبا بالعالم",
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": true,
+                                      "type": "text",
+                                    }
+                                  }
+                                  defaultValue="مرحبا بالعالم"
+                                  iconStart={<IconBackspace />}
+                                  key="control"
+                                  required={true}
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    aria-required={true}
+                                    className="emotion-3"
+                                    defaultValue="مرحبا بالعالم"
+                                    required={true}
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-4"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -2259,7 +2597,7 @@ exports[`FormField demo examples Snapshots: rtl 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: secondaryText 1`] = `
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -2270,9 +2608,9 @@ exports[`FormField demo examples Snapshots: secondaryText 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
@@ -2480,7 +2818,7 @@ exports[`FormField demo examples Snapshots: secondaryText 1`] = `
 >
   <FormField>
     <div
-      className="emotion-7"
+      className="emotion-9"
     >
       <label>
         <Styled(div)
@@ -2543,43 +2881,83 @@ exports[`FormField demo examples Snapshots: secondaryText 1`] = `
               }
               size="large"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-5"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-describedby": undefined,
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "text",
+                  }
+                }
+                size="large"
               >
-                <div
-                  className="emotion-4"
-                >
-                  <Control
-                    controlPropsIn={
-                      Object {
-                        "aria-describedby": undefined,
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "text",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-5"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
                       }
-                    }
-                    key="control"
-                    size="large"
-                    type="text"
-                  >
-                    <input
-                      className="emotion-2"
                       size="large"
-                      type="text"
-                    />
-                  </Control>
-                  <Underlay>
-                    <div
-                      className="emotion-3"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                    >
+                      <FauxControl
+                        className="emotion-5"
+                        control={[Function]}
+                      >
+                        <div
+                          className="emotion-4"
+                        >
+                          <Control
+                            controlPropsIn={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
+                            }
+                            key="control"
+                            size="large"
+                            type="text"
+                          >
+                            <input
+                              className="emotion-2"
+                              size="large"
+                              type="text"
+                            />
+                          </Control>
+                          <Underlay>
+                            <div
+                              className="emotion-3"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -2590,11 +2968,11 @@ exports[`FormField demo examples Snapshots: secondaryText 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: validation 1`] = `
-.emotion-11[class] > *:not(:last-child) {
+.emotion-13[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -2605,9 +2983,9 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
@@ -2807,7 +3185,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   font-weight: 400;
 }
 
-.emotion-10 {
+.emotion-12 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -2833,13 +3211,13 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   vertical-align: middle;
 }
 
-.emotion-10 *,
-.emotion-10 *::before,
-.emotion-10 *::after {
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
   box-sizing: inherit;
 }
 
-.emotion-10:focus {
+.emotion-12:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -2847,41 +3225,41 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   text-decoration: none;
 }
 
-.emotion-10:hover {
+.emotion-12:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-10:active {
+.emotion-12:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-12::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10 [role="img"] {
+.emotion-12 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-10 [role="img"]:first-child {
+.emotion-12 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-10 [role="img"]:last-child {
+.emotion-12 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-10 [role="img"]:only-child {
+.emotion-12 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-9 {
+.emotion-11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2899,7 +3277,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   width: 100%;
 }
 
-.emotion-8 {
+.emotion-10 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -2910,11 +3288,11 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-8:first-child {
+.emotion-10:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-8:last-child {
+.emotion-10:last-child {
   padding-right: 0.5714285714285714em;
 }
 
@@ -2925,7 +3303,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
         marginBottom="1rem"
       >
         <div
-          className="emotion-11"
+          className="emotion-13"
         >
           <FormField
             input={[Function]}
@@ -2938,7 +3316,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
           >
             <FormField>
               <div
-                className="emotion-7"
+                className="emotion-9"
               >
                 <label>
                   <Styled(div)
@@ -3007,55 +3385,99 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
                         }
                         size="large"
                       >
-                        <FauxControl
+                        <Themed(FauxControl)
                           className="emotion-5"
                           control={[Function]}
+                          controlProps={
+                            Object {
+                              "aria-describedby": undefined,
+                              "aria-invalid": undefined,
+                              "aria-required": true,
+                              "controlRef": [Function],
+                              "disabled": undefined,
+                              "onChange": [Function],
+                              "readOnly": undefined,
+                              "required": true,
+                              "type": "text",
+                              "value": "",
+                            }
+                          }
+                          size="large"
                         >
-                          <div
-                            className="emotion-4"
-                          >
-                            <Control
-                              aria-required={true}
-                              controlPropsIn={
-                                Object {
-                                  "aria-describedby": undefined,
-                                  "aria-invalid": undefined,
-                                  "aria-required": true,
-                                  "controlRef": [Function],
-                                  "disabled": undefined,
-                                  "onChange": [Function],
-                                  "readOnly": undefined,
-                                  "required": true,
-                                  "type": "text",
-                                  "value": "",
+                          <ThemeProvider>
+                            <ThemeProvider>
+                              <FauxControl
+                                className="emotion-5"
+                                control={[Function]}
+                                controlProps={
+                                  Object {
+                                    "aria-describedby": undefined,
+                                    "aria-invalid": undefined,
+                                    "aria-required": true,
+                                    "controlRef": [Function],
+                                    "disabled": undefined,
+                                    "onChange": [Function],
+                                    "readOnly": undefined,
+                                    "required": true,
+                                    "type": "text",
+                                    "value": "",
+                                  }
                                 }
-                              }
-                              controlRef={[Function]}
-                              innerRef={[Function]}
-                              key="control"
-                              onChange={[Function]}
-                              required={true}
-                              size="large"
-                              type="text"
-                              value=""
-                            >
-                              <input
-                                aria-required={true}
-                                className="emotion-2"
-                                onChange={[Function]}
-                                required={true}
                                 size="large"
-                                type="text"
-                                value=""
-                              />
-                            </Control>
-                            <Underlay>
-                              <div
-                                className="emotion-3"
-                              />
-                            </Underlay>
-                          </div>
-                        </FauxControl>
+                              >
+                                <FauxControl
+                                  className="emotion-5"
+                                  control={[Function]}
+                                >
+                                  <div
+                                    className="emotion-4"
+                                  >
+                                    <Control
+                                      aria-required={true}
+                                      controlPropsIn={
+                                        Object {
+                                          "aria-describedby": undefined,
+                                          "aria-invalid": undefined,
+                                          "aria-required": true,
+                                          "controlRef": [Function],
+                                          "disabled": undefined,
+                                          "onChange": [Function],
+                                          "readOnly": undefined,
+                                          "required": true,
+                                          "type": "text",
+                                          "value": "",
+                                        }
+                                      }
+                                      controlRef={[Function]}
+                                      innerRef={[Function]}
+                                      key="control"
+                                      onChange={[Function]}
+                                      required={true}
+                                      size="large"
+                                      type="text"
+                                      value=""
+                                    >
+                                      <input
+                                        aria-required={true}
+                                        className="emotion-2"
+                                        onChange={[Function]}
+                                        required={true}
+                                        size="large"
+                                        type="text"
+                                        value=""
+                                      />
+                                    </Control>
+                                    <Underlay>
+                                      <div
+                                        className="emotion-3"
+                                      />
+                                    </Underlay>
+                                  </div>
+                                </FauxControl>
+                              </FauxControl>
+                            </ThemeProvider>
+                          </ThemeProvider>
+                        </Themed(FauxControl)>
                       </TextInput>
                     </TextInput>
                   </TextInput>
@@ -3077,19 +3499,19 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
               type="button"
             >
               <button
-                className="emotion-10"
+                className="emotion-12"
                 onClick={[Function]}
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-9"
+                    className="emotion-11"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-8"
+                        className="emotion-10"
                       >
                         Validate
                       </span>
@@ -3107,11 +3529,11 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
 `;
 
 exports[`FormField demo examples Snapshots: variants 1`] = `
-.emotion-27[class] > *:not(:last-child) {
+.emotion-33[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-8 {
+.emotion-10 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3122,9 +3544,9 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-8 *,
-.emotion-8 *::before,
-.emotion-8 *::after {
+.emotion-10 *,
+.emotion-10 *::before,
+.emotion-10 *::after {
   box-sizing: inherit;
 }
 
@@ -3325,13 +3747,13 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-7 {
+.emotion-9 {
   color: #2a854e;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
 }
 
-.emotion-14 {
+.emotion-16 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3344,7 +3766,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-14 [role="img"] {
+.emotion-16 [role="img"] {
   color: #ad5f00;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -3353,11 +3775,11 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-14 [role="img"]:last-of-type {
+.emotion-16 [role="img"]:last-of-type {
   color: #ad5f00;
 }
 
-.emotion-13 {
+.emotion-15 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3380,27 +3802,27 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-13 *,
-.emotion-13 *::before,
-.emotion-13 *::after {
+.emotion-15 *,
+.emotion-15 *::before,
+.emotion-15 *::after {
   box-sizing: inherit;
 }
 
-.emotion-13:hover > div:last-child {
+.emotion-15:hover > div:last-child {
   border-color: #cf7911;
 }
 
-.emotion-13:focus > div:last-child {
+.emotion-15:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-13:active > div:last-child {
+.emotion-15:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-13 [role="img"] {
+.emotion-15 [role="img"] {
   color: #ad5f00;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -3409,11 +3831,11 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-13 [role="img"]:last-of-type {
+.emotion-15 [role="img"]:last-of-type {
   color: #ad5f00;
 }
 
-.emotion-10 {
+.emotion-12 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -3432,60 +3854,60 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-10[type="search"] {
+.emotion-12[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-10[type="search"]::-webkit-search-decoration {
+.emotion-12[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-10::-webkit-input-placeholder {
+.emotion-12::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-moz-placeholder {
+.emotion-12::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-12:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::placeholder {
+.emotion-12::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-input-placeholder {
+.emotion-12::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-12:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-clear {
+.emotion-12::-ms-clear {
   display: none;
 }
 
-.emotion-10:focus ~ div:last-child {
+.emotion-12:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-12 {
+.emotion-14 {
   background-color: #ffffff;
   border-color: #ad5f00;
   border-radius: 0.1875em;
@@ -3499,13 +3921,13 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-16 {
+.emotion-20 {
   color: #ad5f00;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
 }
 
-.emotion-23 {
+.emotion-27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3518,7 +3940,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-23 [role="img"] {
+.emotion-27 [role="img"] {
   color: #de1b1b;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -3527,11 +3949,11 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-23 [role="img"]:last-of-type {
+.emotion-27 [role="img"]:last-of-type {
   color: #de1b1b;
 }
 
-.emotion-22 {
+.emotion-26 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3554,27 +3976,27 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-22 *,
-.emotion-22 *::before,
-.emotion-22 *::after {
+.emotion-26 *,
+.emotion-26 *::before,
+.emotion-26 *::after {
   box-sizing: inherit;
 }
 
-.emotion-22:hover > div:last-child {
+.emotion-26:hover > div:last-child {
   border-color: #f55353;
 }
 
-.emotion-22:focus > div:last-child {
+.emotion-26:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-22:active > div:last-child {
+.emotion-26:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-22 [role="img"] {
+.emotion-26 [role="img"] {
   color: #de1b1b;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -3583,11 +4005,11 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-22 [role="img"]:last-of-type {
+.emotion-26 [role="img"]:last-of-type {
   color: #de1b1b;
 }
 
-.emotion-19 {
+.emotion-23 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -3606,60 +4028,60 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-19[type="search"] {
+.emotion-23[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-19[type="search"]::-webkit-search-decoration {
+.emotion-23[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-19::-webkit-input-placeholder {
+.emotion-23::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-19::-moz-placeholder {
+.emotion-23::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-19:-ms-input-placeholder {
+.emotion-23:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-19::placeholder {
+.emotion-23::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-19::-ms-input-placeholder {
+.emotion-23::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-19:-ms-input-placeholder {
+.emotion-23:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-19::-ms-clear {
+.emotion-23::-ms-clear {
   display: none;
 }
 
-.emotion-19:focus ~ div:last-child {
+.emotion-23:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-21 {
+.emotion-25 {
   background-color: #ffffff;
   border-color: #de1b1b;
   border-radius: 0.1875em;
@@ -3673,7 +4095,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-25 {
+.emotion-31 {
   color: #de1b1b;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
@@ -3684,7 +4106,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-27"
+      className="emotion-33"
     >
       <FormField
         caption="This is help text"
@@ -3695,7 +4117,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
       >
         <FormField>
           <div
-            className="emotion-8"
+            className="emotion-10"
           >
             <label>
               <Styled(div)
@@ -3753,81 +4175,123 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                     size="large"
                     variant="success"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-5"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": "formField-13-caption",
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                       variant="success"
                     >
-                      <div
-                        className="emotion-4"
-                      >
-                        <Control
-                          aria-describedby="formField-13-caption"
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": "formField-13-caption",
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-5"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": "formField-13-caption",
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="text"
-                          variant="success"
-                        >
-                          <input
-                            aria-describedby="formField-13-caption"
-                            className="emotion-1"
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <IconSuccess
-                          key="iconEnd"
-                          size="1.5em"
-                        >
-                          <Icon
-                            rtl={false}
-                            size="1.5em"
+                            variant="success"
                           >
-                            <Styled(svg)
-                              aria-hidden={true}
-                              focusable="false"
-                              role="img"
-                              rtl={false}
-                              size="1.5em"
-                              viewBox="0 0 24 24"
+                            <FauxControl
+                              className="emotion-5"
+                              control={[Function]}
+                              variant="success"
                             >
-                              <svg
-                                aria-hidden={true}
-                                className="emotion-2"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 24 24"
+                              <div
+                                className="emotion-4"
                               >
-                                <g>
-                                  <path
-                                    d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                                <Control
+                                  aria-describedby="formField-13-caption"
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": "formField-13-caption",
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="text"
+                                  variant="success"
+                                >
+                                  <input
+                                    aria-describedby="formField-13-caption"
+                                    className="emotion-1"
+                                    size="large"
+                                    type="text"
                                   />
-                                </g>
-                              </svg>
-                            </Styled(svg)>
-                          </Icon>
-                        </IconSuccess>
-                        <Underlay
-                          variant="success"
-                        >
-                          <div
-                            className="emotion-3"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                                </Control>
+                                <IconSuccess
+                                  key="iconEnd"
+                                  size="1.5em"
+                                >
+                                  <Icon
+                                    rtl={false}
+                                    size="1.5em"
+                                  >
+                                    <Styled(svg)
+                                      aria-hidden={true}
+                                      focusable="false"
+                                      role="img"
+                                      rtl={false}
+                                      size="1.5em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="emotion-2"
+                                        focusable="false"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <g>
+                                          <path
+                                            d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </Styled(svg)>
+                                  </Icon>
+                                </IconSuccess>
+                                <Underlay
+                                  variant="success"
+                                >
+                                  <div
+                                    className="emotion-3"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -3838,7 +4302,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
               variant="success"
             >
               <div
-                className="emotion-7"
+                className="emotion-9"
                 id="formField-13-caption"
               >
                 This is help text
@@ -3856,7 +4320,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
       >
         <FormField>
           <div
-            className="emotion-8"
+            className="emotion-10"
           >
             <label>
               <Styled(div)
@@ -3897,7 +4361,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                   variant="warning"
                 >
                   <TextInput
-                    className="emotion-14"
+                    className="emotion-16"
                     control={[Function]}
                     controlProps={
                       Object {
@@ -3914,81 +4378,123 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                     size="large"
                     variant="warning"
                   >
-                    <FauxControl
-                      className="emotion-14"
+                    <Themed(FauxControl)
+                      className="emotion-16"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": "formField-15-caption",
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                       variant="warning"
                     >
-                      <div
-                        className="emotion-13"
-                      >
-                        <Control
-                          aria-describedby="formField-15-caption"
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": "formField-15-caption",
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-16"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": "formField-15-caption",
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="text"
-                          variant="warning"
-                        >
-                          <input
-                            aria-describedby="formField-15-caption"
-                            className="emotion-10"
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <IconWarning
-                          key="iconEnd"
-                          size="1.5em"
-                        >
-                          <Icon
-                            rtl={false}
-                            size="1.5em"
+                            variant="warning"
                           >
-                            <Styled(svg)
-                              aria-hidden={true}
-                              focusable="false"
-                              role="img"
-                              rtl={false}
-                              size="1.5em"
-                              viewBox="0 0 24 24"
+                            <FauxControl
+                              className="emotion-16"
+                              control={[Function]}
+                              variant="warning"
                             >
-                              <svg
-                                aria-hidden={true}
-                                className="emotion-2"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 24 24"
+                              <div
+                                className="emotion-15"
                               >
-                                <g>
-                                  <path
-                                    d="M13.414 2.718l7.868 7.868c.78.78.78 2.047 0 2.828l-7.868 7.868c-.78.78-2.047.78-2.828 0l-7.868-7.868a2.001 2.001 0 0 1 0-2.828l7.868-7.868c.78-.78 2.047-.78 2.828 0zM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm1-3.958V8h-2v5.042h2z"
+                                <Control
+                                  aria-describedby="formField-15-caption"
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": "formField-15-caption",
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="text"
+                                  variant="warning"
+                                >
+                                  <input
+                                    aria-describedby="formField-15-caption"
+                                    className="emotion-12"
+                                    size="large"
+                                    type="text"
                                   />
-                                </g>
-                              </svg>
-                            </Styled(svg)>
-                          </Icon>
-                        </IconWarning>
-                        <Underlay
-                          variant="warning"
-                        >
-                          <div
-                            className="emotion-12"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                                </Control>
+                                <IconWarning
+                                  key="iconEnd"
+                                  size="1.5em"
+                                >
+                                  <Icon
+                                    rtl={false}
+                                    size="1.5em"
+                                  >
+                                    <Styled(svg)
+                                      aria-hidden={true}
+                                      focusable="false"
+                                      role="img"
+                                      rtl={false}
+                                      size="1.5em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="emotion-2"
+                                        focusable="false"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <g>
+                                          <path
+                                            d="M13.414 2.718l7.868 7.868c.78.78.78 2.047 0 2.828l-7.868 7.868c-.78.78-2.047.78-2.828 0l-7.868-7.868a2.001 2.001 0 0 1 0-2.828l7.868-7.868c.78-.78 2.047-.78 2.828 0zM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm1-3.958V8h-2v5.042h2z"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </Styled(svg)>
+                                  </Icon>
+                                </IconWarning>
+                                <Underlay
+                                  variant="warning"
+                                >
+                                  <div
+                                    className="emotion-14"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -3999,7 +4505,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
               variant="warning"
             >
               <div
-                className="emotion-16"
+                className="emotion-20"
                 id="formField-15-caption"
               >
                 This is help text
@@ -4017,7 +4523,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
       >
         <FormField>
           <div
-            className="emotion-8"
+            className="emotion-10"
           >
             <label>
               <Styled(div)
@@ -4058,7 +4564,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                   variant="danger"
                 >
                   <TextInput
-                    className="emotion-23"
+                    className="emotion-27"
                     control={[Function]}
                     controlProps={
                       Object {
@@ -4075,81 +4581,123 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                     size="large"
                     variant="danger"
                   >
-                    <FauxControl
-                      className="emotion-23"
+                    <Themed(FauxControl)
+                      className="emotion-27"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": "formField-17-caption",
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
+                      }
+                      size="large"
                       variant="danger"
                     >
-                      <div
-                        className="emotion-22"
-                      >
-                        <Control
-                          aria-describedby="formField-17-caption"
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": "formField-17-caption",
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-27"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": "formField-17-caption",
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="text"
-                          variant="danger"
-                        >
-                          <input
-                            aria-describedby="formField-17-caption"
-                            className="emotion-19"
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <IconDanger
-                          key="iconEnd"
-                          size="1.5em"
-                        >
-                          <Icon
-                            rtl={false}
-                            size="1.5em"
+                            variant="danger"
                           >
-                            <Styled(svg)
-                              aria-hidden={true}
-                              focusable="false"
-                              role="img"
-                              rtl={false}
-                              size="1.5em"
-                              viewBox="0 0 24 24"
+                            <FauxControl
+                              className="emotion-27"
+                              control={[Function]}
+                              variant="danger"
                             >
-                              <svg
-                                aria-hidden={true}
-                                className="emotion-2"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 24 24"
+                              <div
+                                className="emotion-26"
                               >
-                                <g>
-                                  <path
-                                    d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                <Control
+                                  aria-describedby="formField-17-caption"
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": "formField-17-caption",
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="text"
+                                  variant="danger"
+                                >
+                                  <input
+                                    aria-describedby="formField-17-caption"
+                                    className="emotion-23"
+                                    size="large"
+                                    type="text"
                                   />
-                                </g>
-                              </svg>
-                            </Styled(svg)>
-                          </Icon>
-                        </IconDanger>
-                        <Underlay
-                          variant="danger"
-                        >
-                          <div
-                            className="emotion-21"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                                </Control>
+                                <IconDanger
+                                  key="iconEnd"
+                                  size="1.5em"
+                                >
+                                  <Icon
+                                    rtl={false}
+                                    size="1.5em"
+                                  >
+                                    <Styled(svg)
+                                      aria-hidden={true}
+                                      focusable="false"
+                                      role="img"
+                                      rtl={false}
+                                      size="1.5em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="emotion-2"
+                                        focusable="false"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <g>
+                                          <path
+                                            d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </Styled(svg)>
+                                  </Icon>
+                                </IconDanger>
+                                <Underlay
+                                  variant="danger"
+                                >
+                                  <div
+                                    className="emotion-25"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -4160,7 +4708,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
               variant="danger"
             >
               <div
-                className="emotion-25"
+                className="emotion-31"
                 id="formField-17-caption"
               >
                 This is help text

--- a/src/library/Form/__tests__/__snapshots__/FormFieldDivider.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormFieldDivider.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
-.emotion-22[class] > *:not(:last-child) {
+.emotion-28[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-6 {
+.emotion-8 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -16,9 +16,9 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
+.emotion-8 *,
+.emotion-8 *::before,
+.emotion-8 *::after {
   box-sizing: inherit;
 }
 
@@ -212,7 +212,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
   z-index: -1;
 }
 
-.emotion-7 {
+.emotion-9 {
   background-color: #c8d1e0;
   height: 1px;
   margin: 0.5em 0;
@@ -223,7 +223,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-22"
+      className="emotion-28"
     >
       <FormField
         label="Old Password"
@@ -231,7 +231,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -285,43 +285,83 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-4"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "password",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-3"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "password",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "password",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="password"
-                        >
-                          <input
-                            className="emotion-1"
                             size="large"
-                            type="password"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-4"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-3"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "password",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="password"
+                                >
+                                  <input
+                                    className="emotion-1"
+                                    size="large"
+                                    type="password"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -334,7 +374,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
           role="separator"
         >
           <div
-            className="emotion-7"
+            className="emotion-9"
             role="separator"
           />
         </FormFieldDivider>
@@ -345,7 +385,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -399,43 +439,83 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-4"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "password",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-3"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "password",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "password",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="password"
-                        >
-                          <input
-                            className="emotion-1"
                             size="large"
-                            type="password"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-4"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-3"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "password",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="password"
+                                >
+                                  <input
+                                    className="emotion-1"
+                                    size="large"
+                                    type="password"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -449,7 +529,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
       >
         <FormField>
           <div
-            className="emotion-6"
+            className="emotion-8"
           >
             <label>
               <Styled(div)
@@ -503,43 +583,83 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                     }
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-4"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": undefined,
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "password",
+                        }
+                      }
+                      size="large"
                     >
-                      <div
-                        className="emotion-3"
-                      >
-                        <Control
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": undefined,
-                              "aria-invalid": undefined,
-                              "aria-required": undefined,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": undefined,
-                              "type": "password",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "password",
+                              }
                             }
-                          }
-                          key="control"
-                          size="large"
-                          type="password"
-                        >
-                          <input
-                            className="emotion-1"
                             size="large"
-                            type="password"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-2"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-4"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-3"
+                              >
+                                <Control
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "password",
+                                    }
+                                  }
+                                  key="control"
+                                  size="large"
+                                  type="password"
+                                >
+                                  <input
+                                    className="emotion-1"
+                                    size="large"
+                                    type="password"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-2"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>

--- a/src/library/Form/__tests__/__snapshots__/FormFieldset.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormFieldset.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormFieldset demo examples Snapshots: basic 1`] = `
-.emotion-15 {
+.emotion-19 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -15,13 +15,13 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
   padding: 0;
 }
 
-.emotion-15 *,
-.emotion-15 *::before,
-.emotion-15 *::after {
+.emotion-19 *,
+.emotion-19 *::before,
+.emotion-19 *::after {
   box-sizing: inherit;
 }
 
-.emotion-15 > legend {
+.emotion-19 > legend {
   color: #333840;
   font-size: 0.875em;
   font-weight: 700;
@@ -30,11 +30,11 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
   padding-right: 0.5em;
 }
 
-.emotion-14[class] > *:not(:last-child) {
+.emotion-18[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-6 {
+.emotion-8 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -45,9 +45,9 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
+.emotion-8 *,
+.emotion-8 *::before,
+.emotion-8 *::after {
   box-sizing: inherit;
 }
 
@@ -246,7 +246,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
 >
   <FormFieldset>
     <fieldset
-      className="emotion-15"
+      className="emotion-19"
     >
       <legend>
         Login
@@ -256,7 +256,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
           marginBottom="1rem"
         >
           <div
-            className="emotion-14"
+            className="emotion-18"
           >
             <FormField
               label="Email"
@@ -264,7 +264,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
             >
               <FormField>
                 <div
-                  className="emotion-6"
+                  className="emotion-8"
                 >
                   <label>
                     <Styled(div)
@@ -318,43 +318,83 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
                           }
                           size="large"
                         >
-                          <FauxControl
+                          <Themed(FauxControl)
                             className="emotion-4"
                             control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "email",
+                              }
+                            }
+                            size="large"
                           >
-                            <div
-                              className="emotion-3"
-                            >
-                              <Control
-                                controlPropsIn={
-                                  Object {
-                                    "aria-describedby": undefined,
-                                    "aria-invalid": undefined,
-                                    "aria-required": undefined,
-                                    "controlRef": undefined,
-                                    "disabled": undefined,
-                                    "readOnly": undefined,
-                                    "required": undefined,
-                                    "type": "email",
+                            <ThemeProvider>
+                              <ThemeProvider>
+                                <FauxControl
+                                  className="emotion-4"
+                                  control={[Function]}
+                                  controlProps={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "email",
+                                    }
                                   }
-                                }
-                                key="control"
-                                size="large"
-                                type="email"
-                              >
-                                <input
-                                  className="emotion-1"
                                   size="large"
-                                  type="email"
-                                />
-                              </Control>
-                              <Underlay>
-                                <div
-                                  className="emotion-2"
-                                />
-                              </Underlay>
-                            </div>
-                          </FauxControl>
+                                >
+                                  <FauxControl
+                                    className="emotion-4"
+                                    control={[Function]}
+                                  >
+                                    <div
+                                      className="emotion-3"
+                                    >
+                                      <Control
+                                        controlPropsIn={
+                                          Object {
+                                            "aria-describedby": undefined,
+                                            "aria-invalid": undefined,
+                                            "aria-required": undefined,
+                                            "controlRef": undefined,
+                                            "disabled": undefined,
+                                            "readOnly": undefined,
+                                            "required": undefined,
+                                            "type": "email",
+                                          }
+                                        }
+                                        key="control"
+                                        size="large"
+                                        type="email"
+                                      >
+                                        <input
+                                          className="emotion-1"
+                                          size="large"
+                                          type="email"
+                                        />
+                                      </Control>
+                                      <Underlay>
+                                        <div
+                                          className="emotion-2"
+                                        />
+                                      </Underlay>
+                                    </div>
+                                  </FauxControl>
+                                </FauxControl>
+                              </ThemeProvider>
+                            </ThemeProvider>
+                          </Themed(FauxControl)>
                         </TextInput>
                       </TextInput>
                     </TextInput>
@@ -368,7 +408,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
             >
               <FormField>
                 <div
-                  className="emotion-6"
+                  className="emotion-8"
                 >
                   <label>
                     <Styled(div)
@@ -422,43 +462,83 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
                           }
                           size="large"
                         >
-                          <FauxControl
+                          <Themed(FauxControl)
                             className="emotion-4"
                             control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "password",
+                              }
+                            }
+                            size="large"
                           >
-                            <div
-                              className="emotion-3"
-                            >
-                              <Control
-                                controlPropsIn={
-                                  Object {
-                                    "aria-describedby": undefined,
-                                    "aria-invalid": undefined,
-                                    "aria-required": undefined,
-                                    "controlRef": undefined,
-                                    "disabled": undefined,
-                                    "readOnly": undefined,
-                                    "required": undefined,
-                                    "type": "password",
+                            <ThemeProvider>
+                              <ThemeProvider>
+                                <FauxControl
+                                  className="emotion-4"
+                                  control={[Function]}
+                                  controlProps={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "password",
+                                    }
                                   }
-                                }
-                                key="control"
-                                size="large"
-                                type="password"
-                              >
-                                <input
-                                  className="emotion-1"
                                   size="large"
-                                  type="password"
-                                />
-                              </Control>
-                              <Underlay>
-                                <div
-                                  className="emotion-2"
-                                />
-                              </Underlay>
-                            </div>
-                          </FauxControl>
+                                >
+                                  <FauxControl
+                                    className="emotion-4"
+                                    control={[Function]}
+                                  >
+                                    <div
+                                      className="emotion-3"
+                                    >
+                                      <Control
+                                        controlPropsIn={
+                                          Object {
+                                            "aria-describedby": undefined,
+                                            "aria-invalid": undefined,
+                                            "aria-required": undefined,
+                                            "controlRef": undefined,
+                                            "disabled": undefined,
+                                            "readOnly": undefined,
+                                            "required": undefined,
+                                            "type": "password",
+                                          }
+                                        }
+                                        key="control"
+                                        size="large"
+                                        type="password"
+                                      >
+                                        <input
+                                          className="emotion-1"
+                                          size="large"
+                                          type="password"
+                                        />
+                                      </Control>
+                                      <Underlay>
+                                        <div
+                                          className="emotion-2"
+                                        />
+                                      </Underlay>
+                                    </div>
+                                  </FauxControl>
+                                </FauxControl>
+                              </ThemeProvider>
+                            </ThemeProvider>
+                          </Themed(FauxControl)>
                         </TextInput>
                       </TextInput>
                     </TextInput>
@@ -475,11 +555,11 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
 `;
 
 exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
-.emotion-14[class] > *:not(:last-child) {
+.emotion-18[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-6 {
+.emotion-8 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -490,9 +570,9 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
+.emotion-8 *,
+.emotion-8 *::before,
+.emotion-8 *::after {
   box-sizing: inherit;
 }
 
@@ -544,7 +624,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
   color: #c8d1e0;
 }
 
-.emotion-15 {
+.emotion-19 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -558,13 +638,13 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
   padding: 0;
 }
 
-.emotion-15 *,
-.emotion-15 *::before,
-.emotion-15 *::after {
+.emotion-19 *,
+.emotion-19 *::before,
+.emotion-19 *::after {
   box-sizing: inherit;
 }
 
-.emotion-15 > legend {
+.emotion-19 > legend {
   color: #afbacc;
   font-size: 0.875em;
   font-weight: 700;
@@ -714,7 +794,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
     disabled={true}
   >
     <fieldset
-      className="emotion-15"
+      className="emotion-19"
       disabled={true}
     >
       <legend>
@@ -725,7 +805,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
           marginBottom="1rem"
         >
           <div
-            className="emotion-14"
+            className="emotion-18"
           >
             <FormField
               label="Email"
@@ -733,7 +813,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
             >
               <FormField>
                 <div
-                  className="emotion-6"
+                  className="emotion-8"
                 >
                   <label>
                     <Styled(div)
@@ -790,48 +870,90 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
                           disabled={true}
                           size="large"
                         >
-                          <FauxControl
+                          <Themed(FauxControl)
                             className="emotion-4"
                             control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": true,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "email",
+                              }
+                            }
                             disabled={true}
+                            size="large"
                           >
-                            <div
-                              className="emotion-3"
-                            >
-                              <Control
-                                controlPropsIn={
-                                  Object {
-                                    "aria-describedby": undefined,
-                                    "aria-invalid": undefined,
-                                    "aria-required": undefined,
-                                    "controlRef": undefined,
-                                    "disabled": true,
-                                    "readOnly": undefined,
-                                    "required": undefined,
-                                    "type": "email",
+                            <ThemeProvider>
+                              <ThemeProvider>
+                                <FauxControl
+                                  className="emotion-4"
+                                  control={[Function]}
+                                  controlProps={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": true,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "email",
+                                    }
                                   }
-                                }
-                                disabled={true}
-                                key="control"
-                                size="large"
-                                type="email"
-                              >
-                                <input
-                                  className="emotion-1"
                                   disabled={true}
                                   size="large"
-                                  type="email"
-                                />
-                              </Control>
-                              <Underlay
-                                disabled={true}
-                              >
-                                <div
-                                  className="emotion-2"
-                                />
-                              </Underlay>
-                            </div>
-                          </FauxControl>
+                                >
+                                  <FauxControl
+                                    className="emotion-4"
+                                    control={[Function]}
+                                    disabled={true}
+                                  >
+                                    <div
+                                      className="emotion-3"
+                                    >
+                                      <Control
+                                        controlPropsIn={
+                                          Object {
+                                            "aria-describedby": undefined,
+                                            "aria-invalid": undefined,
+                                            "aria-required": undefined,
+                                            "controlRef": undefined,
+                                            "disabled": true,
+                                            "readOnly": undefined,
+                                            "required": undefined,
+                                            "type": "email",
+                                          }
+                                        }
+                                        disabled={true}
+                                        key="control"
+                                        size="large"
+                                        type="email"
+                                      >
+                                        <input
+                                          className="emotion-1"
+                                          disabled={true}
+                                          size="large"
+                                          type="email"
+                                        />
+                                      </Control>
+                                      <Underlay
+                                        disabled={true}
+                                      >
+                                        <div
+                                          className="emotion-2"
+                                        />
+                                      </Underlay>
+                                    </div>
+                                  </FauxControl>
+                                </FauxControl>
+                              </ThemeProvider>
+                            </ThemeProvider>
+                          </Themed(FauxControl)>
                         </TextInput>
                       </TextInput>
                     </TextInput>
@@ -845,7 +967,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
             >
               <FormField>
                 <div
-                  className="emotion-6"
+                  className="emotion-8"
                 >
                   <label>
                     <Styled(div)
@@ -902,48 +1024,90 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
                           disabled={true}
                           size="large"
                         >
-                          <FauxControl
+                          <Themed(FauxControl)
                             className="emotion-4"
                             control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": true,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "password",
+                              }
+                            }
                             disabled={true}
+                            size="large"
                           >
-                            <div
-                              className="emotion-3"
-                            >
-                              <Control
-                                controlPropsIn={
-                                  Object {
-                                    "aria-describedby": undefined,
-                                    "aria-invalid": undefined,
-                                    "aria-required": undefined,
-                                    "controlRef": undefined,
-                                    "disabled": true,
-                                    "readOnly": undefined,
-                                    "required": undefined,
-                                    "type": "password",
+                            <ThemeProvider>
+                              <ThemeProvider>
+                                <FauxControl
+                                  className="emotion-4"
+                                  control={[Function]}
+                                  controlProps={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "disabled": true,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "password",
+                                    }
                                   }
-                                }
-                                disabled={true}
-                                key="control"
-                                size="large"
-                                type="password"
-                              >
-                                <input
-                                  className="emotion-1"
                                   disabled={true}
                                   size="large"
-                                  type="password"
-                                />
-                              </Control>
-                              <Underlay
-                                disabled={true}
-                              >
-                                <div
-                                  className="emotion-2"
-                                />
-                              </Underlay>
-                            </div>
-                          </FauxControl>
+                                >
+                                  <FauxControl
+                                    className="emotion-4"
+                                    control={[Function]}
+                                    disabled={true}
+                                  >
+                                    <div
+                                      className="emotion-3"
+                                    >
+                                      <Control
+                                        controlPropsIn={
+                                          Object {
+                                            "aria-describedby": undefined,
+                                            "aria-invalid": undefined,
+                                            "aria-required": undefined,
+                                            "controlRef": undefined,
+                                            "disabled": true,
+                                            "readOnly": undefined,
+                                            "required": undefined,
+                                            "type": "password",
+                                          }
+                                        }
+                                        disabled={true}
+                                        key="control"
+                                        size="large"
+                                        type="password"
+                                      >
+                                        <input
+                                          className="emotion-1"
+                                          disabled={true}
+                                          size="large"
+                                          type="password"
+                                        />
+                                      </Control>
+                                      <Underlay
+                                        disabled={true}
+                                      >
+                                        <div
+                                          className="emotion-2"
+                                        />
+                                      </Underlay>
+                                    </div>
+                                  </FauxControl>
+                                </FauxControl>
+                              </ThemeProvider>
+                            </ThemeProvider>
+                          </Themed(FauxControl)>
                         </TextInput>
                       </TextInput>
                     </TextInput>
@@ -960,7 +1124,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
 `;
 
 exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -971,9 +1135,9 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
@@ -1095,7 +1259,7 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
   z-index: -1;
 }
 
-.emotion-8 {
+.emotion-10 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -1109,13 +1273,13 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
   padding: 0;
 }
 
-.emotion-8 *,
-.emotion-8 *::before,
-.emotion-8 *::after {
+.emotion-10 *,
+.emotion-10 *::before,
+.emotion-10 *::after {
   box-sizing: inherit;
 }
 
-.emotion-8 > legend {
+.emotion-10 > legend {
   color: #333840;
   font-size: 0.875em;
   font-weight: 700;
@@ -1216,7 +1380,7 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
       >
         <FormFieldset>
           <fieldset
-            className="emotion-8"
+            className="emotion-10"
           >
             <legend>
               أسطورة
@@ -1227,7 +1391,7 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
             >
               <FormField>
                 <div
-                  className="emotion-7"
+                  className="emotion-9"
                 >
                   <label>
                     <Styled(div)
@@ -1287,79 +1451,123 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
                           iconStart={<IconBackspace />}
                           size="large"
                         >
-                          <FauxControl
+                          <Themed(FauxControl)
                             className="emotion-5"
                             control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": undefined,
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "defaultValue": "مرحبا بالعالم",
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
+                            }
+                            iconStart={<IconBackspace />}
+                            size="large"
                           >
-                            <div
-                              className="emotion-4"
-                            >
-                              <IconBackspace
-                                key="iconStart"
-                                size="1.5em"
-                              >
-                                <Icon
-                                  rtl={true}
-                                  size="1.5em"
-                                >
-                                  <Styled(svg)
-                                    aria-hidden={true}
-                                    focusable="false"
-                                    role="img"
-                                    rtl={true}
-                                    size="1.5em"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      className="emotion-1"
-                                      focusable="false"
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <g>
-                                        <path
-                                          d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
-                                        />
-                                      </g>
-                                    </svg>
-                                  </Styled(svg)>
-                                </Icon>
-                              </IconBackspace>
-                              <Control
-                                controlPropsIn={
-                                  Object {
-                                    "aria-describedby": undefined,
-                                    "aria-invalid": undefined,
-                                    "aria-required": undefined,
-                                    "controlRef": undefined,
-                                    "defaultValue": "مرحبا بالعالم",
-                                    "disabled": undefined,
-                                    "readOnly": undefined,
-                                    "required": undefined,
-                                    "type": "text",
+                            <ThemeProvider>
+                              <ThemeProvider>
+                                <FauxControl
+                                  className="emotion-5"
+                                  control={[Function]}
+                                  controlProps={
+                                    Object {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": undefined,
+                                      "aria-required": undefined,
+                                      "controlRef": undefined,
+                                      "defaultValue": "مرحبا بالعالم",
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": undefined,
+                                      "type": "text",
+                                    }
                                   }
-                                }
-                                defaultValue="مرحبا بالعالم"
-                                iconStart={<IconBackspace />}
-                                key="control"
-                                size="large"
-                                type="text"
-                              >
-                                <input
-                                  className="emotion-2"
-                                  defaultValue="مرحبا بالعالم"
+                                  iconStart={<IconBackspace />}
                                   size="large"
-                                  type="text"
-                                />
-                              </Control>
-                              <Underlay>
-                                <div
-                                  className="emotion-3"
-                                />
-                              </Underlay>
-                            </div>
-                          </FauxControl>
+                                >
+                                  <FauxControl
+                                    className="emotion-5"
+                                    control={[Function]}
+                                  >
+                                    <div
+                                      className="emotion-4"
+                                    >
+                                      <IconBackspace
+                                        key="iconStart"
+                                        size="1.5em"
+                                      >
+                                        <Icon
+                                          rtl={true}
+                                          size="1.5em"
+                                        >
+                                          <Styled(svg)
+                                            aria-hidden={true}
+                                            focusable="false"
+                                            role="img"
+                                            rtl={true}
+                                            size="1.5em"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="emotion-1"
+                                              focusable="false"
+                                              role="img"
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <g>
+                                                <path
+                                                  d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </Styled(svg)>
+                                        </Icon>
+                                      </IconBackspace>
+                                      <Control
+                                        controlPropsIn={
+                                          Object {
+                                            "aria-describedby": undefined,
+                                            "aria-invalid": undefined,
+                                            "aria-required": undefined,
+                                            "controlRef": undefined,
+                                            "defaultValue": "مرحبا بالعالم",
+                                            "disabled": undefined,
+                                            "readOnly": undefined,
+                                            "required": undefined,
+                                            "type": "text",
+                                          }
+                                        }
+                                        defaultValue="مرحبا بالعالم"
+                                        iconStart={<IconBackspace />}
+                                        key="control"
+                                        size="large"
+                                        type="text"
+                                      >
+                                        <input
+                                          className="emotion-2"
+                                          defaultValue="مرحبا بالعالم"
+                                          size="large"
+                                          type="text"
+                                        />
+                                      </Control>
+                                      <Underlay>
+                                        <div
+                                          className="emotion-3"
+                                        />
+                                      </Underlay>
+                                    </div>
+                                  </FauxControl>
+                                </FauxControl>
+                              </ThemeProvider>
+                            </ThemeProvider>
+                          </Themed(FauxControl)>
                         </TextInput>
                       </TextInput>
                     </TextInput>

--- a/src/library/Radio/Radio.js
+++ b/src/library/Radio/Radio.js
@@ -48,39 +48,34 @@ type Props = {
   value?: string
 };
 
-export const componentTheme = (baseTheme: Object) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'Choice',
-        theme: choiceComponentTheme(baseTheme)
-      },
-      {
-        name: 'Radio',
-        theme: {
-          RadioControl_borderRadius: '100%'
-        }
-      },
-      baseTheme
-    )
-  };
-};
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
+    {
+      name: 'Choice',
+      theme: choiceComponentTheme(baseTheme)
+    },
+    {
+      name: 'Radio',
+      theme: {
+        RadioControl_borderRadius: '100%'
+      }
+    },
+    baseTheme
+  );
 
-const Root = createThemedComponent(Choice, ({ theme: baseTheme }) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'Radio',
-        theme: componentTheme(baseTheme)
-      },
-      {
-        name: 'Choice',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-});
+const Root = createThemedComponent(Choice, ({ theme: baseTheme }) =>
+  mapComponentThemes(
+    {
+      name: 'Radio',
+      theme: componentTheme(baseTheme)
+    },
+    {
+      name: 'Choice',
+      theme: {}
+    },
+    baseTheme
+  )
+);
 
 /**
  * Radio is an interactive control that can be turned on or off. Radios are most

--- a/src/library/Radio/RadioGroup.js
+++ b/src/library/Radio/RadioGroup.js
@@ -32,37 +32,32 @@ type Props = {
   rootProps?: Object
 };
 
-export const componentTheme = (baseTheme: Object) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'ChoiceGroup',
-        theme: choiceGroupComponentTheme(baseTheme)
-      },
-      {
-        name: 'RadioGroup',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-};
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
+    {
+      name: 'ChoiceGroup',
+      theme: choiceGroupComponentTheme(baseTheme)
+    },
+    {
+      name: 'RadioGroup',
+      theme: {}
+    },
+    baseTheme
+  );
 
-const Root = createThemedComponent(ChoiceGroup, ({ theme: baseTheme }) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'RadioGroup',
-        theme: componentTheme(baseTheme)
-      },
-      {
-        name: 'ChoiceGroup',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-});
+const Root = createThemedComponent(ChoiceGroup, ({ theme: baseTheme }) =>
+  mapComponentThemes(
+    {
+      name: 'RadioGroup',
+      theme: componentTheme(baseTheme)
+    },
+    {
+      name: 'ChoiceGroup',
+      theme: {}
+    },
+    baseTheme
+  )
+);
 
 /**
  * RadioGroup allows authors to construct a group of [Radios](/components/radio)

--- a/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
@@ -3192,7 +3192,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   width: 1em;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #333840;
   font-size: 0.875em;
   margin-left: 1.1428571428571428em;
@@ -3206,7 +3206,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   margin-right: 0;
 }
 
-.emotion-41 {
+.emotion-47 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3233,13 +3233,13 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   width: 1.5em;
 }
 
-.emotion-41 svg {
+.emotion-47 svg {
   fill: currentColor;
   height: auto;
   width: 100%;
 }
 
-.emotion-38 {
+.emotion-44 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3265,13 +3265,13 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-38 *,
-.emotion-38 *::before,
-.emotion-38 *::after {
+.emotion-44 *,
+.emotion-44 *::before,
+.emotion-44 *::after {
   box-sizing: inherit;
 }
 
-.emotion-38:focus {
+.emotion-44:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -3279,41 +3279,41 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-38:hover {
+.emotion-44:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-38:active {
+.emotion-44:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-38::-moz-focus-inner {
+.emotion-44::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-38 [role="img"] {
+.emotion-44 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-38 [role="img"]:first-child {
+.emotion-44 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-38 [role="img"]:last-child {
+.emotion-44 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-38 [role="img"]:only-child {
+.emotion-44 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-11 {
+.emotion-13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3331,7 +3331,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   width: 100%;
 }
 
-.emotion-36 {
+.emotion-42 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -3342,15 +3342,15 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-36:first-child {
+.emotion-42:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-36:last-child {
+.emotion-42:last-child {
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-53 > * {
+.emotion-61 > * {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3361,18 +3361,18 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   display: flex;
 }
 
-.emotion-53 > * > * {
+.emotion-61 > * > * {
   -webkit-flex: 0 0 8rem;
   -ms-flex: 0 0 8rem;
   flex: 0 0 8rem;
   margin-right: 0.5rem;
 }
 
-.emotion-52 > *:not(:last-child) {
+.emotion-60 > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-52 > * {
+.emotion-60 > * {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3383,7 +3383,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   display: flex;
 }
 
-.emotion-52 > * > * {
+.emotion-60 > * > * {
   -webkit-flex: 0 0 8rem;
   -ms-flex: 0 0 8rem;
   flex: 0 0 8rem;
@@ -3558,7 +3558,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   z-index: -1;
 }
 
-.emotion-12 {
+.emotion-14 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3584,13 +3584,13 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12:focus {
+.emotion-14:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -3598,41 +3598,41 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-12:hover {
+.emotion-14:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-12:active {
+.emotion-14:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-12::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-12 [role="img"] {
+.emotion-14 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-12 [role="img"]:first-child {
+.emotion-14 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-12 [role="img"]:last-child {
+.emotion-14 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-12 [role="img"]:only-child {
+.emotion-14 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -3643,7 +3643,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 2em;
 }
 
-.emotion-18 {
+.emotion-20 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -3662,60 +3662,60 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-18[type="search"] {
+.emotion-20[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-18[type="search"]::-webkit-search-decoration {
+.emotion-20[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-20::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-20::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-20:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::placeholder {
+.emotion-20::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-20::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-20:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-clear {
+.emotion-20::-ms-clear {
   display: none;
 }
 
-.emotion-18:focus ~ div:last-child {
+.emotion-20:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-25 {
+.emotion-29 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3741,13 +3741,13 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-25 *,
-.emotion-25 *::before,
-.emotion-25 *::after {
+.emotion-29 *,
+.emotion-29 *::before,
+.emotion-29 *::after {
   box-sizing: inherit;
 }
 
-.emotion-25:focus {
+.emotion-29:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -3755,41 +3755,41 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-25:hover {
+.emotion-29:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-29:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-25::-moz-focus-inner {
+.emotion-29::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-25 [role="img"] {
+.emotion-29 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-25 [role="img"]:first-child {
+.emotion-29 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-25 [role="img"]:last-child {
+.emotion-29 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-25 [role="img"]:only-child {
+.emotion-29 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-23 {
+.emotion-27 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -3800,7 +3800,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 2.2857142857142856em;
 }
 
-.emotion-31 {
+.emotion-35 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -3819,60 +3819,60 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-31[type="search"] {
+.emotion-35[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-31[type="search"]::-webkit-search-decoration {
+.emotion-35[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-31::-webkit-input-placeholder {
+.emotion-35::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::-moz-placeholder {
+.emotion-35::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31:-ms-input-placeholder {
+.emotion-35:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::placeholder {
+.emotion-35::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::-ms-input-placeholder {
+.emotion-35::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31:-ms-input-placeholder {
+.emotion-35:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-31::-ms-clear {
+.emotion-35::-ms-clear {
   display: none;
 }
 
-.emotion-31:focus ~ div:last-child {
+.emotion-35:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-44 {
+.emotion-50 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -3891,60 +3891,60 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-44[type="search"] {
+.emotion-50[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-44[type="search"]::-webkit-search-decoration {
+.emotion-50[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-44::-webkit-input-placeholder {
+.emotion-50::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::-moz-placeholder {
+.emotion-50::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44:-ms-input-placeholder {
+.emotion-50:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::placeholder {
+.emotion-50::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::-ms-input-placeholder {
+.emotion-50::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44:-ms-input-placeholder {
+.emotion-50:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-44::-ms-clear {
+.emotion-50::-ms-clear {
   display: none;
 }
 
-.emotion-44:focus ~ div:last-child {
+.emotion-50:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-51 {
+.emotion-59 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -3970,13 +3970,13 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   vertical-align: middle;
 }
 
-.emotion-51 *,
-.emotion-51 *::before,
-.emotion-51 *::after {
+.emotion-59 *,
+.emotion-59 *::before,
+.emotion-59 *::after {
   box-sizing: inherit;
 }
 
-.emotion-51:focus {
+.emotion-59:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -3984,41 +3984,41 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   text-decoration: none;
 }
 
-.emotion-51:hover {
+.emotion-59:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-51:active {
+.emotion-59:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-51::-moz-focus-inner {
+.emotion-59::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-51 [role="img"] {
+.emotion-59 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-51 [role="img"]:first-child {
+.emotion-59 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-51 [role="img"]:last-child {
+.emotion-59 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-51 [role="img"]:only-child {
+.emotion-59 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-49 {
+.emotion-57 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -4029,24 +4029,24 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
   line-height: 3.7142857142857144em;
 }
 
-.emotion-49:first-child {
+.emotion-57:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-49:last-child {
+.emotion-57:last-child {
   padding-right: 0.5714285714285714em;
 }
 
 <Styled(DemoForm)>
   <DemoForm
-    className="emotion-53"
+    className="emotion-61"
   >
     <Styled(form)
-      className="emotion-53"
+      className="emotion-61"
       onSubmit={[Function]}
     >
       <form
-        className="emotion-52"
+        className="emotion-60"
         onSubmit={[Function]}
       >
         <div>
@@ -4215,45 +4215,85 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="small"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Small",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="small"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Small",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Small",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Small"
-                      key="control"
-                      size="small"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-5"
-                        defaultValue="Small"
                         size="small"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Small",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Small"
+                              key="control"
+                              size="small"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-5"
+                                defaultValue="Small"
+                                size="small"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4269,18 +4309,18 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-12"
+                className="emotion-14"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="small"
                     >
                       <span
-                        className="emotion-10"
+                        className="emotion-12"
                       >
                         Small
                       </span>
@@ -4406,7 +4446,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="medium"
                           >
                             <span
-                              className="emotion-16"
+                              className="emotion-18"
                             >
                               Medium
                             </span>
@@ -4457,45 +4497,85 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="medium"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Medium",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="medium"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Medium",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Medium",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Medium"
-                      key="control"
-                      size="medium"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-18"
-                        defaultValue="Medium"
                         size="medium"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Medium",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Medium"
+                              key="control"
+                              size="medium"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-20"
+                                defaultValue="Medium"
+                                size="medium"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4511,18 +4591,18 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-25"
+                className="emotion-29"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="medium"
                     >
                       <span
-                        className="emotion-23"
+                        className="emotion-27"
                       >
                         Medium
                       </span>
@@ -4648,7 +4728,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="large"
                           >
                             <span
-                              className="emotion-16"
+                              className="emotion-18"
                             >
                               Large
                             </span>
@@ -4699,45 +4779,85 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Large",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="large"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Large",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Large",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Large"
-                      key="control"
-                      size="large"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-31"
-                        defaultValue="Large"
                         size="large"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Large",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Large"
+                              key="control"
+                              size="large"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-35"
+                                defaultValue="Large"
+                                size="large"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4753,18 +4873,18 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-38"
+                className="emotion-44"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-36"
+                        className="emotion-42"
                       >
                         Large
                       </span>
@@ -4850,7 +4970,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="jumbo"
                           >
                             <span
-                              className="emotion-41"
+                              className="emotion-47"
                             >
                               <IconRadioButtonCheck>
                                 <Icon
@@ -4890,7 +5010,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                             size="jumbo"
                           >
                             <span
-                              className="emotion-16"
+                              className="emotion-18"
                             >
                               Jumbo
                             </span>
@@ -4941,45 +5061,85 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="jumbo"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-8"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Jumbo",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="jumbo"
                 >
-                  <div
-                    className="emotion-7"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Jumbo",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-8"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Jumbo",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Jumbo"
-                      key="control"
-                      size="jumbo"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-44"
-                        defaultValue="Jumbo"
                         size="jumbo"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-6"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-8"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-7"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Jumbo",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Jumbo"
+                              key="control"
+                              size="jumbo"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-50"
+                                defaultValue="Jumbo"
+                                size="jumbo"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-6"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4995,18 +5155,18 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-51"
+                className="emotion-59"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-11"
+                    className="emotion-13"
                   >
                     <Styled(span)
                       size="jumbo"
                     >
                       <span
-                        className="emotion-49"
+                        className="emotion-57"
                       >
                         Jumbo
                       </span>

--- a/src/library/Select/Select.js
+++ b/src/library/Select/Select.js
@@ -137,8 +137,8 @@ type RenderProps = {
   props: Object
 } & StateAndHelpers;
 
-export const componentTheme = (baseTheme: Object) => ({
-  ...mapComponentThemes(
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
     {
       name: 'Dropdown',
       theme: dropdownComponentTheme(baseTheme)
@@ -151,24 +151,20 @@ export const componentTheme = (baseTheme: Object) => ({
       ...selectTriggerComponentTheme(baseTheme),
       ...baseTheme
     }
-  )
-});
+  );
 
-const ThemedDropdown = createThemedComponent(
-  Dropdown,
-  ({ theme: baseTheme }) => ({
-    ...mapComponentThemes(
-      {
-        name: 'Select',
-        theme: componentTheme(baseTheme)
-      },
-      {
-        name: 'Dropdown',
-        theme: {}
-      },
-      baseTheme
-    )
-  })
+const ThemedDropdown = createThemedComponent(Dropdown, ({ theme: baseTheme }) =>
+  mapComponentThemes(
+    {
+      name: 'Select',
+      theme: componentTheme(baseTheme)
+    },
+    {
+      name: 'Dropdown',
+      theme: {}
+    },
+    baseTheme
+  )
 );
 
 const Root = createStyledComponent(

--- a/src/library/Select/SelectTrigger.js
+++ b/src/library/Select/SelectTrigger.js
@@ -5,7 +5,7 @@ import IconDanger from '../Icon/IconDanger';
 import IconSuccess from '../Icon/IconSuccess';
 import IconWarning from '../Icon/IconWarning';
 import { createStyledComponent, getNormalizedValue, pxToEm } from '../styles';
-import { mapComponentThemes } from '../themes';
+import { createThemedComponent, mapComponentThemes } from '../themes';
 import IconArrowDropdownUp from '../Icon/IconArrowDropdownUp';
 import IconArrowDropdownDown from '../Icon/IconArrowDropdownDown';
 import FauxControl from '../FauxControl';
@@ -36,8 +36,8 @@ type Props = {
   variant?: 'success' | 'warning' | 'danger'
 };
 
-export const componentTheme = (baseTheme: Object) => ({
-  ...mapComponentThemes(
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
     {
       name: 'TextInput',
       theme: textInputComponentTheme(baseTheme)
@@ -54,8 +54,23 @@ export const componentTheme = (baseTheme: Object) => ({
       }
     },
     baseTheme
-  )
-});
+  );
+
+const ThemedFauxControl = createThemedComponent(
+  FauxControl,
+  ({ theme: baseTheme }) =>
+    mapComponentThemes(
+      {
+        name: 'Select',
+        theme: componentTheme(baseTheme)
+      },
+      {
+        name: 'FauxControl',
+        theme: {}
+      },
+      baseTheme
+    )
+);
 
 const styles = {
   root: ({
@@ -135,7 +150,7 @@ const styles = {
   }
 };
 
-const Root = createStyledComponent(FauxControl, styles.root, {
+const Root = createStyledComponent(ThemedFauxControl, styles.root, {
   displayName: 'SelectTrigger'
 });
 const Trigger = createStyledComponent('div', styles.trigger, {

--- a/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select demo examples Snapshots: controlled 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -21,17 +21,17 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -303,7 +303,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
         size="large"
       >
         <Select
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -340,7 +340,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
           size="large"
         >
           <Themed(Dropdown)
-            className="emotion-14"
+            className="emotion-16"
             data={
               Array [
                 Object {
@@ -379,7 +379,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -416,7 +416,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                   size="large"
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -440,7 +440,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-14"
+                      className="emotion-16"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -465,13 +465,13 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-5"
                         onChange={[Function]}
                         tag="span"
                       >
                         <span
-                          className="emotion-12"
+                          className="emotion-14"
                           id="select-5"
                           onChange={[Function]}
                         >
@@ -495,11 +495,11 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-5-content"
@@ -580,111 +580,181 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                         size="large"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-5-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-5-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-describedby="select-5-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-5-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                            >
-                                              <div
-                                                className="emotion-1"
+                                                aria-describedby="select-5-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-5-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Select...
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-3"
-                                                  size="1.5em"
+                                                <FauxControl
+                                                  aria-describedby="select-5-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-5-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-3"
-                                                    rtl={false}
-                                                    size="1.5em"
+                                                  <div
+                                                    aria-describedby="select-5-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-5-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-3"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-2"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-1"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Select...
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-3"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-3"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-3"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-2"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -708,15 +778,15 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: custom-item 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -728,17 +798,17 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -1021,7 +1091,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
       size="large"
     >
       <Select
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -1064,7 +1134,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
         size="large"
       >
         <Themed(Dropdown)
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -1109,7 +1179,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
           <ThemeProvider>
             <ThemeProvider>
               <Dropdown
-                className="emotion-14"
+                className="emotion-16"
                 data={
                   Array [
                     Object {
@@ -1152,7 +1222,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                 size="large"
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -1175,7 +1245,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -1199,12 +1269,12 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-97"
                       tag="span"
                     >
                       <span
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-97"
                       >
                         <PopoverTrigger
@@ -1227,11 +1297,11 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                             component="span"
                           >
                             <PopoverTrigger
-                              className="emotion-10"
+                              className="emotion-12"
                               component="span"
                             >
                               <span
-                                className="emotion-10"
+                                className="emotion-12"
                               >
                                 <SelectTrigger
                                   aria-describedby="select-97-content"
@@ -1312,111 +1382,181 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <FauxControl
+                                      <Themed(FauxControl)
+                                        afterItems={
+                                          Array [
+                                            <withProps(Styled(IconArrowDropdownDown)) />,
+                                            <input
+                                              name={undefined}
+                                              type="hidden"
+                                              value=""
+                                            />,
+                                          ]
+                                        }
                                         aria-describedby="select-97-content"
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-owns="select-97-content"
                                         className="emotion-8"
                                         control={[Function]}
-                                        innerRef={[Function]}
+                                        controlProps={
+                                          Object {
+                                            "hasPlaceholder": true,
+                                            "variant": undefined,
+                                          }
+                                        }
+                                        fauxControlRef={[Function]}
                                         onBlur={[Function]}
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         onKeyUp={[Function]}
                                         role="button"
+                                        size="large"
                                         tabIndex={0}
                                       >
-                                        <div
-                                          aria-describedby="select-97-content"
-                                          aria-expanded={false}
-                                          aria-haspopup="listbox"
-                                          aria-owns="select-97-content"
-                                          className="emotion-7"
-                                          onBlur={[Function]}
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          onKeyUp={[Function]}
-                                          role="button"
-                                          tabIndex={0}
-                                        >
-                                          <Control
-                                            controlPropsIn={
-                                              Object {
-                                                "hasPlaceholder": true,
-                                                "variant": undefined,
+                                        <ThemeProvider>
+                                          <ThemeProvider>
+                                            <FauxControl
+                                              afterItems={
+                                                Array [
+                                                  <withProps(Styled(IconArrowDropdownDown)) />,
+                                                  <input
+                                                    name={undefined}
+                                                    type="hidden"
+                                                    value=""
+                                                  />,
+                                                ]
                                               }
-                                            }
-                                            hasPlaceholder={true}
-                                            key="control"
-                                            size="large"
-                                          >
-                                            <div
-                                              className="emotion-1"
+                                              aria-describedby="select-97-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-97-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              controlProps={
+                                                Object {
+                                                  "hasPlaceholder": true,
+                                                  "variant": undefined,
+                                                }
+                                              }
+                                              fauxControlRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              size="large"
+                                              tabIndex={0}
                                             >
-                                              <TriggerContent>
-                                                <span
-                                                  className="emotion-0"
-                                                >
-                                                  Select...
-                                                </span>
-                                              </TriggerContent>
-                                            </div>
-                                          </Control>
-                                          <withProps(Styled(IconArrowDropdownDown))
-                                            key="arrow"
-                                          >
-                                            <Styled(IconArrowDropdownDown)
-                                              size="1.5em"
-                                            >
-                                              <IconArrowDropdownDown
-                                                className="emotion-3"
-                                                size="1.5em"
+                                              <FauxControl
+                                                aria-describedby="select-97-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-97-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                innerRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Icon
-                                                  className="emotion-3"
-                                                  rtl={false}
-                                                  size="1.5em"
+                                                <div
+                                                  aria-describedby="select-97-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-97-content"
+                                                  className="emotion-7"
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Styled(svg)
-                                                    aria-hidden={true}
-                                                    className="emotion-3"
-                                                    focusable="false"
-                                                    role="img"
-                                                    rtl={false}
-                                                    size="1.5em"
-                                                    viewBox="0 0 24 24"
+                                                  <Control
+                                                    controlPropsIn={
+                                                      Object {
+                                                        "hasPlaceholder": true,
+                                                        "variant": undefined,
+                                                      }
+                                                    }
+                                                    hasPlaceholder={true}
+                                                    key="control"
+                                                    size="large"
                                                   >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="emotion-2"
-                                                      focusable="false"
-                                                      role="img"
-                                                      viewBox="0 0 24 24"
+                                                    <div
+                                                      className="emotion-1"
                                                     >
-                                                      <g>
-                                                        <path
-                                                          d="M12 17.5l-8-8h16z"
-                                                        />
-                                                      </g>
-                                                    </svg>
-                                                  </Styled(svg)>
-                                                </Icon>
-                                              </IconArrowDropdownDown>
-                                            </Styled(IconArrowDropdownDown)>
-                                          </withProps(Styled(IconArrowDropdownDown))>
-                                          <input
-                                            key="input"
-                                            type="hidden"
-                                            value=""
-                                          />
-                                          <Underlay>
-                                            <div
-                                              className="emotion-6"
-                                            />
-                                          </Underlay>
-                                        </div>
-                                      </FauxControl>
+                                                      <TriggerContent>
+                                                        <span
+                                                          className="emotion-0"
+                                                        >
+                                                          Select...
+                                                        </span>
+                                                      </TriggerContent>
+                                                    </div>
+                                                  </Control>
+                                                  <withProps(Styled(IconArrowDropdownDown))
+                                                    key="arrow"
+                                                  >
+                                                    <Styled(IconArrowDropdownDown)
+                                                      size="1.5em"
+                                                    >
+                                                      <IconArrowDropdownDown
+                                                        className="emotion-3"
+                                                        size="1.5em"
+                                                      >
+                                                        <Icon
+                                                          className="emotion-3"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                        >
+                                                          <Styled(svg)
+                                                            aria-hidden={true}
+                                                            className="emotion-3"
+                                                            focusable="false"
+                                                            role="img"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="emotion-2"
+                                                              focusable="false"
+                                                              role="img"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <g>
+                                                                <path
+                                                                  d="M12 17.5l-8-8h16z"
+                                                                />
+                                                              </g>
+                                                            </svg>
+                                                          </Styled(svg)>
+                                                        </Icon>
+                                                      </IconArrowDropdownDown>
+                                                    </Styled(IconArrowDropdownDown)>
+                                                  </withProps(Styled(IconArrowDropdownDown))>
+                                                  <input
+                                                    key="input"
+                                                    type="hidden"
+                                                    value=""
+                                                  />
+                                                  <Underlay>
+                                                    <div
+                                                      className="emotion-6"
+                                                    />
+                                                  </Underlay>
+                                                </div>
+                                              </FauxControl>
+                                            </FauxControl>
+                                          </ThemeProvider>
+                                        </ThemeProvider>
+                                      </Themed(FauxControl)>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </SelectTrigger>
@@ -1439,15 +1579,15 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: custom-menu 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -1459,17 +1599,17 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -1739,7 +1879,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
       size="large"
     >
       <Select
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -1775,7 +1915,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
         size="large"
       >
         <Themed(Dropdown)
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -1813,7 +1953,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
           <ThemeProvider>
             <ThemeProvider>
               <Dropdown
-                className="emotion-14"
+                className="emotion-16"
                 data={
                   Array [
                     Object {
@@ -1849,7 +1989,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                 size="large"
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -1872,7 +2012,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -1896,12 +2036,12 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-101"
                       tag="span"
                     >
                       <span
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-101"
                       >
                         <PopoverTrigger
@@ -1924,11 +2064,11 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                             component="span"
                           >
                             <PopoverTrigger
-                              className="emotion-10"
+                              className="emotion-12"
                               component="span"
                             >
                               <span
-                                className="emotion-10"
+                                className="emotion-12"
                               >
                                 <SelectTrigger
                                   aria-describedby="select-101-content"
@@ -2009,111 +2149,181 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <FauxControl
+                                      <Themed(FauxControl)
+                                        afterItems={
+                                          Array [
+                                            <withProps(Styled(IconArrowDropdownDown)) />,
+                                            <input
+                                              name={undefined}
+                                              type="hidden"
+                                              value=""
+                                            />,
+                                          ]
+                                        }
                                         aria-describedby="select-101-content"
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-owns="select-101-content"
                                         className="emotion-8"
                                         control={[Function]}
-                                        innerRef={[Function]}
+                                        controlProps={
+                                          Object {
+                                            "hasPlaceholder": true,
+                                            "variant": undefined,
+                                          }
+                                        }
+                                        fauxControlRef={[Function]}
                                         onBlur={[Function]}
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         onKeyUp={[Function]}
                                         role="button"
+                                        size="large"
                                         tabIndex={0}
                                       >
-                                        <div
-                                          aria-describedby="select-101-content"
-                                          aria-expanded={false}
-                                          aria-haspopup="listbox"
-                                          aria-owns="select-101-content"
-                                          className="emotion-7"
-                                          onBlur={[Function]}
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          onKeyUp={[Function]}
-                                          role="button"
-                                          tabIndex={0}
-                                        >
-                                          <Control
-                                            controlPropsIn={
-                                              Object {
-                                                "hasPlaceholder": true,
-                                                "variant": undefined,
+                                        <ThemeProvider>
+                                          <ThemeProvider>
+                                            <FauxControl
+                                              afterItems={
+                                                Array [
+                                                  <withProps(Styled(IconArrowDropdownDown)) />,
+                                                  <input
+                                                    name={undefined}
+                                                    type="hidden"
+                                                    value=""
+                                                  />,
+                                                ]
                                               }
-                                            }
-                                            hasPlaceholder={true}
-                                            key="control"
-                                            size="large"
-                                          >
-                                            <div
-                                              className="emotion-1"
+                                              aria-describedby="select-101-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-101-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              controlProps={
+                                                Object {
+                                                  "hasPlaceholder": true,
+                                                  "variant": undefined,
+                                                }
+                                              }
+                                              fauxControlRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              size="large"
+                                              tabIndex={0}
                                             >
-                                              <TriggerContent>
-                                                <span
-                                                  className="emotion-0"
-                                                >
-                                                  Select...
-                                                </span>
-                                              </TriggerContent>
-                                            </div>
-                                          </Control>
-                                          <withProps(Styled(IconArrowDropdownDown))
-                                            key="arrow"
-                                          >
-                                            <Styled(IconArrowDropdownDown)
-                                              size="1.5em"
-                                            >
-                                              <IconArrowDropdownDown
-                                                className="emotion-3"
-                                                size="1.5em"
+                                              <FauxControl
+                                                aria-describedby="select-101-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-101-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                innerRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Icon
-                                                  className="emotion-3"
-                                                  rtl={false}
-                                                  size="1.5em"
+                                                <div
+                                                  aria-describedby="select-101-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-101-content"
+                                                  className="emotion-7"
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Styled(svg)
-                                                    aria-hidden={true}
-                                                    className="emotion-3"
-                                                    focusable="false"
-                                                    role="img"
-                                                    rtl={false}
-                                                    size="1.5em"
-                                                    viewBox="0 0 24 24"
+                                                  <Control
+                                                    controlPropsIn={
+                                                      Object {
+                                                        "hasPlaceholder": true,
+                                                        "variant": undefined,
+                                                      }
+                                                    }
+                                                    hasPlaceholder={true}
+                                                    key="control"
+                                                    size="large"
                                                   >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="emotion-2"
-                                                      focusable="false"
-                                                      role="img"
-                                                      viewBox="0 0 24 24"
+                                                    <div
+                                                      className="emotion-1"
                                                     >
-                                                      <g>
-                                                        <path
-                                                          d="M12 17.5l-8-8h16z"
-                                                        />
-                                                      </g>
-                                                    </svg>
-                                                  </Styled(svg)>
-                                                </Icon>
-                                              </IconArrowDropdownDown>
-                                            </Styled(IconArrowDropdownDown)>
-                                          </withProps(Styled(IconArrowDropdownDown))>
-                                          <input
-                                            key="input"
-                                            type="hidden"
-                                            value=""
-                                          />
-                                          <Underlay>
-                                            <div
-                                              className="emotion-6"
-                                            />
-                                          </Underlay>
-                                        </div>
-                                      </FauxControl>
+                                                      <TriggerContent>
+                                                        <span
+                                                          className="emotion-0"
+                                                        >
+                                                          Select...
+                                                        </span>
+                                                      </TriggerContent>
+                                                    </div>
+                                                  </Control>
+                                                  <withProps(Styled(IconArrowDropdownDown))
+                                                    key="arrow"
+                                                  >
+                                                    <Styled(IconArrowDropdownDown)
+                                                      size="1.5em"
+                                                    >
+                                                      <IconArrowDropdownDown
+                                                        className="emotion-3"
+                                                        size="1.5em"
+                                                      >
+                                                        <Icon
+                                                          className="emotion-3"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                        >
+                                                          <Styled(svg)
+                                                            aria-hidden={true}
+                                                            className="emotion-3"
+                                                            focusable="false"
+                                                            role="img"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="emotion-2"
+                                                              focusable="false"
+                                                              role="img"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <g>
+                                                                <path
+                                                                  d="M12 17.5l-8-8h16z"
+                                                                />
+                                                              </g>
+                                                            </svg>
+                                                          </Styled(svg)>
+                                                        </Icon>
+                                                      </IconArrowDropdownDown>
+                                                    </Styled(IconArrowDropdownDown)>
+                                                  </withProps(Styled(IconArrowDropdownDown))>
+                                                  <input
+                                                    key="input"
+                                                    type="hidden"
+                                                    value=""
+                                                  />
+                                                  <Underlay>
+                                                    <div
+                                                      className="emotion-6"
+                                                    />
+                                                  </Underlay>
+                                                </div>
+                                              </FauxControl>
+                                            </FauxControl>
+                                          </ThemeProvider>
+                                        </ThemeProvider>
+                                      </Themed(FauxControl)>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </SelectTrigger>
@@ -2461,15 +2671,15 @@ exports[`Select demo examples Snapshots: custom-trigger 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: data 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -2481,17 +2691,17 @@ exports[`Select demo examples Snapshots: data 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -2794,7 +3004,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
       size="large"
     >
       <Select
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -2847,7 +3057,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
         size="large"
       >
         <Themed(Dropdown)
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -2902,7 +3112,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
           <ThemeProvider>
             <ThemeProvider>
               <Dropdown
-                className="emotion-14"
+                className="emotion-16"
                 data={
                   Array [
                     Object {
@@ -2955,7 +3165,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                 size="large"
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -2978,7 +3188,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -3002,12 +3212,12 @@ exports[`Select demo examples Snapshots: data 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-9"
                       tag="span"
                     >
                       <span
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-9"
                       >
                         <PopoverTrigger
@@ -3030,11 +3240,11 @@ exports[`Select demo examples Snapshots: data 1`] = `
                             component="span"
                           >
                             <PopoverTrigger
-                              className="emotion-10"
+                              className="emotion-12"
                               component="span"
                             >
                               <span
-                                className="emotion-10"
+                                className="emotion-12"
                               >
                                 <SelectTrigger
                                   aria-describedby="select-9-content"
@@ -3115,111 +3325,181 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <FauxControl
+                                      <Themed(FauxControl)
+                                        afterItems={
+                                          Array [
+                                            <withProps(Styled(IconArrowDropdownDown)) />,
+                                            <input
+                                              name={undefined}
+                                              type="hidden"
+                                              value=""
+                                            />,
+                                          ]
+                                        }
                                         aria-describedby="select-9-content"
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-owns="select-9-content"
                                         className="emotion-8"
                                         control={[Function]}
-                                        innerRef={[Function]}
+                                        controlProps={
+                                          Object {
+                                            "hasPlaceholder": true,
+                                            "variant": undefined,
+                                          }
+                                        }
+                                        fauxControlRef={[Function]}
                                         onBlur={[Function]}
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         onKeyUp={[Function]}
                                         role="button"
+                                        size="large"
                                         tabIndex={0}
                                       >
-                                        <div
-                                          aria-describedby="select-9-content"
-                                          aria-expanded={false}
-                                          aria-haspopup="listbox"
-                                          aria-owns="select-9-content"
-                                          className="emotion-7"
-                                          onBlur={[Function]}
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          onKeyUp={[Function]}
-                                          role="button"
-                                          tabIndex={0}
-                                        >
-                                          <Control
-                                            controlPropsIn={
-                                              Object {
-                                                "hasPlaceholder": true,
-                                                "variant": undefined,
+                                        <ThemeProvider>
+                                          <ThemeProvider>
+                                            <FauxControl
+                                              afterItems={
+                                                Array [
+                                                  <withProps(Styled(IconArrowDropdownDown)) />,
+                                                  <input
+                                                    name={undefined}
+                                                    type="hidden"
+                                                    value=""
+                                                  />,
+                                                ]
                                               }
-                                            }
-                                            hasPlaceholder={true}
-                                            key="control"
-                                            size="large"
-                                          >
-                                            <div
-                                              className="emotion-1"
+                                              aria-describedby="select-9-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-9-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              controlProps={
+                                                Object {
+                                                  "hasPlaceholder": true,
+                                                  "variant": undefined,
+                                                }
+                                              }
+                                              fauxControlRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              size="large"
+                                              tabIndex={0}
                                             >
-                                              <TriggerContent>
-                                                <span
-                                                  className="emotion-0"
-                                                >
-                                                  Select...
-                                                </span>
-                                              </TriggerContent>
-                                            </div>
-                                          </Control>
-                                          <withProps(Styled(IconArrowDropdownDown))
-                                            key="arrow"
-                                          >
-                                            <Styled(IconArrowDropdownDown)
-                                              size="1.5em"
-                                            >
-                                              <IconArrowDropdownDown
-                                                className="emotion-3"
-                                                size="1.5em"
+                                              <FauxControl
+                                                aria-describedby="select-9-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-9-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                innerRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Icon
-                                                  className="emotion-3"
-                                                  rtl={false}
-                                                  size="1.5em"
+                                                <div
+                                                  aria-describedby="select-9-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-9-content"
+                                                  className="emotion-7"
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Styled(svg)
-                                                    aria-hidden={true}
-                                                    className="emotion-3"
-                                                    focusable="false"
-                                                    role="img"
-                                                    rtl={false}
-                                                    size="1.5em"
-                                                    viewBox="0 0 24 24"
+                                                  <Control
+                                                    controlPropsIn={
+                                                      Object {
+                                                        "hasPlaceholder": true,
+                                                        "variant": undefined,
+                                                      }
+                                                    }
+                                                    hasPlaceholder={true}
+                                                    key="control"
+                                                    size="large"
                                                   >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="emotion-2"
-                                                      focusable="false"
-                                                      role="img"
-                                                      viewBox="0 0 24 24"
+                                                    <div
+                                                      className="emotion-1"
                                                     >
-                                                      <g>
-                                                        <path
-                                                          d="M12 17.5l-8-8h16z"
-                                                        />
-                                                      </g>
-                                                    </svg>
-                                                  </Styled(svg)>
-                                                </Icon>
-                                              </IconArrowDropdownDown>
-                                            </Styled(IconArrowDropdownDown)>
-                                          </withProps(Styled(IconArrowDropdownDown))>
-                                          <input
-                                            key="input"
-                                            type="hidden"
-                                            value=""
-                                          />
-                                          <Underlay>
-                                            <div
-                                              className="emotion-6"
-                                            />
-                                          </Underlay>
-                                        </div>
-                                      </FauxControl>
+                                                      <TriggerContent>
+                                                        <span
+                                                          className="emotion-0"
+                                                        >
+                                                          Select...
+                                                        </span>
+                                                      </TriggerContent>
+                                                    </div>
+                                                  </Control>
+                                                  <withProps(Styled(IconArrowDropdownDown))
+                                                    key="arrow"
+                                                  >
+                                                    <Styled(IconArrowDropdownDown)
+                                                      size="1.5em"
+                                                    >
+                                                      <IconArrowDropdownDown
+                                                        className="emotion-3"
+                                                        size="1.5em"
+                                                      >
+                                                        <Icon
+                                                          className="emotion-3"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                        >
+                                                          <Styled(svg)
+                                                            aria-hidden={true}
+                                                            className="emotion-3"
+                                                            focusable="false"
+                                                            role="img"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="emotion-2"
+                                                              focusable="false"
+                                                              role="img"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <g>
+                                                                <path
+                                                                  d="M12 17.5l-8-8h16z"
+                                                                />
+                                                              </g>
+                                                            </svg>
+                                                          </Styled(svg)>
+                                                        </Icon>
+                                                      </IconArrowDropdownDown>
+                                                    </Styled(IconArrowDropdownDown)>
+                                                  </withProps(Styled(IconArrowDropdownDown))>
+                                                  <input
+                                                    key="input"
+                                                    type="hidden"
+                                                    value=""
+                                                  />
+                                                  <Underlay>
+                                                    <div
+                                                      className="emotion-6"
+                                                    />
+                                                  </Underlay>
+                                                </div>
+                                              </FauxControl>
+                                            </FauxControl>
+                                          </ThemeProvider>
+                                        </ThemeProvider>
+                                      </Themed(FauxControl)>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </SelectTrigger>
@@ -3242,15 +3522,15 @@ exports[`Select demo examples Snapshots: data 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: disabled 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -3262,17 +3542,17 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -3533,7 +3813,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
     size="large"
   >
     <Select
-      className="emotion-14"
+      className="emotion-16"
       data={
         Array [
           Object {
@@ -3570,7 +3850,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -3609,7 +3889,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -3646,7 +3926,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
               size="large"
             >
               <Popover
-                className="emotion-14"
+                className="emotion-16"
                 content={[Function]}
                 disabled={true}
                 focusTriggerOnClose={true}
@@ -3670,7 +3950,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   disabled={true}
                   focusTriggerOnClose={true}
@@ -3695,12 +3975,12 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-12"
+                    className="emotion-14"
                     id="select-17"
                     tag="span"
                   >
                     <span
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-17"
                     >
                       <PopoverTrigger
@@ -3723,11 +4003,11 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-describedby="select-17-content"
@@ -3808,7 +4088,17 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                     role="button"
                                     size="large"
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value=""
+                                          />,
+                                        ]
+                                      }
                                       aria-describedby="select-17-content"
                                       aria-disabled={true}
                                       aria-expanded={false}
@@ -3816,105 +4106,165 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                       aria-owns="select-17-content"
                                       className="emotion-8"
                                       control={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": true,
+                                          "variant": undefined,
+                                        }
+                                      }
                                       disabled={true}
-                                      innerRef={[Function]}
+                                      fauxControlRef={[Function]}
                                       onBlur={[Function]}
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
                                       role="button"
+                                      size="large"
                                     >
-                                      <div
-                                        aria-describedby="select-17-content"
-                                        aria-disabled={true}
-                                        aria-expanded={false}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-17-content"
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": true,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value=""
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          disabled={true}
-                                          hasPlaceholder={true}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-describedby="select-17-content"
+                                            aria-disabled={true}
+                                            aria-expanded={false}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-17-content"
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": true,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            disabled={true}
+                                            fauxControlRef={[Function]}
+                                            onBlur={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Select...
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownDown))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownDown)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownDown
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-describedby="select-17-content"
+                                              aria-disabled={true}
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-17-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              disabled={true}
+                                              innerRef={[Function]}
+                                              onBlur={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-describedby="select-17-content"
+                                                aria-disabled={true}
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-17-content"
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  disabled={true}
+                                                  hasPlaceholder={true}
+                                                  key="control"
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 17.5l-8-8h16z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownDown>
-                                          </Styled(IconArrowDropdownDown)>
-                                        </withProps(Styled(IconArrowDropdownDown))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value=""
-                                        />
-                                        <Underlay
-                                          disabled={true}
-                                        >
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Select...
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownDown))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownDown)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownDown
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 17.5l-8-8h16z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownDown>
+                                                  </Styled(IconArrowDropdownDown)>
+                                                </withProps(Styled(IconArrowDropdownDown))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value=""
+                                                />
+                                                <Underlay
+                                                  disabled={true}
+                                                >
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -3936,15 +4286,15 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: form-field 1`] = `
+.emotion-18 {
+  width: 100%;
+}
+
+.emotion-18 > span {
+  width: 100%;
+}
+
 .emotion-16 {
-  width: 100%;
-}
-
-.emotion-16 > span {
-  width: 100%;
-}
-
-.emotion-14 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -3956,17 +4306,17 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
   width: 100%;
 }
 
-.emotion-14 *,
-.emotion-14 *::before,
-.emotion-14 *::after {
+.emotion-16 *,
+.emotion-16 *::before,
+.emotion-16 *::after {
   box-sizing: inherit;
 }
 
-.emotion-14 > span {
+.emotion-16 > span {
   width: 100%;
 }
 
-.emotion-12 {
+.emotion-14 {
   display: inline-block;
 }
 
@@ -4176,11 +4526,11 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-23[class] > *:not(:last-child) {
+.emotion-25[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-22 {
+.emotion-24 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -4191,9 +4541,9 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-22 *,
-.emotion-22 *::before,
-.emotion-22 *::after {
+.emotion-24 *,
+.emotion-24 *::before,
+.emotion-24 *::after {
   box-sizing: inherit;
 }
 
@@ -4225,7 +4575,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
   font-weight: 400;
 }
 
-.emotion-21 {
+.emotion-23 {
   color: #58606e;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
@@ -4233,7 +4583,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
 
 <Styled(div)>
   <div
-    className="emotion-23"
+    className="emotion-25"
   >
     <FormField
       caption="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
@@ -4450,7 +4800,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
     >
       <FormField>
         <div
-          className="emotion-22"
+          className="emotion-24"
         >
           <label>
             <Styled(div)
@@ -4915,7 +5265,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
               >
                 <Select
                   aria-describedby="formField-107-caption"
-                  className="emotion-16"
+                  className="emotion-18"
                   data={
                     Array [
                       Object {
@@ -5142,7 +5492,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                 >
                   <Themed(Dropdown)
                     aria-describedby="formField-107-caption"
-                    className="emotion-16"
+                    className="emotion-18"
                     data={
                       Array [
                         Object {
@@ -5371,7 +5721,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                       <ThemeProvider>
                         <Dropdown
                           aria-describedby="formField-107-caption"
-                          className="emotion-16"
+                          className="emotion-18"
                           data={
                             Array [
                               Object {
@@ -5598,7 +5948,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                         >
                           <Popover
                             aria-describedby="formField-107-caption"
-                            className="emotion-16"
+                            className="emotion-18"
                             content={[Function]}
                             focusTriggerOnClose={true}
                             hasArrow={true}
@@ -5624,7 +5974,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                           >
                             <Popover
                               aria-describedby="formField-107-caption"
-                              className="emotion-16"
+                              className="emotion-18"
                               content={[Function]}
                               focusTriggerOnClose={true}
                               hasArrow={true}
@@ -5651,13 +6001,13 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                             >
                               <Popover
                                 aria-describedby="formField-107-caption"
-                                className="emotion-14"
+                                className="emotion-16"
                                 id="select-108"
                                 tag="span"
                               >
                                 <span
                                   aria-describedby="formField-107-caption"
-                                  className="emotion-14"
+                                  className="emotion-16"
                                   id="select-108"
                                 >
                                   <PopoverTrigger
@@ -5682,11 +6032,11 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                       component="span"
                                     >
                                       <PopoverTrigger
-                                        className="emotion-12"
+                                        className="emotion-14"
                                         component="span"
                                       >
                                         <span
-                                          className="emotion-12"
+                                          className="emotion-14"
                                         >
                                           <SelectTrigger
                                             aria-describedby="select-108-content"
@@ -5771,7 +6121,17 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                 size="large"
                                                 tabIndex={0}
                                               >
-                                                <FauxControl
+                                                <Themed(FauxControl)
+                                                  afterItems={
+                                                    Array [
+                                                      <withProps(Styled(IconArrowDropdownDown)) />,
+                                                      <input
+                                                        name="state"
+                                                        type="hidden"
+                                                        value=""
+                                                      />,
+                                                    ]
+                                                  }
                                                   aria-describedby="select-108-content"
                                                   aria-expanded={false}
                                                   aria-haspopup="listbox"
@@ -5779,106 +6139,168 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                   aria-required={true}
                                                   className="emotion-10"
                                                   control={[Function]}
-                                                  innerRef={[Function]}
+                                                  controlProps={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  fauxControlRef={[Function]}
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
                                                   onKeyUp={[Function]}
                                                   role="button"
+                                                  size="large"
                                                   tabIndex={0}
                                                 >
-                                                  <div
-                                                    aria-describedby="select-108-content"
-                                                    aria-expanded={false}
-                                                    aria-haspopup="listbox"
-                                                    aria-owns="select-108-content"
-                                                    aria-required={true}
-                                                    className="emotion-9"
-                                                    onBlur={[Function]}
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onKeyUp={[Function]}
-                                                    role="button"
-                                                    tabIndex={0}
-                                                  >
-                                                    <Control
-                                                      controlPropsIn={
-                                                        Object {
-                                                          "hasPlaceholder": true,
-                                                          "variant": undefined,
+                                                  <ThemeProvider>
+                                                    <ThemeProvider>
+                                                      <FauxControl
+                                                        afterItems={
+                                                          Array [
+                                                            <withProps(Styled(IconArrowDropdownDown)) />,
+                                                            <input
+                                                              name="state"
+                                                              type="hidden"
+                                                              value=""
+                                                            />,
+                                                          ]
                                                         }
-                                                      }
-                                                      hasPlaceholder={true}
-                                                      key="control"
-                                                      size="large"
-                                                    >
-                                                      <div
-                                                        className="emotion-3"
+                                                        aria-describedby="select-108-content"
+                                                        aria-expanded={false}
+                                                        aria-haspopup="listbox"
+                                                        aria-owns="select-108-content"
+                                                        aria-required={true}
+                                                        className="emotion-10"
+                                                        control={[Function]}
+                                                        controlProps={
+                                                          Object {
+                                                            "hasPlaceholder": true,
+                                                            "variant": undefined,
+                                                          }
+                                                        }
+                                                        fauxControlRef={[Function]}
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        role="button"
+                                                        size="large"
+                                                        tabIndex={0}
                                                       >
-                                                        <TriggerContent>
-                                                          <span
-                                                            className="emotion-2"
-                                                          >
-                                                            Choose a state...
-                                                          </span>
-                                                        </TriggerContent>
-                                                      </div>
-                                                    </Control>
-                                                    <withProps(Styled(IconArrowDropdownDown))
-                                                      key="arrow"
-                                                    >
-                                                      <Styled(IconArrowDropdownDown)
-                                                        size="1.5em"
-                                                      >
-                                                        <IconArrowDropdownDown
-                                                          className="emotion-5"
-                                                          size="1.5em"
+                                                        <FauxControl
+                                                          aria-describedby="select-108-content"
+                                                          aria-expanded={false}
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="select-108-content"
+                                                          aria-required={true}
+                                                          className="emotion-10"
+                                                          control={[Function]}
+                                                          innerRef={[Function]}
+                                                          onBlur={[Function]}
+                                                          onClick={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          role="button"
+                                                          tabIndex={0}
                                                         >
-                                                          <Icon
-                                                            className="emotion-5"
-                                                            rtl={false}
-                                                            size="1.5em"
+                                                          <div
+                                                            aria-describedby="select-108-content"
+                                                            aria-expanded={false}
+                                                            aria-haspopup="listbox"
+                                                            aria-owns="select-108-content"
+                                                            aria-required={true}
+                                                            className="emotion-9"
+                                                            onBlur={[Function]}
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            onKeyUp={[Function]}
+                                                            role="button"
+                                                            tabIndex={0}
                                                           >
-                                                            <Styled(svg)
-                                                              aria-hidden={true}
-                                                              className="emotion-5"
-                                                              focusable="false"
-                                                              role="img"
-                                                              rtl={false}
-                                                              size="1.5em"
-                                                              viewBox="0 0 24 24"
+                                                            <Control
+                                                              controlPropsIn={
+                                                                Object {
+                                                                  "hasPlaceholder": true,
+                                                                  "variant": undefined,
+                                                                }
+                                                              }
+                                                              hasPlaceholder={true}
+                                                              key="control"
+                                                              size="large"
                                                             >
-                                                              <svg
-                                                                aria-hidden={true}
-                                                                className="emotion-4"
-                                                                focusable="false"
-                                                                role="img"
-                                                                viewBox="0 0 24 24"
+                                                              <div
+                                                                className="emotion-3"
                                                               >
-                                                                <g>
-                                                                  <path
-                                                                    d="M12 17.5l-8-8h16z"
-                                                                  />
-                                                                </g>
-                                                              </svg>
-                                                            </Styled(svg)>
-                                                          </Icon>
-                                                        </IconArrowDropdownDown>
-                                                      </Styled(IconArrowDropdownDown)>
-                                                    </withProps(Styled(IconArrowDropdownDown))>
-                                                    <input
-                                                      key="input"
-                                                      name="state"
-                                                      type="hidden"
-                                                      value=""
-                                                    />
-                                                    <Underlay>
-                                                      <div
-                                                        className="emotion-8"
-                                                      />
-                                                    </Underlay>
-                                                  </div>
-                                                </FauxControl>
+                                                                <TriggerContent>
+                                                                  <span
+                                                                    className="emotion-2"
+                                                                  >
+                                                                    Choose a state...
+                                                                  </span>
+                                                                </TriggerContent>
+                                                              </div>
+                                                            </Control>
+                                                            <withProps(Styled(IconArrowDropdownDown))
+                                                              key="arrow"
+                                                            >
+                                                              <Styled(IconArrowDropdownDown)
+                                                                size="1.5em"
+                                                              >
+                                                                <IconArrowDropdownDown
+                                                                  className="emotion-5"
+                                                                  size="1.5em"
+                                                                >
+                                                                  <Icon
+                                                                    className="emotion-5"
+                                                                    rtl={false}
+                                                                    size="1.5em"
+                                                                  >
+                                                                    <Styled(svg)
+                                                                      aria-hidden={true}
+                                                                      className="emotion-5"
+                                                                      focusable="false"
+                                                                      role="img"
+                                                                      rtl={false}
+                                                                      size="1.5em"
+                                                                      viewBox="0 0 24 24"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="emotion-4"
+                                                                        focusable="false"
+                                                                        role="img"
+                                                                        viewBox="0 0 24 24"
+                                                                      >
+                                                                        <g>
+                                                                          <path
+                                                                            d="M12 17.5l-8-8h16z"
+                                                                          />
+                                                                        </g>
+                                                                      </svg>
+                                                                    </Styled(svg)>
+                                                                  </Icon>
+                                                                </IconArrowDropdownDown>
+                                                              </Styled(IconArrowDropdownDown)>
+                                                            </withProps(Styled(IconArrowDropdownDown))>
+                                                            <input
+                                                              key="input"
+                                                              name="state"
+                                                              type="hidden"
+                                                              value=""
+                                                            />
+                                                            <Underlay>
+                                                              <div
+                                                                className="emotion-8"
+                                                              />
+                                                            </Underlay>
+                                                          </div>
+                                                        </FauxControl>
+                                                      </FauxControl>
+                                                    </ThemeProvider>
+                                                  </ThemeProvider>
+                                                </Themed(FauxControl)>
                                               </SelectTrigger>
                                             </SelectTrigger>
                                           </SelectTrigger>
@@ -5903,7 +6325,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
             id="formField-107-caption"
           >
             <div
-              className="emotion-21"
+              className="emotion-23"
               id="formField-107-caption"
             >
               Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -5917,15 +6339,15 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: invalid 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -5937,17 +6359,17 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -6217,7 +6639,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
     size="large"
   >
     <Select
-      className="emotion-14"
+      className="emotion-16"
       data={
         Array [
           Object {
@@ -6254,7 +6676,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -6293,7 +6715,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -6330,7 +6752,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
               size="large"
             >
               <Popover
-                className="emotion-14"
+                className="emotion-16"
                 content={[Function]}
                 focusTriggerOnClose={true}
                 hasArrow={true}
@@ -6354,7 +6776,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -6379,12 +6801,12 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-12"
+                    className="emotion-14"
                     id="select-29"
                     tag="span"
                   >
                     <span
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-29"
                     >
                       <PopoverTrigger
@@ -6408,11 +6830,11 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-describedby="select-29-content"
@@ -6496,7 +6918,17 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value=""
+                                          />,
+                                        ]
+                                      }
                                       aria-describedby="select-29-content"
                                       aria-expanded={false}
                                       aria-haspopup="listbox"
@@ -6504,105 +6936,167 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                       aria-owns="select-29-content"
                                       className="emotion-8"
                                       control={[Function]}
-                                      innerRef={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": true,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
                                       role="button"
+                                      size="large"
                                       tabIndex={0}
                                     >
-                                      <div
-                                        aria-describedby="select-29-content"
-                                        aria-expanded={false}
-                                        aria-haspopup="listbox"
-                                        aria-invalid={true}
-                                        aria-owns="select-29-content"
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": true,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value=""
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          hasPlaceholder={true}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-describedby="select-29-content"
+                                            aria-expanded={false}
+                                            aria-haspopup="listbox"
+                                            aria-invalid={true}
+                                            aria-owns="select-29-content"
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": true,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Select...
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownDown))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownDown)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownDown
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-describedby="select-29-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-invalid={true}
+                                              aria-owns="select-29-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-describedby="select-29-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-invalid={true}
+                                                aria-owns="select-29-content"
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={true}
+                                                  key="control"
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 17.5l-8-8h16z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownDown>
-                                          </Styled(IconArrowDropdownDown)>
-                                        </withProps(Styled(IconArrowDropdownDown))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value=""
-                                        />
-                                        <Underlay>
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Select...
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownDown))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownDown)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownDown
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 17.5l-8-8h16z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownDown>
+                                                  </Styled(IconArrowDropdownDown)>
+                                                </withProps(Styled(IconArrowDropdownDown))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value=""
+                                                />
+                                                <Underlay>
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -6624,15 +7118,15 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: overflow 1`] = `
+.emotion-37 {
+  width: 100%;
+}
+
+.emotion-37 > span {
+  width: 100%;
+}
+
 .emotion-35 {
-  width: 100%;
-}
-
-.emotion-35 > span {
-  width: 100%;
-}
-
-.emotion-33 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -6644,17 +7138,17 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   width: 100%;
 }
 
-.emotion-33 *,
-.emotion-33 *::before,
-.emotion-33 *::after {
+.emotion-35 *,
+.emotion-35 *::before,
+.emotion-35 *::after {
   box-sizing: inherit;
 }
 
-.emotion-33 > span {
+.emotion-35 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -6864,7 +7358,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-29 {
+.emotion-31 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -6887,33 +7381,33 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   z-index: 100;
 }
 
-.emotion-29 *,
-.emotion-29 *::before,
-.emotion-29 *::after {
+.emotion-31 *,
+.emotion-31 *::before,
+.emotion-31 *::after {
   box-sizing: inherit;
 }
 
-.emotion-29[data-placement^="top"] {
+.emotion-31[data-placement^="top"] {
   margin-bottom: 5px;
 }
 
-.emotion-29[data-placement^="bottom"] {
+.emotion-31[data-placement^="bottom"] {
   margin-top: 5px;
 }
 
-.emotion-29[data-placement^="left"] {
+.emotion-31[data-placement^="left"] {
   margin-right: 5px;
 }
 
-.emotion-29[data-placement^="right"] {
+.emotion-31[data-placement^="right"] {
   margin-left: 5px;
 }
 
-.emotion-29[data-x-out-of-boundaries] {
+.emotion-31[data-x-out-of-boundaries] {
   visibility: hidden;
 }
 
-.emotion-28 {
+.emotion-30 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -6924,55 +7418,55 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-28 *,
-.emotion-28 *::before,
-.emotion-28 *::after {
+.emotion-30 *,
+.emotion-30 *::before,
+.emotion-30 *::after {
   box-sizing: inherit;
 }
 
-.emotion-27 {
+.emotion-29 {
   margin: 0.5em 0;
 }
 
-.emotion-27:first-child,
-.emotion-27 + .emotion-27 {
+.emotion-29:first-child,
+.emotion-29 + .emotion-29 {
   margin-top: 0;
 }
 
-.emotion-27:last-child {
+.emotion-29:last-child {
   margin-bottom: 0;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #333840;
   cursor: pointer;
   font-weight: 400;
   padding: 0.5em 1em;
 }
 
-.emotion-16:focus {
+.emotion-18:focus {
   background-color: #f5f7fa;
   outline: 0;
 }
 
-.emotion-16:hover {
+.emotion-18:hover {
   background-color: #f5f7fa;
 }
 
-.emotion-16:active {
+.emotion-18:active {
   background-color: #ebeff5;
 }
 
-.emotion-16[aria-selected="true"] {
+.emotion-18[aria-selected="true"] {
   background-color: #f0f5fc;
   font-weight: 700;
 }
 
-.emotion-16[aria-selected="true"]:active {
+.emotion-18[aria-selected="true"]:active {
   background-color: #accbfc;
 }
 
-.emotion-16 [role="img"] {
+.emotion-18 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
@@ -6981,15 +7475,15 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-16 [role="img"]:first-child {
+.emotion-18 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-16 [role="img"]:last-child {
+.emotion-18 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-15 {
+.emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7000,7 +7494,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   justify-content: space-between;
 }
 
-.emotion-14 {
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7020,20 +7514,20 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
   word-break: break-all;
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 0.875em;
   margin-right: 0.5714285714285714em;
   word-break: break-word;
 }
 
-.emotion-13 {
+.emotion-15 {
   color: #58606e;
   font-size: 0.6875em;
   padding-top: 0.18181818181818182em;
   word-break: break-word;
 }
 
-.emotion-40 {
+.emotion-42 {
   background-color: aliceblue;
   margin: 0 0 105px 0;
   overflow: hidden;
@@ -7042,7 +7536,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
 
 <Styled(div)>
   <div
-    className="emotion-40"
+    className="emotion-42"
   >
     <Select
       data={
@@ -7103,7 +7597,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
         size="large"
       >
         <Select
-          className="emotion-35"
+          className="emotion-37"
           data={
             Array [
               Object {
@@ -7139,7 +7633,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
           size="large"
         >
           <Themed(Dropdown)
-            className="emotion-35"
+            className="emotion-37"
             data={
               Array [
                 Object {
@@ -7177,7 +7671,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-35"
+                  className="emotion-37"
                   data={
                     Array [
                       Object {
@@ -7213,7 +7707,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                   size="large"
                 >
                   <Popover
-                    className="emotion-35"
+                    className="emotion-37"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -7236,7 +7730,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-35"
+                      className="emotion-37"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -7260,12 +7754,12 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-33"
+                        className="emotion-35"
                         id="select-71"
                         tag="span"
                       >
                         <span
-                          className="emotion-33"
+                          className="emotion-35"
                           id="select-71"
                         >
                           <PopoverTrigger
@@ -7289,11 +7783,11 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-activedescendant="select-71-menu"
@@ -7377,7 +7871,17 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                         size="large"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownUp)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-activedescendant="select-71-menu"
                                           aria-describedby="select-71-content"
                                           aria-expanded={true}
@@ -7385,105 +7889,167 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                           aria-owns="select-71-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-activedescendant="select-71-menu"
-                                            aria-describedby="select-71-content"
-                                            aria-expanded={true}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-71-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownUp)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                            >
-                                              <div
-                                                className="emotion-1"
+                                                aria-activedescendant="select-71-menu"
+                                                aria-describedby="select-71-content"
+                                                aria-expanded={true}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-71-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Select...
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownUp))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownUp)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownUp
-                                                  className="emotion-3"
-                                                  size="1.5em"
+                                                <FauxControl
+                                                  aria-activedescendant="select-71-menu"
+                                                  aria-describedby="select-71-content"
+                                                  aria-expanded={true}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-71-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-3"
-                                                    rtl={false}
-                                                    size="1.5em"
+                                                  <div
+                                                    aria-activedescendant="select-71-menu"
+                                                    aria-describedby="select-71-content"
+                                                    aria-expanded={true}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-71-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-3"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-2"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-1"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 7.5l8 8H4z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownUp>
-                                              </Styled(IconArrowDropdownUp)>
-                                            </withProps(Styled(IconArrowDropdownUp))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Select...
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownUp))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownUp)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownUp
+                                                          className="emotion-3"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-3"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-3"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-2"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 7.5l8 8H4z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownUp>
+                                                      </Styled(IconArrowDropdownUp)>
+                                                    </withProps(Styled(IconArrowDropdownUp))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -7520,7 +8086,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                               placement="bottom-start"
                             >
                               <DropdownContent
-                                className="emotion-29"
+                                className="emotion-31"
                                 id="select-71-content"
                                 modifiers={
                                   Object {
@@ -7534,7 +8100,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                 placement="bottom-start"
                               >
                                 <RtlPopper
-                                  className="emotion-29"
+                                  className="emotion-31"
                                   id="select-71-content"
                                   modifiers={
                                     Object {
@@ -7766,7 +8332,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                   }
                                 >
                                   <Popper
-                                    className="emotion-29"
+                                    className="emotion-31"
                                     component="div"
                                     eventsEnabled={true}
                                     id="select-71-content"
@@ -7783,7 +8349,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                     positionFixed={false}
                                   >
                                     <div
-                                      className="emotion-29"
+                                      className="emotion-31"
                                       id="select-71-content"
                                       onBlur={[Function]}
                                       style={
@@ -7823,7 +8389,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                           role="listbox"
                                         >
                                           <div
-                                            className="emotion-28"
+                                            className="emotion-30"
                                             id="select-71-menu"
                                             role="listbox"
                                           >
@@ -7832,7 +8398,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                             >
                                               <MenuGroup>
                                                 <div
-                                                  className="emotion-27"
+                                                  className="emotion-29"
                                                 >
                                                   <MenuItem
                                                     index={0}
@@ -7885,7 +8451,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                       >
                                                         <div
                                                           aria-selected={false}
-                                                          className="emotion-16"
+                                                          className="emotion-18"
                                                           id="select-71-item-0"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
@@ -7894,22 +8460,22 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                         >
                                                           <Styled(span)>
                                                             <span
-                                                              className="emotion-15"
+                                                              className="emotion-17"
                                                             >
                                                               <Styled(span)>
                                                                 <span
-                                                                  className="emotion-14"
+                                                                  className="emotion-16"
                                                                 >
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-12"
+                                                                      className="emotion-14"
                                                                     >
                                                                       Alpha
                                                                     </span>
                                                                   </Styled(span)>
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-13"
+                                                                      className="emotion-15"
                                                                     />
                                                                   </Styled(span)>
                                                                 </span>
@@ -7971,7 +8537,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                       >
                                                         <div
                                                           aria-selected={false}
-                                                          className="emotion-16"
+                                                          className="emotion-18"
                                                           id="select-71-item-1"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
@@ -7980,22 +8546,22 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                         >
                                                           <Styled(span)>
                                                             <span
-                                                              className="emotion-15"
+                                                              className="emotion-17"
                                                             >
                                                               <Styled(span)>
                                                                 <span
-                                                                  className="emotion-14"
+                                                                  className="emotion-16"
                                                                 >
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-12"
+                                                                      className="emotion-14"
                                                                     >
                                                                       Beta
                                                                     </span>
                                                                   </Styled(span)>
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-13"
+                                                                      className="emotion-15"
                                                                     />
                                                                   </Styled(span)>
                                                                 </span>
@@ -8057,7 +8623,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                       >
                                                         <div
                                                           aria-selected={false}
-                                                          className="emotion-16"
+                                                          className="emotion-18"
                                                           id="select-71-item-2"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
@@ -8066,22 +8632,22 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                         >
                                                           <Styled(span)>
                                                             <span
-                                                              className="emotion-15"
+                                                              className="emotion-17"
                                                             >
                                                               <Styled(span)>
                                                                 <span
-                                                                  className="emotion-14"
+                                                                  className="emotion-16"
                                                                 >
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-12"
+                                                                      className="emotion-14"
                                                                     >
                                                                       Gamma
                                                                     </span>
                                                                   </Styled(span)>
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-13"
+                                                                      className="emotion-15"
                                                                     />
                                                                   </Styled(span)>
                                                                 </span>
@@ -8138,15 +8704,15 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: placeholder 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -8158,17 +8724,17 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -8812,7 +9378,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
     size="large"
   >
     <Select
-      className="emotion-14"
+      className="emotion-16"
       data={
         Array [
           Object {
@@ -9036,7 +9602,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -9262,7 +9828,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -9486,7 +10052,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
               size="large"
             >
               <Popover
-                className="emotion-14"
+                className="emotion-16"
                 content={[Function]}
                 focusTriggerOnClose={true}
                 hasArrow={true}
@@ -9509,7 +10075,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -9533,12 +10099,12 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-12"
+                    className="emotion-14"
                     id="select-13"
                     tag="span"
                   >
                     <span
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-13"
                     >
                       <PopoverTrigger
@@ -9561,11 +10127,11 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-describedby="select-13-content"
@@ -9646,111 +10212,181 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value=""
+                                          />,
+                                        ]
+                                      }
                                       aria-describedby="select-13-content"
                                       aria-expanded={false}
                                       aria-haspopup="listbox"
                                       aria-owns="select-13-content"
                                       className="emotion-8"
                                       control={[Function]}
-                                      innerRef={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": true,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
                                       role="button"
+                                      size="large"
                                       tabIndex={0}
                                     >
-                                      <div
-                                        aria-describedby="select-13-content"
-                                        aria-expanded={false}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-13-content"
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": true,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value=""
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          hasPlaceholder={true}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-describedby="select-13-content"
+                                            aria-expanded={false}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-13-content"
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": true,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Choose a state...
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownDown))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownDown)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownDown
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-describedby="select-13-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-13-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-describedby="select-13-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-13-content"
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={true}
+                                                  key="control"
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 17.5l-8-8h16z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownDown>
-                                          </Styled(IconArrowDropdownDown)>
-                                        </withProps(Styled(IconArrowDropdownDown))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value=""
-                                        />
-                                        <Underlay>
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Choose a state...
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownDown))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownDown)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownDown
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 17.5l-8-8h16z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownDown>
+                                                  </Styled(IconArrowDropdownDown)>
+                                                </withProps(Styled(IconArrowDropdownDown))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value=""
+                                                />
+                                                <Underlay>
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -9772,15 +10408,15 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: placement 1`] = `
+.emotion-37 {
+  width: 100%;
+}
+
+.emotion-37 > span {
+  width: 100%;
+}
+
 .emotion-35 {
-  width: 100%;
-}
-
-.emotion-35 > span {
-  width: 100%;
-}
-
-.emotion-33 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -9792,17 +10428,17 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   width: 100%;
 }
 
-.emotion-33 *,
-.emotion-33 *::before,
-.emotion-33 *::after {
+.emotion-35 *,
+.emotion-35 *::before,
+.emotion-35 *::after {
   box-sizing: inherit;
 }
 
-.emotion-33 > span {
+.emotion-35 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -10012,7 +10648,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-40 {
+.emotion-42 {
   height: 175px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -10028,7 +10664,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   justify-content: center;
 }
 
-.emotion-29 {
+.emotion-31 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -10051,33 +10687,33 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   z-index: 100;
 }
 
-.emotion-29 *,
-.emotion-29 *::before,
-.emotion-29 *::after {
+.emotion-31 *,
+.emotion-31 *::before,
+.emotion-31 *::after {
   box-sizing: inherit;
 }
 
-.emotion-29[data-placement^="top"] {
+.emotion-31[data-placement^="top"] {
   margin-bottom: 5px;
 }
 
-.emotion-29[data-placement^="bottom"] {
+.emotion-31[data-placement^="bottom"] {
   margin-top: 5px;
 }
 
-.emotion-29[data-placement^="left"] {
+.emotion-31[data-placement^="left"] {
   margin-right: 5px;
 }
 
-.emotion-29[data-placement^="right"] {
+.emotion-31[data-placement^="right"] {
   margin-left: 5px;
 }
 
-.emotion-29[data-x-out-of-boundaries] {
+.emotion-31[data-x-out-of-boundaries] {
   visibility: hidden;
 }
 
-.emotion-28 {
+.emotion-30 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -10088,55 +10724,55 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-28 *,
-.emotion-28 *::before,
-.emotion-28 *::after {
+.emotion-30 *,
+.emotion-30 *::before,
+.emotion-30 *::after {
   box-sizing: inherit;
 }
 
-.emotion-27 {
+.emotion-29 {
   margin: 0.5em 0;
 }
 
-.emotion-27:first-child,
-.emotion-27 + .emotion-27 {
+.emotion-29:first-child,
+.emotion-29 + .emotion-29 {
   margin-top: 0;
 }
 
-.emotion-27:last-child {
+.emotion-29:last-child {
   margin-bottom: 0;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #333840;
   cursor: pointer;
   font-weight: 400;
   padding: 0.5em 1em;
 }
 
-.emotion-16:focus {
+.emotion-18:focus {
   background-color: #f5f7fa;
   outline: 0;
 }
 
-.emotion-16:hover {
+.emotion-18:hover {
   background-color: #f5f7fa;
 }
 
-.emotion-16:active {
+.emotion-18:active {
   background-color: #ebeff5;
 }
 
-.emotion-16[aria-selected="true"] {
+.emotion-18[aria-selected="true"] {
   background-color: #f0f5fc;
   font-weight: 700;
 }
 
-.emotion-16[aria-selected="true"]:active {
+.emotion-18[aria-selected="true"]:active {
   background-color: #accbfc;
 }
 
-.emotion-16 [role="img"] {
+.emotion-18 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
@@ -10145,15 +10781,15 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-16 [role="img"]:first-child {
+.emotion-18 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-16 [role="img"]:last-child {
+.emotion-18 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-15 {
+.emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10164,7 +10800,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   justify-content: space-between;
 }
 
-.emotion-14 {
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10184,13 +10820,13 @@ exports[`Select demo examples Snapshots: placement 1`] = `
   word-break: break-all;
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 0.875em;
   margin-right: 0.5714285714285714em;
   word-break: break-word;
 }
 
-.emotion-13 {
+.emotion-15 {
   color: #58606e;
   font-size: 0.6875em;
   padding-top: 0.18181818181818182em;
@@ -10199,7 +10835,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
 
 <Styled(div)>
   <div
-    className="emotion-40"
+    className="emotion-42"
   >
     <Select
       data={
@@ -10260,7 +10896,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
         size="large"
       >
         <Select
-          className="emotion-35"
+          className="emotion-37"
           data={
             Array [
               Object {
@@ -10296,7 +10932,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
           size="large"
         >
           <Themed(Dropdown)
-            className="emotion-35"
+            className="emotion-37"
             data={
               Array [
                 Object {
@@ -10334,7 +10970,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-35"
+                  className="emotion-37"
                   data={
                     Array [
                       Object {
@@ -10370,7 +11006,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                   size="large"
                 >
                   <Popover
-                    className="emotion-35"
+                    className="emotion-37"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -10393,7 +11029,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-35"
+                      className="emotion-37"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -10417,12 +11053,12 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-33"
+                        className="emotion-35"
                         id="select-67"
                         tag="span"
                       >
                         <span
-                          className="emotion-33"
+                          className="emotion-35"
                           id="select-67"
                         >
                           <PopoverTrigger
@@ -10446,11 +11082,11 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-activedescendant="select-67-menu"
@@ -10534,7 +11170,17 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                         size="large"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownUp)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-activedescendant="select-67-menu"
                                           aria-describedby="select-67-content"
                                           aria-expanded={true}
@@ -10542,105 +11188,167 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                           aria-owns="select-67-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-activedescendant="select-67-menu"
-                                            aria-describedby="select-67-content"
-                                            aria-expanded={true}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-67-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownUp)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                            >
-                                              <div
-                                                className="emotion-1"
+                                                aria-activedescendant="select-67-menu"
+                                                aria-describedby="select-67-content"
+                                                aria-expanded={true}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-67-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Select...
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownUp))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownUp)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownUp
-                                                  className="emotion-3"
-                                                  size="1.5em"
+                                                <FauxControl
+                                                  aria-activedescendant="select-67-menu"
+                                                  aria-describedby="select-67-content"
+                                                  aria-expanded={true}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-67-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-3"
-                                                    rtl={false}
-                                                    size="1.5em"
+                                                  <div
+                                                    aria-activedescendant="select-67-menu"
+                                                    aria-describedby="select-67-content"
+                                                    aria-expanded={true}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-67-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-3"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-2"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-1"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 7.5l8 8H4z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownUp>
-                                              </Styled(IconArrowDropdownUp)>
-                                            </withProps(Styled(IconArrowDropdownUp))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Select...
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownUp))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownUp)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownUp
+                                                          className="emotion-3"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-3"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-3"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-2"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 7.5l8 8H4z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownUp>
+                                                      </Styled(IconArrowDropdownUp)>
+                                                    </withProps(Styled(IconArrowDropdownUp))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -10677,7 +11385,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                               placement="bottom-start"
                             >
                               <DropdownContent
-                                className="emotion-29"
+                                className="emotion-31"
                                 id="select-67-content"
                                 modifiers={
                                   Object {
@@ -10691,7 +11399,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                 placement="bottom-start"
                               >
                                 <RtlPopper
-                                  className="emotion-29"
+                                  className="emotion-31"
                                   id="select-67-content"
                                   modifiers={
                                     Object {
@@ -10923,7 +11631,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                   }
                                 >
                                   <Popper
-                                    className="emotion-29"
+                                    className="emotion-31"
                                     component="div"
                                     eventsEnabled={true}
                                     id="select-67-content"
@@ -10940,7 +11648,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                     positionFixed={false}
                                   >
                                     <div
-                                      className="emotion-29"
+                                      className="emotion-31"
                                       id="select-67-content"
                                       onBlur={[Function]}
                                       style={
@@ -10980,7 +11688,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                           role="listbox"
                                         >
                                           <div
-                                            className="emotion-28"
+                                            className="emotion-30"
                                             id="select-67-menu"
                                             role="listbox"
                                           >
@@ -10989,7 +11697,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                             >
                                               <MenuGroup>
                                                 <div
-                                                  className="emotion-27"
+                                                  className="emotion-29"
                                                 >
                                                   <MenuItem
                                                     index={0}
@@ -11042,7 +11750,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                       >
                                                         <div
                                                           aria-selected={false}
-                                                          className="emotion-16"
+                                                          className="emotion-18"
                                                           id="select-67-item-0"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
@@ -11051,22 +11759,22 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                         >
                                                           <Styled(span)>
                                                             <span
-                                                              className="emotion-15"
+                                                              className="emotion-17"
                                                             >
                                                               <Styled(span)>
                                                                 <span
-                                                                  className="emotion-14"
+                                                                  className="emotion-16"
                                                                 >
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-12"
+                                                                      className="emotion-14"
                                                                     >
                                                                       Alpha
                                                                     </span>
                                                                   </Styled(span)>
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-13"
+                                                                      className="emotion-15"
                                                                     />
                                                                   </Styled(span)>
                                                                 </span>
@@ -11128,7 +11836,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                       >
                                                         <div
                                                           aria-selected={false}
-                                                          className="emotion-16"
+                                                          className="emotion-18"
                                                           id="select-67-item-1"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
@@ -11137,22 +11845,22 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                         >
                                                           <Styled(span)>
                                                             <span
-                                                              className="emotion-15"
+                                                              className="emotion-17"
                                                             >
                                                               <Styled(span)>
                                                                 <span
-                                                                  className="emotion-14"
+                                                                  className="emotion-16"
                                                                 >
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-12"
+                                                                      className="emotion-14"
                                                                     >
                                                                       Beta
                                                                     </span>
                                                                   </Styled(span)>
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-13"
+                                                                      className="emotion-15"
                                                                     />
                                                                   </Styled(span)>
                                                                 </span>
@@ -11214,7 +11922,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                       >
                                                         <div
                                                           aria-selected={false}
-                                                          className="emotion-16"
+                                                          className="emotion-18"
                                                           id="select-67-item-2"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
@@ -11223,22 +11931,22 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                         >
                                                           <Styled(span)>
                                                             <span
-                                                              className="emotion-15"
+                                                              className="emotion-17"
                                                             >
                                                               <Styled(span)>
                                                                 <span
-                                                                  className="emotion-14"
+                                                                  className="emotion-16"
                                                                 >
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-12"
+                                                                      className="emotion-14"
                                                                     >
                                                                       Gamma
                                                                     </span>
                                                                   </Styled(span)>
                                                                   <Styled(span)>
                                                                     <span
-                                                                      className="emotion-13"
+                                                                      className="emotion-15"
                                                                     />
                                                                   </Styled(span)>
                                                                 </span>
@@ -11295,15 +12003,15 @@ exports[`Select demo examples Snapshots: placement 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: portal 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -11315,17 +12023,17 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -11535,18 +12243,18 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-26 {
+.emotion-28 {
   position: relative;
 }
 
-.emotion-20 {
+.emotion-22 {
   background-color: aliceblue;
   height: 360px;
   overflow: auto;
   position: relative;
 }
 
-.emotion-19 {
+.emotion-21 {
   height: 860px;
   width: 300vw;
   display: -webkit-box;
@@ -11563,13 +12271,13 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   justify-content: center;
 }
 
-.emotion-24 {
+.emotion-26 {
   left: 0;
   position: absolute;
   top: 0;
 }
 
-.emotion-23 {
+.emotion-25 {
   box-sizing: border-box;
   color: #3272d9;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -11598,54 +12306,54 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   top: 0;
 }
 
-.emotion-23 *,
-.emotion-23 *::before,
-.emotion-23 *::after {
+.emotion-25 *,
+.emotion-25 *::before,
+.emotion-25 *::after {
   box-sizing: inherit;
 }
 
-.emotion-23:focus {
+.emotion-25:focus {
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #3272d9;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-23:hover {
+.emotion-25:hover {
   background-color: #f5f7fa;
   color: #3272d9;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-23:active {
+.emotion-25:active {
   background-color: #ebeff5;
   color: #3272d9;
 }
 
-.emotion-23::-moz-focus-inner {
+.emotion-25::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-23 [role="img"] {
+.emotion-25 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-23 [role="img"]:first-child {
+.emotion-25 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-23 [role="img"]:last-child {
+.emotion-25 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-23 [role="img"]:only-child {
+.emotion-25 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-22 {
+.emotion-24 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11663,7 +12371,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
   width: 100%;
 }
 
-.emotion-21 {
+.emotion-23 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -11680,19 +12388,19 @@ exports[`Select demo examples Snapshots: portal 1`] = `
 >
   <Styled(div)>
     <div
-      className="emotion-26"
+      className="emotion-28"
     >
       <Styled(div)
         height={360}
       >
         <div
-          className="emotion-20"
+          className="emotion-22"
         >
           <Styled(div)
             scrollAreaHeight={360}
           >
             <div
-              className="emotion-19"
+              className="emotion-21"
             >
               <Select
                 data={
@@ -11799,7 +12507,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                       usePortal={true}
                     >
                       <Select
-                        className="emotion-14"
+                        className="emotion-16"
                         data={
                           Array [
                             Object {
@@ -11839,7 +12547,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                         usePortal={true}
                       >
                         <Themed(Dropdown)
-                          className="emotion-14"
+                          className="emotion-16"
                           data={
                             Array [
                               Object {
@@ -11881,7 +12589,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                           <ThemeProvider>
                             <ThemeProvider>
                               <Dropdown
-                                className="emotion-14"
+                                className="emotion-16"
                                 data={
                                   Array [
                                     Object {
@@ -11921,7 +12629,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                 usePortal={true}
                               >
                                 <Popover
-                                  className="emotion-14"
+                                  className="emotion-16"
                                   content={[Function]}
                                   focusTriggerOnClose={true}
                                   hasArrow={true}
@@ -11948,7 +12656,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                   usePortal={true}
                                 >
                                   <Popover
-                                    className="emotion-14"
+                                    className="emotion-16"
                                     content={[Function]}
                                     focusTriggerOnClose={true}
                                     hasArrow={true}
@@ -11976,12 +12684,12 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                     usePortal={true}
                                   >
                                     <Popover
-                                      className="emotion-12"
+                                      className="emotion-14"
                                       id="select-79"
                                       tag="span"
                                     >
                                       <span
-                                        className="emotion-12"
+                                        className="emotion-14"
                                         id="select-79"
                                       >
                                         <PopoverTrigger
@@ -12005,11 +12713,11 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                             component="span"
                                           >
                                             <PopoverTrigger
-                                              className="emotion-10"
+                                              className="emotion-12"
                                               component="span"
                                             >
                                               <span
-                                                className="emotion-10"
+                                                className="emotion-12"
                                               >
                                                 <SelectTrigger
                                                   aria-activedescendant="select-79-menu"
@@ -12093,7 +12801,17 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                       size="large"
                                                       tabIndex={0}
                                                     >
-                                                      <FauxControl
+                                                      <Themed(FauxControl)
+                                                        afterItems={
+                                                          Array [
+                                                            <withProps(Styled(IconArrowDropdownUp)) />,
+                                                            <input
+                                                              name={undefined}
+                                                              type="hidden"
+                                                              value=""
+                                                            />,
+                                                          ]
+                                                        }
                                                         aria-activedescendant="select-79-menu"
                                                         aria-describedby="select-79-content"
                                                         aria-expanded={true}
@@ -12101,105 +12819,167 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                         aria-owns="select-79-content"
                                                         className="emotion-8"
                                                         control={[Function]}
-                                                        innerRef={[Function]}
+                                                        controlProps={
+                                                          Object {
+                                                            "hasPlaceholder": true,
+                                                            "variant": undefined,
+                                                          }
+                                                        }
+                                                        fauxControlRef={[Function]}
                                                         onBlur={[Function]}
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
                                                         onKeyUp={[Function]}
                                                         role="button"
+                                                        size="large"
                                                         tabIndex={0}
                                                       >
-                                                        <div
-                                                          aria-activedescendant="select-79-menu"
-                                                          aria-describedby="select-79-content"
-                                                          aria-expanded={true}
-                                                          aria-haspopup="listbox"
-                                                          aria-owns="select-79-content"
-                                                          className="emotion-7"
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="button"
-                                                          tabIndex={0}
-                                                        >
-                                                          <Control
-                                                            controlPropsIn={
-                                                              Object {
-                                                                "hasPlaceholder": true,
-                                                                "variant": undefined,
+                                                        <ThemeProvider>
+                                                          <ThemeProvider>
+                                                            <FauxControl
+                                                              afterItems={
+                                                                Array [
+                                                                  <withProps(Styled(IconArrowDropdownUp)) />,
+                                                                  <input
+                                                                    name={undefined}
+                                                                    type="hidden"
+                                                                    value=""
+                                                                  />,
+                                                                ]
                                                               }
-                                                            }
-                                                            hasPlaceholder={true}
-                                                            key="control"
-                                                            size="large"
-                                                          >
-                                                            <div
-                                                              className="emotion-1"
+                                                              aria-activedescendant="select-79-menu"
+                                                              aria-describedby="select-79-content"
+                                                              aria-expanded={true}
+                                                              aria-haspopup="listbox"
+                                                              aria-owns="select-79-content"
+                                                              className="emotion-8"
+                                                              control={[Function]}
+                                                              controlProps={
+                                                                Object {
+                                                                  "hasPlaceholder": true,
+                                                                  "variant": undefined,
+                                                                }
+                                                              }
+                                                              fauxControlRef={[Function]}
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              role="button"
+                                                              size="large"
+                                                              tabIndex={0}
                                                             >
-                                                              <TriggerContent>
-                                                                <span
-                                                                  className="emotion-0"
-                                                                >
-                                                                  Select...
-                                                                </span>
-                                                              </TriggerContent>
-                                                            </div>
-                                                          </Control>
-                                                          <withProps(Styled(IconArrowDropdownUp))
-                                                            key="arrow"
-                                                          >
-                                                            <Styled(IconArrowDropdownUp)
-                                                              size="1.5em"
-                                                            >
-                                                              <IconArrowDropdownUp
-                                                                className="emotion-3"
-                                                                size="1.5em"
+                                                              <FauxControl
+                                                                aria-activedescendant="select-79-menu"
+                                                                aria-describedby="select-79-content"
+                                                                aria-expanded={true}
+                                                                aria-haspopup="listbox"
+                                                                aria-owns="select-79-content"
+                                                                className="emotion-8"
+                                                                control={[Function]}
+                                                                innerRef={[Function]}
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                role="button"
+                                                                tabIndex={0}
                                                               >
-                                                                <Icon
-                                                                  className="emotion-3"
-                                                                  rtl={false}
-                                                                  size="1.5em"
+                                                                <div
+                                                                  aria-activedescendant="select-79-menu"
+                                                                  aria-describedby="select-79-content"
+                                                                  aria-expanded={true}
+                                                                  aria-haspopup="listbox"
+                                                                  aria-owns="select-79-content"
+                                                                  className="emotion-7"
+                                                                  onBlur={[Function]}
+                                                                  onClick={[Function]}
+                                                                  onKeyDown={[Function]}
+                                                                  onKeyUp={[Function]}
+                                                                  role="button"
+                                                                  tabIndex={0}
                                                                 >
-                                                                  <Styled(svg)
-                                                                    aria-hidden={true}
-                                                                    className="emotion-3"
-                                                                    focusable="false"
-                                                                    role="img"
-                                                                    rtl={false}
-                                                                    size="1.5em"
-                                                                    viewBox="0 0 24 24"
+                                                                  <Control
+                                                                    controlPropsIn={
+                                                                      Object {
+                                                                        "hasPlaceholder": true,
+                                                                        "variant": undefined,
+                                                                      }
+                                                                    }
+                                                                    hasPlaceholder={true}
+                                                                    key="control"
+                                                                    size="large"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden={true}
-                                                                      className="emotion-2"
-                                                                      focusable="false"
-                                                                      role="img"
-                                                                      viewBox="0 0 24 24"
+                                                                    <div
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <g>
-                                                                        <path
-                                                                          d="M12 7.5l8 8H4z"
-                                                                        />
-                                                                      </g>
-                                                                    </svg>
-                                                                  </Styled(svg)>
-                                                                </Icon>
-                                                              </IconArrowDropdownUp>
-                                                            </Styled(IconArrowDropdownUp)>
-                                                          </withProps(Styled(IconArrowDropdownUp))>
-                                                          <input
-                                                            key="input"
-                                                            type="hidden"
-                                                            value=""
-                                                          />
-                                                          <Underlay>
-                                                            <div
-                                                              className="emotion-6"
-                                                            />
-                                                          </Underlay>
-                                                        </div>
-                                                      </FauxControl>
+                                                                      <TriggerContent>
+                                                                        <span
+                                                                          className="emotion-0"
+                                                                        >
+                                                                          Select...
+                                                                        </span>
+                                                                      </TriggerContent>
+                                                                    </div>
+                                                                  </Control>
+                                                                  <withProps(Styled(IconArrowDropdownUp))
+                                                                    key="arrow"
+                                                                  >
+                                                                    <Styled(IconArrowDropdownUp)
+                                                                      size="1.5em"
+                                                                    >
+                                                                      <IconArrowDropdownUp
+                                                                        className="emotion-3"
+                                                                        size="1.5em"
+                                                                      >
+                                                                        <Icon
+                                                                          className="emotion-3"
+                                                                          rtl={false}
+                                                                          size="1.5em"
+                                                                        >
+                                                                          <Styled(svg)
+                                                                            aria-hidden={true}
+                                                                            className="emotion-3"
+                                                                            focusable="false"
+                                                                            role="img"
+                                                                            rtl={false}
+                                                                            size="1.5em"
+                                                                            viewBox="0 0 24 24"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              className="emotion-2"
+                                                                              focusable="false"
+                                                                              role="img"
+                                                                              viewBox="0 0 24 24"
+                                                                            >
+                                                                              <g>
+                                                                                <path
+                                                                                  d="M12 7.5l8 8H4z"
+                                                                                />
+                                                                              </g>
+                                                                            </svg>
+                                                                          </Styled(svg)>
+                                                                        </Icon>
+                                                                      </IconArrowDropdownUp>
+                                                                    </Styled(IconArrowDropdownUp)>
+                                                                  </withProps(Styled(IconArrowDropdownUp))>
+                                                                  <input
+                                                                    key="input"
+                                                                    type="hidden"
+                                                                    value=""
+                                                                  />
+                                                                  <Underlay>
+                                                                    <div
+                                                                      className="emotion-6"
+                                                                    />
+                                                                  </Underlay>
+                                                                </div>
+                                                              </FauxControl>
+                                                            </FauxControl>
+                                                          </ThemeProvider>
+                                                        </ThemeProvider>
+                                                      </Themed(FauxControl)>
                                                     </SelectTrigger>
                                                   </SelectTrigger>
                                                 </SelectTrigger>
@@ -12251,7 +13031,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
         type="button"
       >
         <Button
-          className="emotion-24"
+          className="emotion-26"
           element="button"
           minimal={true}
           onClick={[Function]}
@@ -12259,7 +13039,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
           type="button"
         >
           <Button
-            className="emotion-24"
+            className="emotion-26"
             element="button"
             minimal={true}
             onClick={[Function]}
@@ -12268,19 +13048,19 @@ exports[`Select demo examples Snapshots: portal 1`] = `
             type="button"
           >
             <button
-              className="emotion-23"
+              className="emotion-25"
               onClick={[Function]}
               type="button"
             >
               <Styled(span)>
                 <span
-                  className="emotion-22"
+                  className="emotion-24"
                 >
                   <Styled(span)
                     size="small"
                   >
                     <span
-                      className="emotion-21"
+                      className="emotion-23"
                     >
                       Re-center
                     </span>
@@ -12297,15 +13077,15 @@ exports[`Select demo examples Snapshots: portal 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: read-only 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -12317,17 +13097,17 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -12608,7 +13388,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
     size="large"
   >
     <Select
-      className="emotion-14"
+      className="emotion-16"
       data={
         Array [
           Object {
@@ -12651,7 +13431,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -12696,7 +13476,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -12739,7 +13519,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
               size="large"
             >
               <Popover
-                className="emotion-14"
+                className="emotion-16"
                 content={[Function]}
                 disabled={true}
                 focusTriggerOnClose={true}
@@ -12769,7 +13549,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   disabled={true}
                   focusTriggerOnClose={true}
@@ -12800,12 +13580,12 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-12"
+                    className="emotion-14"
                     id="select-21"
                     tag="span"
                   >
                     <span
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-21"
                     >
                       <PopoverTrigger
@@ -12836,11 +13616,11 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-describedby="select-21-content"
@@ -12945,7 +13725,17 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value="alpha"
+                                          />,
+                                        ]
+                                      }
                                       aria-describedby="select-21-content"
                                       aria-disabled={true}
                                       aria-expanded={false}
@@ -12954,7 +13744,13 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                       aria-readonly={true}
                                       className="emotion-8"
                                       control={[Function]}
-                                      innerRef={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": false,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
                                       item={
                                         Object {
                                           "text": "Alpha",
@@ -12964,105 +13760,175 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                       onBlur={[Function]}
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
+                                      readOnly={true}
                                       role="button"
+                                      size="large"
                                       tabIndex={0}
                                     >
-                                      <div
-                                        aria-describedby="select-21-content"
-                                        aria-disabled={true}
-                                        aria-expanded={false}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-21-content"
-                                        aria-readonly={true}
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": false,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value="alpha"
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          hasPlaceholder={false}
-                                          key="control"
-                                          readOnly={true}
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-describedby="select-21-content"
+                                            aria-disabled={true}
+                                            aria-expanded={false}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-21-content"
+                                            aria-readonly={true}
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": false,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            item={
+                                              Object {
+                                                "text": "Alpha",
+                                                "value": "alpha",
+                                              }
+                                            }
+                                            onBlur={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
                                             readOnly={true}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Alpha
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownDown))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownDown)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownDown
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-describedby="select-21-content"
+                                              aria-disabled={true}
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-21-content"
+                                              aria-readonly={true}
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              item={
+                                                Object {
+                                                  "text": "Alpha",
+                                                  "value": "alpha",
+                                                }
+                                              }
+                                              onBlur={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-describedby="select-21-content"
+                                                aria-disabled={true}
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-21-content"
+                                                aria-readonly={true}
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": false,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={false}
+                                                  key="control"
+                                                  readOnly={true}
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
+                                                    readOnly={true}
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 17.5l-8-8h16z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownDown>
-                                          </Styled(IconArrowDropdownDown)>
-                                        </withProps(Styled(IconArrowDropdownDown))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value="alpha"
-                                        />
-                                        <Underlay
-                                          readOnly={true}
-                                        >
-                                          <div
-                                            className="emotion-6"
-                                            readOnly={true}
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Alpha
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownDown))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownDown)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownDown
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 17.5l-8-8h16z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownDown>
+                                                  </Styled(IconArrowDropdownDown)>
+                                                </withProps(Styled(IconArrowDropdownDown))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value="alpha"
+                                                />
+                                                <Underlay
+                                                  readOnly={true}
+                                                >
+                                                  <div
+                                                    className="emotion-6"
+                                                    readOnly={true}
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -13084,15 +13950,15 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: required 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -13104,17 +13970,17 @@ exports[`Select demo examples Snapshots: required 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -13384,7 +14250,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
     size="large"
   >
     <Select
-      className="emotion-14"
+      className="emotion-16"
       data={
         Array [
           Object {
@@ -13421,7 +14287,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -13460,7 +14326,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -13497,7 +14363,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
               size="large"
             >
               <Popover
-                className="emotion-14"
+                className="emotion-16"
                 content={[Function]}
                 focusTriggerOnClose={true}
                 hasArrow={true}
@@ -13521,7 +14387,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -13546,12 +14412,12 @@ exports[`Select demo examples Snapshots: required 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-12"
+                    className="emotion-14"
                     id="select-25"
                     tag="span"
                   >
                     <span
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-25"
                     >
                       <PopoverTrigger
@@ -13575,11 +14441,11 @@ exports[`Select demo examples Snapshots: required 1`] = `
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-describedby="select-25-content"
@@ -13663,7 +14529,17 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value=""
+                                          />,
+                                        ]
+                                      }
                                       aria-describedby="select-25-content"
                                       aria-expanded={false}
                                       aria-haspopup="listbox"
@@ -13671,105 +14547,167 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                       aria-required={true}
                                       className="emotion-8"
                                       control={[Function]}
-                                      innerRef={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": true,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
                                       role="button"
+                                      size="large"
                                       tabIndex={0}
                                     >
-                                      <div
-                                        aria-describedby="select-25-content"
-                                        aria-expanded={false}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-25-content"
-                                        aria-required={true}
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": true,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value=""
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          hasPlaceholder={true}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-describedby="select-25-content"
+                                            aria-expanded={false}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-25-content"
+                                            aria-required={true}
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": true,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Select...
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownDown))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownDown)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownDown
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-describedby="select-25-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-25-content"
+                                              aria-required={true}
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-describedby="select-25-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-25-content"
+                                                aria-required={true}
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={true}
+                                                  key="control"
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 17.5l-8-8h16z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownDown>
-                                          </Styled(IconArrowDropdownDown)>
-                                        </withProps(Styled(IconArrowDropdownDown))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value=""
-                                        />
-                                        <Underlay>
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Select...
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownDown))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownDown)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownDown
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 17.5l-8-8h16z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownDown>
+                                                  </Styled(IconArrowDropdownDown)>
+                                                </withProps(Styled(IconArrowDropdownDown))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value=""
+                                                />
+                                                <Underlay>
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -13791,15 +14729,15 @@ exports[`Select demo examples Snapshots: required 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: rtl 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -13811,17 +14749,17 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -13933,18 +14871,18 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-39[class] > *:not(:last-child) {
+.emotion-43[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-21 {
+.emotion-23 {
   fill: currentcolor;
   font-size: 16px;
   height: 1.5em;
   width: 1.5em;
 }
 
-.emotion-26 {
+.emotion-28 {
   background-color: #ffffff;
   border-color: #2a854e;
   border-radius: 0.1875em;
@@ -14056,7 +14994,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   margin-right: 0.5em;
 }
 
-.emotion-28 {
+.emotion-30 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14068,7 +15006,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
-.emotion-28 [role="img"] {
+.emotion-30 [role="img"] {
   display: block;
   color: #3272d9;
   -webkit-flex: 0 0 auto;
@@ -14076,21 +15014,21 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-28 [role="img"]:first-child {
+.emotion-30 [role="img"]:first-child {
   color: #3272d9;
   margin: 0 0.5em;
 }
 
-.emotion-28 :not([role="img"]) ~ [role="img"] {
+.emotion-30 :not([role="img"]) ~ [role="img"] {
   color: #2a854e;
 }
 
-.emotion-28 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+.emotion-30 :not([role="img"]) + [role="img"]:not(:last-of-type) {
   color: #2a854e;
   margin-right: 0.5em;
 }
 
-.emotion-27 {
+.emotion-29 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -14112,27 +15050,27 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
-.emotion-27 *,
-.emotion-27 *::before,
-.emotion-27 *::after {
+.emotion-29 *,
+.emotion-29 *::before,
+.emotion-29 *::after {
   box-sizing: inherit;
 }
 
-.emotion-27:hover > div:last-child {
+.emotion-29:hover > div:last-child {
   border-color: #3ba164;
 }
 
-.emotion-27:focus > div:last-child {
+.emotion-29:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-27:active > div:last-child {
+.emotion-29:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-27 [role="img"] {
+.emotion-29 [role="img"] {
   display: block;
   color: #3272d9;
   -webkit-flex: 0 0 auto;
@@ -14140,21 +15078,21 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-27 [role="img"]:first-child {
+.emotion-29 [role="img"]:first-child {
   color: #3272d9;
   margin: 0 0.5em;
 }
 
-.emotion-27 :not([role="img"]) ~ [role="img"] {
+.emotion-29 :not([role="img"]) ~ [role="img"] {
   color: #2a854e;
 }
 
-.emotion-27 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+.emotion-29 :not([role="img"]) + [role="img"]:not(:last-of-type) {
   color: #2a854e;
   margin-right: 0.5em;
 }
 
-.emotion-20 {
+.emotion-22 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14178,47 +15116,47 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-20::-webkit-input-placeholder {
+.emotion-22::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::-moz-placeholder {
+.emotion-22::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20:-ms-input-placeholder {
+.emotion-22:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::placeholder {
+.emotion-22::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::-ms-input-placeholder {
+.emotion-22::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20:-ms-input-placeholder {
+.emotion-22:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::-ms-clear {
+.emotion-22::-ms-clear {
   display: none;
 }
 
-.emotion-20:focus ~ div:last-child {
+.emotion-22:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
@@ -14230,7 +15168,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
     <ThemeProvider>
       <Styled(div)>
         <div
-          className="emotion-39"
+          className="emotion-43"
         >
           <Select
             data={
@@ -14290,7 +15228,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
               size="large"
             >
               <Select
-                className="emotion-14"
+                className="emotion-16"
                 data={
                   Array [
                     Object {
@@ -14326,7 +15264,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                 size="large"
               >
                 <Themed(Dropdown)
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -14364,7 +15302,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                   <ThemeProvider>
                     <ThemeProvider>
                       <Dropdown
-                        className="emotion-14"
+                        className="emotion-16"
                         data={
                           Array [
                             Object {
@@ -14400,7 +15338,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                         size="large"
                       >
                         <Popover
-                          className="emotion-14"
+                          className="emotion-16"
                           content={[Function]}
                           focusTriggerOnClose={true}
                           hasArrow={true}
@@ -14423,7 +15361,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                           triggerRef={[Function]}
                         >
                           <Popover
-                            className="emotion-14"
+                            className="emotion-16"
                             content={[Function]}
                             focusTriggerOnClose={true}
                             hasArrow={true}
@@ -14447,12 +15385,12 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                             triggerRef={[Function]}
                           >
                             <Popover
-                              className="emotion-12"
+                              className="emotion-14"
                               id="select-87"
                               tag="span"
                             >
                               <span
-                                className="emotion-12"
+                                className="emotion-14"
                                 id="select-87"
                               >
                                 <PopoverTrigger
@@ -14475,11 +15413,11 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                     component="span"
                                   >
                                     <PopoverTrigger
-                                      className="emotion-10"
+                                      className="emotion-12"
                                       component="span"
                                     >
                                       <span
-                                        className="emotion-10"
+                                        className="emotion-12"
                                       >
                                         <SelectTrigger
                                           aria-describedby="select-87-content"
@@ -14560,111 +15498,181 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                               size="large"
                                               tabIndex={0}
                                             >
-                                              <FauxControl
+                                              <Themed(FauxControl)
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
+                                                }
                                                 aria-describedby="select-87-content"
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-owns="select-87-content"
                                                 className="emotion-8"
                                                 control={[Function]}
-                                                innerRef={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
                                                 onBlur={[Function]}
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 onKeyUp={[Function]}
                                                 role="button"
+                                                size="large"
                                                 tabIndex={0}
                                               >
-                                                <div
-                                                  aria-describedby="select-87-content"
-                                                  aria-expanded={false}
-                                                  aria-haspopup="listbox"
-                                                  aria-owns="select-87-content"
-                                                  className="emotion-7"
-                                                  onBlur={[Function]}
-                                                  onClick={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  onKeyUp={[Function]}
-                                                  role="button"
-                                                  tabIndex={0}
-                                                >
-                                                  <Control
-                                                    controlPropsIn={
-                                                      Object {
-                                                        "hasPlaceholder": true,
-                                                        "variant": undefined,
+                                                <ThemeProvider>
+                                                  <ThemeProvider>
+                                                    <FauxControl
+                                                      afterItems={
+                                                        Array [
+                                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                                          <input
+                                                            name={undefined}
+                                                            type="hidden"
+                                                            value=""
+                                                          />,
+                                                        ]
                                                       }
-                                                    }
-                                                    hasPlaceholder={true}
-                                                    key="control"
-                                                    size="large"
-                                                  >
-                                                    <div
-                                                      className="emotion-1"
+                                                      aria-describedby="select-87-content"
+                                                      aria-expanded={false}
+                                                      aria-haspopup="listbox"
+                                                      aria-owns="select-87-content"
+                                                      className="emotion-8"
+                                                      control={[Function]}
+                                                      controlProps={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      fauxControlRef={[Function]}
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      role="button"
+                                                      size="large"
+                                                      tabIndex={0}
                                                     >
-                                                      <TriggerContent>
-                                                        <span
-                                                          className="emotion-0"
-                                                        >
-                                                          تحديد...
-                                                        </span>
-                                                      </TriggerContent>
-                                                    </div>
-                                                  </Control>
-                                                  <withProps(Styled(IconArrowDropdownDown))
-                                                    key="arrow"
-                                                  >
-                                                    <Styled(IconArrowDropdownDown)
-                                                      size="1.5em"
-                                                    >
-                                                      <IconArrowDropdownDown
-                                                        className="emotion-3"
-                                                        size="1.5em"
+                                                      <FauxControl
+                                                        aria-describedby="select-87-content"
+                                                        aria-expanded={false}
+                                                        aria-haspopup="listbox"
+                                                        aria-owns="select-87-content"
+                                                        className="emotion-8"
+                                                        control={[Function]}
+                                                        innerRef={[Function]}
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        role="button"
+                                                        tabIndex={0}
                                                       >
-                                                        <Icon
-                                                          className="emotion-3"
-                                                          rtl={false}
-                                                          size="1.5em"
+                                                        <div
+                                                          aria-describedby="select-87-content"
+                                                          aria-expanded={false}
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="select-87-content"
+                                                          className="emotion-7"
+                                                          onBlur={[Function]}
+                                                          onClick={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          role="button"
+                                                          tabIndex={0}
                                                         >
-                                                          <Styled(svg)
-                                                            aria-hidden={true}
-                                                            className="emotion-3"
-                                                            focusable="false"
-                                                            role="img"
-                                                            rtl={false}
-                                                            size="1.5em"
-                                                            viewBox="0 0 24 24"
+                                                          <Control
+                                                            controlPropsIn={
+                                                              Object {
+                                                                "hasPlaceholder": true,
+                                                                "variant": undefined,
+                                                              }
+                                                            }
+                                                            hasPlaceholder={true}
+                                                            key="control"
+                                                            size="large"
                                                           >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="emotion-2"
-                                                              focusable="false"
-                                                              role="img"
-                                                              viewBox="0 0 24 24"
+                                                            <div
+                                                              className="emotion-1"
                                                             >
-                                                              <g>
-                                                                <path
-                                                                  d="M12 17.5l-8-8h16z"
-                                                                />
-                                                              </g>
-                                                            </svg>
-                                                          </Styled(svg)>
-                                                        </Icon>
-                                                      </IconArrowDropdownDown>
-                                                    </Styled(IconArrowDropdownDown)>
-                                                  </withProps(Styled(IconArrowDropdownDown))>
-                                                  <input
-                                                    key="input"
-                                                    type="hidden"
-                                                    value=""
-                                                  />
-                                                  <Underlay>
-                                                    <div
-                                                      className="emotion-6"
-                                                    />
-                                                  </Underlay>
-                                                </div>
-                                              </FauxControl>
+                                                              <TriggerContent>
+                                                                <span
+                                                                  className="emotion-0"
+                                                                >
+                                                                  تحديد...
+                                                                </span>
+                                                              </TriggerContent>
+                                                            </div>
+                                                          </Control>
+                                                          <withProps(Styled(IconArrowDropdownDown))
+                                                            key="arrow"
+                                                          >
+                                                            <Styled(IconArrowDropdownDown)
+                                                              size="1.5em"
+                                                            >
+                                                              <IconArrowDropdownDown
+                                                                className="emotion-3"
+                                                                size="1.5em"
+                                                              >
+                                                                <Icon
+                                                                  className="emotion-3"
+                                                                  rtl={false}
+                                                                  size="1.5em"
+                                                                >
+                                                                  <Styled(svg)
+                                                                    aria-hidden={true}
+                                                                    className="emotion-3"
+                                                                    focusable="false"
+                                                                    role="img"
+                                                                    rtl={false}
+                                                                    size="1.5em"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="emotion-2"
+                                                                      focusable="false"
+                                                                      role="img"
+                                                                      viewBox="0 0 24 24"
+                                                                    >
+                                                                      <g>
+                                                                        <path
+                                                                          d="M12 17.5l-8-8h16z"
+                                                                        />
+                                                                      </g>
+                                                                    </svg>
+                                                                  </Styled(svg)>
+                                                                </Icon>
+                                                              </IconArrowDropdownDown>
+                                                            </Styled(IconArrowDropdownDown)>
+                                                          </withProps(Styled(IconArrowDropdownDown))>
+                                                          <input
+                                                            key="input"
+                                                            type="hidden"
+                                                            value=""
+                                                          />
+                                                          <Underlay>
+                                                            <div
+                                                              className="emotion-6"
+                                                            />
+                                                          </Underlay>
+                                                        </div>
+                                                      </FauxControl>
+                                                    </FauxControl>
+                                                  </ThemeProvider>
+                                                </ThemeProvider>
+                                              </Themed(FauxControl)>
                                             </SelectTrigger>
                                           </SelectTrigger>
                                         </SelectTrigger>
@@ -14743,7 +15751,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
               variant="success"
             >
               <Select
-                className="emotion-14"
+                className="emotion-16"
                 data={
                   Array [
                     Object {
@@ -14780,7 +15788,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                 variant="success"
               >
                 <Themed(Dropdown)
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -14819,7 +15827,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                   <ThemeProvider>
                     <ThemeProvider>
                       <Dropdown
-                        className="emotion-14"
+                        className="emotion-16"
                         data={
                           Array [
                             Object {
@@ -14856,7 +15864,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                         variant="success"
                       >
                         <Popover
-                          className="emotion-14"
+                          className="emotion-16"
                           content={[Function]}
                           focusTriggerOnClose={true}
                           hasArrow={true}
@@ -14880,7 +15888,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                           variant="success"
                         >
                           <Popover
-                            className="emotion-14"
+                            className="emotion-16"
                             content={[Function]}
                             focusTriggerOnClose={true}
                             hasArrow={true}
@@ -14905,12 +15913,12 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                             variant="success"
                           >
                             <Popover
-                              className="emotion-12"
+                              className="emotion-14"
                               id="select-89"
                               tag="span"
                             >
                               <span
-                                className="emotion-12"
+                                className="emotion-14"
                                 id="select-89"
                               >
                                 <PopoverTrigger
@@ -14934,11 +15942,11 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                     component="span"
                                   >
                                     <PopoverTrigger
-                                      className="emotion-10"
+                                      className="emotion-12"
                                       component="span"
                                     >
                                       <span
-                                        className="emotion-10"
+                                        className="emotion-12"
                                       >
                                         <SelectTrigger
                                           aria-describedby="select-89-content"
@@ -15004,7 +16012,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-owns="select-89-content"
-                                              className="emotion-28"
+                                              className="emotion-30"
                                               control={[Function]}
                                               controlProps={
                                                 Object {
@@ -15022,147 +16030,219 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                               tabIndex={0}
                                               variant="success"
                                             >
-                                              <FauxControl
+                                              <Themed(FauxControl)
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
+                                                }
                                                 aria-describedby="select-89-content"
                                                 aria-expanded={false}
                                                 aria-haspopup="listbox"
                                                 aria-owns="select-89-content"
-                                                className="emotion-28"
+                                                className="emotion-30"
                                                 control={[Function]}
-                                                innerRef={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
                                                 onBlur={[Function]}
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 onKeyUp={[Function]}
                                                 role="button"
+                                                size="large"
                                                 tabIndex={0}
                                                 variant="success"
                                               >
-                                                <div
-                                                  aria-describedby="select-89-content"
-                                                  aria-expanded={false}
-                                                  aria-haspopup="listbox"
-                                                  aria-owns="select-89-content"
-                                                  className="emotion-27"
-                                                  onBlur={[Function]}
-                                                  onClick={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  onKeyUp={[Function]}
-                                                  role="button"
-                                                  tabIndex={0}
-                                                >
-                                                  <Control
-                                                    controlPropsIn={
-                                                      Object {
-                                                        "hasPlaceholder": true,
-                                                        "variant": undefined,
+                                                <ThemeProvider>
+                                                  <ThemeProvider>
+                                                    <FauxControl
+                                                      afterItems={
+                                                        Array [
+                                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                                          <input
+                                                            name={undefined}
+                                                            type="hidden"
+                                                            value=""
+                                                          />,
+                                                        ]
                                                       }
-                                                    }
-                                                    hasPlaceholder={true}
-                                                    key="control"
-                                                    size="large"
-                                                    variant="success"
-                                                  >
-                                                    <div
-                                                      className="emotion-20"
+                                                      aria-describedby="select-89-content"
+                                                      aria-expanded={false}
+                                                      aria-haspopup="listbox"
+                                                      aria-owns="select-89-content"
+                                                      className="emotion-30"
+                                                      control={[Function]}
+                                                      controlProps={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      fauxControlRef={[Function]}
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      role="button"
+                                                      size="large"
+                                                      tabIndex={0}
+                                                      variant="success"
                                                     >
-                                                      <TriggerContent>
-                                                        <span
-                                                          className="emotion-0"
-                                                        >
-                                                          تحديد...
-                                                        </span>
-                                                      </TriggerContent>
-                                                    </div>
-                                                  </Control>
-                                                  <IconSuccess
-                                                    key="iconEnd"
-                                                    size="1.5em"
-                                                  >
-                                                    <Icon
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                    >
-                                                      <Styled(svg)
-                                                        aria-hidden={true}
-                                                        focusable="false"
-                                                        role="img"
-                                                        rtl={false}
-                                                        size="1.5em"
-                                                        viewBox="0 0 24 24"
+                                                      <FauxControl
+                                                        aria-describedby="select-89-content"
+                                                        aria-expanded={false}
+                                                        aria-haspopup="listbox"
+                                                        aria-owns="select-89-content"
+                                                        className="emotion-30"
+                                                        control={[Function]}
+                                                        innerRef={[Function]}
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        role="button"
+                                                        tabIndex={0}
+                                                        variant="success"
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="emotion-21"
-                                                          focusable="false"
-                                                          role="img"
-                                                          viewBox="0 0 24 24"
+                                                        <div
+                                                          aria-describedby="select-89-content"
+                                                          aria-expanded={false}
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="select-89-content"
+                                                          className="emotion-29"
+                                                          onBlur={[Function]}
+                                                          onClick={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          role="button"
+                                                          tabIndex={0}
                                                         >
-                                                          <g>
-                                                            <path
-                                                              d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
-                                                            />
-                                                          </g>
-                                                        </svg>
-                                                      </Styled(svg)>
-                                                    </Icon>
-                                                  </IconSuccess>
-                                                  <withProps(Styled(IconArrowDropdownDown))
-                                                    key="arrow"
-                                                  >
-                                                    <Styled(IconArrowDropdownDown)
-                                                      size="1.5em"
-                                                    >
-                                                      <IconArrowDropdownDown
-                                                        className="emotion-3"
-                                                        size="1.5em"
-                                                      >
-                                                        <Icon
-                                                          className="emotion-3"
-                                                          rtl={false}
-                                                          size="1.5em"
-                                                        >
-                                                          <Styled(svg)
-                                                            aria-hidden={true}
-                                                            className="emotion-3"
-                                                            focusable="false"
-                                                            role="img"
-                                                            rtl={false}
-                                                            size="1.5em"
-                                                            viewBox="0 0 24 24"
+                                                          <Control
+                                                            controlPropsIn={
+                                                              Object {
+                                                                "hasPlaceholder": true,
+                                                                "variant": undefined,
+                                                              }
+                                                            }
+                                                            hasPlaceholder={true}
+                                                            key="control"
+                                                            size="large"
+                                                            variant="success"
                                                           >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="emotion-2"
-                                                              focusable="false"
-                                                              role="img"
-                                                              viewBox="0 0 24 24"
+                                                            <div
+                                                              className="emotion-22"
                                                             >
-                                                              <g>
-                                                                <path
-                                                                  d="M12 17.5l-8-8h16z"
-                                                                />
-                                                              </g>
-                                                            </svg>
-                                                          </Styled(svg)>
-                                                        </Icon>
-                                                      </IconArrowDropdownDown>
-                                                    </Styled(IconArrowDropdownDown)>
-                                                  </withProps(Styled(IconArrowDropdownDown))>
-                                                  <input
-                                                    key="input"
-                                                    type="hidden"
-                                                    value=""
-                                                  />
-                                                  <Underlay
-                                                    variant="success"
-                                                  >
-                                                    <div
-                                                      className="emotion-26"
-                                                    />
-                                                  </Underlay>
-                                                </div>
-                                              </FauxControl>
+                                                              <TriggerContent>
+                                                                <span
+                                                                  className="emotion-0"
+                                                                >
+                                                                  تحديد...
+                                                                </span>
+                                                              </TriggerContent>
+                                                            </div>
+                                                          </Control>
+                                                          <IconSuccess
+                                                            key="iconEnd"
+                                                            size="1.5em"
+                                                          >
+                                                            <Icon
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                            >
+                                                              <Styled(svg)
+                                                                aria-hidden={true}
+                                                                focusable="false"
+                                                                role="img"
+                                                                rtl={false}
+                                                                size="1.5em"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="emotion-23"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  viewBox="0 0 24 24"
+                                                                >
+                                                                  <g>
+                                                                    <path
+                                                                      d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                                                                    />
+                                                                  </g>
+                                                                </svg>
+                                                              </Styled(svg)>
+                                                            </Icon>
+                                                          </IconSuccess>
+                                                          <withProps(Styled(IconArrowDropdownDown))
+                                                            key="arrow"
+                                                          >
+                                                            <Styled(IconArrowDropdownDown)
+                                                              size="1.5em"
+                                                            >
+                                                              <IconArrowDropdownDown
+                                                                className="emotion-3"
+                                                                size="1.5em"
+                                                              >
+                                                                <Icon
+                                                                  className="emotion-3"
+                                                                  rtl={false}
+                                                                  size="1.5em"
+                                                                >
+                                                                  <Styled(svg)
+                                                                    aria-hidden={true}
+                                                                    className="emotion-3"
+                                                                    focusable="false"
+                                                                    role="img"
+                                                                    rtl={false}
+                                                                    size="1.5em"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="emotion-2"
+                                                                      focusable="false"
+                                                                      role="img"
+                                                                      viewBox="0 0 24 24"
+                                                                    >
+                                                                      <g>
+                                                                        <path
+                                                                          d="M12 17.5l-8-8h16z"
+                                                                        />
+                                                                      </g>
+                                                                    </svg>
+                                                                  </Styled(svg)>
+                                                                </Icon>
+                                                              </IconArrowDropdownDown>
+                                                            </Styled(IconArrowDropdownDown)>
+                                                          </withProps(Styled(IconArrowDropdownDown))>
+                                                          <input
+                                                            key="input"
+                                                            type="hidden"
+                                                            value=""
+                                                          />
+                                                          <Underlay
+                                                            variant="success"
+                                                          >
+                                                            <div
+                                                              className="emotion-28"
+                                                            />
+                                                          </Underlay>
+                                                        </div>
+                                                      </FauxControl>
+                                                    </FauxControl>
+                                                  </ThemeProvider>
+                                                </ThemeProvider>
+                                              </Themed(FauxControl)>
                                             </SelectTrigger>
                                           </SelectTrigger>
                                         </SelectTrigger>
@@ -15189,15 +16269,15 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: scrolling-container 1`] = `
+.emotion-37 {
+  width: 100%;
+}
+
+.emotion-37 > span {
+  width: 100%;
+}
+
 .emotion-35 {
-  width: 100%;
-}
-
-.emotion-35 > span {
-  width: 100%;
-}
-
-.emotion-33 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -15209,17 +16289,17 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   width: 100%;
 }
 
-.emotion-33 *,
-.emotion-33 *::before,
-.emotion-33 *::after {
+.emotion-35 *,
+.emotion-35 *::before,
+.emotion-35 *::after {
   box-sizing: inherit;
 }
 
-.emotion-33 > span {
+.emotion-35 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -15429,7 +16509,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-29 {
+.emotion-31 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -15452,33 +16532,33 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   z-index: 100;
 }
 
-.emotion-29 *,
-.emotion-29 *::before,
-.emotion-29 *::after {
+.emotion-31 *,
+.emotion-31 *::before,
+.emotion-31 *::after {
   box-sizing: inherit;
 }
 
-.emotion-29[data-placement^="top"] {
+.emotion-31[data-placement^="top"] {
   margin-bottom: 5px;
 }
 
-.emotion-29[data-placement^="bottom"] {
+.emotion-31[data-placement^="bottom"] {
   margin-top: 5px;
 }
 
-.emotion-29[data-placement^="left"] {
+.emotion-31[data-placement^="left"] {
   margin-right: 5px;
 }
 
-.emotion-29[data-placement^="right"] {
+.emotion-31[data-placement^="right"] {
   margin-left: 5px;
 }
 
-.emotion-29[data-x-out-of-boundaries] {
+.emotion-31[data-x-out-of-boundaries] {
   visibility: hidden;
 }
 
-.emotion-28 {
+.emotion-30 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -15489,55 +16569,55 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-28 *,
-.emotion-28 *::before,
-.emotion-28 *::after {
+.emotion-30 *,
+.emotion-30 *::before,
+.emotion-30 *::after {
   box-sizing: inherit;
 }
 
-.emotion-27 {
+.emotion-29 {
   margin: 0.5em 0;
 }
 
-.emotion-27:first-child,
-.emotion-27 + .emotion-27 {
+.emotion-29:first-child,
+.emotion-29 + .emotion-29 {
   margin-top: 0;
 }
 
-.emotion-27:last-child {
+.emotion-29:last-child {
   margin-bottom: 0;
 }
 
-.emotion-16 {
+.emotion-18 {
   color: #333840;
   cursor: pointer;
   font-weight: 400;
   padding: 0.5em 1em;
 }
 
-.emotion-16:focus {
+.emotion-18:focus {
   background-color: #f5f7fa;
   outline: 0;
 }
 
-.emotion-16:hover {
+.emotion-18:hover {
   background-color: #f5f7fa;
 }
 
-.emotion-16:active {
+.emotion-18:active {
   background-color: #ebeff5;
 }
 
-.emotion-16[aria-selected="true"] {
+.emotion-18[aria-selected="true"] {
   background-color: #f0f5fc;
   font-weight: 700;
 }
 
-.emotion-16[aria-selected="true"]:active {
+.emotion-18[aria-selected="true"]:active {
   background-color: #accbfc;
 }
 
-.emotion-16 [role="img"] {
+.emotion-18 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
@@ -15546,15 +16626,15 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-16 [role="img"]:first-child {
+.emotion-18 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-16 [role="img"]:last-child {
+.emotion-18 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-15 {
+.emotion-17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15565,7 +16645,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   justify-content: space-between;
 }
 
-.emotion-14 {
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15585,31 +16665,31 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   word-break: break-all;
 }
 
-.emotion-12 {
+.emotion-14 {
   font-size: 0.875em;
   margin-right: 0.5714285714285714em;
   word-break: break-word;
 }
 
-.emotion-13 {
+.emotion-15 {
   color: #58606e;
   font-size: 0.6875em;
   padding-top: 0.18181818181818182em;
   word-break: break-word;
 }
 
-.emotion-47 {
+.emotion-49 {
   position: relative;
 }
 
-.emotion-41 {
+.emotion-43 {
   background-color: aliceblue;
   height: 360px;
   overflow: auto;
   position: relative;
 }
 
-.emotion-40 {
+.emotion-42 {
   height: 860px;
   width: 300vw;
   display: -webkit-box;
@@ -15626,13 +16706,13 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   justify-content: center;
 }
 
-.emotion-45 {
+.emotion-47 {
   left: 0;
   position: absolute;
   top: 0;
 }
 
-.emotion-44 {
+.emotion-46 {
   box-sizing: border-box;
   color: #3272d9;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -15661,54 +16741,54 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   top: 0;
 }
 
-.emotion-44 *,
-.emotion-44 *::before,
-.emotion-44 *::after {
+.emotion-46 *,
+.emotion-46 *::before,
+.emotion-46 *::after {
   box-sizing: inherit;
 }
 
-.emotion-44:focus {
+.emotion-46:focus {
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #3272d9;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-44:hover {
+.emotion-46:hover {
   background-color: #f5f7fa;
   color: #3272d9;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-44:active {
+.emotion-46:active {
   background-color: #ebeff5;
   color: #3272d9;
 }
 
-.emotion-44::-moz-focus-inner {
+.emotion-46::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-44 [role="img"] {
+.emotion-46 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-44 [role="img"]:first-child {
+.emotion-46 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-44 [role="img"]:last-child {
+.emotion-46 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-44 [role="img"]:only-child {
+.emotion-46 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-43 {
+.emotion-45 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15726,7 +16806,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
   width: 100%;
 }
 
-.emotion-42 {
+.emotion-44 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -15743,19 +16823,19 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
 >
   <Styled(div)>
     <div
-      className="emotion-47"
+      className="emotion-49"
     >
       <Styled(div)
         height={360}
       >
         <div
-          className="emotion-41"
+          className="emotion-43"
         >
           <Styled(div)
             scrollAreaHeight={360}
           >
             <div
-              className="emotion-40"
+              className="emotion-42"
             >
               <Select
                 data={
@@ -15842,7 +16922,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                       size="large"
                     >
                       <Select
-                        className="emotion-35"
+                        className="emotion-37"
                         data={
                           Array [
                             Object {
@@ -15878,7 +16958,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                         size="large"
                       >
                         <Themed(Dropdown)
-                          className="emotion-35"
+                          className="emotion-37"
                           data={
                             Array [
                               Object {
@@ -15916,7 +16996,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                           <ThemeProvider>
                             <ThemeProvider>
                               <Dropdown
-                                className="emotion-35"
+                                className="emotion-37"
                                 data={
                                   Array [
                                     Object {
@@ -15952,7 +17032,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                 size="large"
                               >
                                 <Popover
-                                  className="emotion-35"
+                                  className="emotion-37"
                                   content={[Function]}
                                   focusTriggerOnClose={true}
                                   hasArrow={true}
@@ -15975,7 +17055,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                   triggerRef={[Function]}
                                 >
                                   <Popover
-                                    className="emotion-35"
+                                    className="emotion-37"
                                     content={[Function]}
                                     focusTriggerOnClose={true}
                                     hasArrow={true}
@@ -15999,12 +17079,12 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                     triggerRef={[Function]}
                                   >
                                     <Popover
-                                      className="emotion-33"
+                                      className="emotion-35"
                                       id="select-75"
                                       tag="span"
                                     >
                                       <span
-                                        className="emotion-33"
+                                        className="emotion-35"
                                         id="select-75"
                                       >
                                         <PopoverTrigger
@@ -16028,11 +17108,11 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                             component="span"
                                           >
                                             <PopoverTrigger
-                                              className="emotion-10"
+                                              className="emotion-12"
                                               component="span"
                                             >
                                               <span
-                                                className="emotion-10"
+                                                className="emotion-12"
                                               >
                                                 <SelectTrigger
                                                   aria-activedescendant="select-75-menu"
@@ -16116,7 +17196,17 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                       size="large"
                                                       tabIndex={0}
                                                     >
-                                                      <FauxControl
+                                                      <Themed(FauxControl)
+                                                        afterItems={
+                                                          Array [
+                                                            <withProps(Styled(IconArrowDropdownUp)) />,
+                                                            <input
+                                                              name={undefined}
+                                                              type="hidden"
+                                                              value=""
+                                                            />,
+                                                          ]
+                                                        }
                                                         aria-activedescendant="select-75-menu"
                                                         aria-describedby="select-75-content"
                                                         aria-expanded={true}
@@ -16124,105 +17214,167 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                         aria-owns="select-75-content"
                                                         className="emotion-8"
                                                         control={[Function]}
-                                                        innerRef={[Function]}
+                                                        controlProps={
+                                                          Object {
+                                                            "hasPlaceholder": true,
+                                                            "variant": undefined,
+                                                          }
+                                                        }
+                                                        fauxControlRef={[Function]}
                                                         onBlur={[Function]}
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
                                                         onKeyUp={[Function]}
                                                         role="button"
+                                                        size="large"
                                                         tabIndex={0}
                                                       >
-                                                        <div
-                                                          aria-activedescendant="select-75-menu"
-                                                          aria-describedby="select-75-content"
-                                                          aria-expanded={true}
-                                                          aria-haspopup="listbox"
-                                                          aria-owns="select-75-content"
-                                                          className="emotion-7"
-                                                          onBlur={[Function]}
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          onKeyUp={[Function]}
-                                                          role="button"
-                                                          tabIndex={0}
-                                                        >
-                                                          <Control
-                                                            controlPropsIn={
-                                                              Object {
-                                                                "hasPlaceholder": true,
-                                                                "variant": undefined,
+                                                        <ThemeProvider>
+                                                          <ThemeProvider>
+                                                            <FauxControl
+                                                              afterItems={
+                                                                Array [
+                                                                  <withProps(Styled(IconArrowDropdownUp)) />,
+                                                                  <input
+                                                                    name={undefined}
+                                                                    type="hidden"
+                                                                    value=""
+                                                                  />,
+                                                                ]
                                                               }
-                                                            }
-                                                            hasPlaceholder={true}
-                                                            key="control"
-                                                            size="large"
-                                                          >
-                                                            <div
-                                                              className="emotion-1"
+                                                              aria-activedescendant="select-75-menu"
+                                                              aria-describedby="select-75-content"
+                                                              aria-expanded={true}
+                                                              aria-haspopup="listbox"
+                                                              aria-owns="select-75-content"
+                                                              className="emotion-8"
+                                                              control={[Function]}
+                                                              controlProps={
+                                                                Object {
+                                                                  "hasPlaceholder": true,
+                                                                  "variant": undefined,
+                                                                }
+                                                              }
+                                                              fauxControlRef={[Function]}
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              role="button"
+                                                              size="large"
+                                                              tabIndex={0}
                                                             >
-                                                              <TriggerContent>
-                                                                <span
-                                                                  className="emotion-0"
-                                                                >
-                                                                  Select...
-                                                                </span>
-                                                              </TriggerContent>
-                                                            </div>
-                                                          </Control>
-                                                          <withProps(Styled(IconArrowDropdownUp))
-                                                            key="arrow"
-                                                          >
-                                                            <Styled(IconArrowDropdownUp)
-                                                              size="1.5em"
-                                                            >
-                                                              <IconArrowDropdownUp
-                                                                className="emotion-3"
-                                                                size="1.5em"
+                                                              <FauxControl
+                                                                aria-activedescendant="select-75-menu"
+                                                                aria-describedby="select-75-content"
+                                                                aria-expanded={true}
+                                                                aria-haspopup="listbox"
+                                                                aria-owns="select-75-content"
+                                                                className="emotion-8"
+                                                                control={[Function]}
+                                                                innerRef={[Function]}
+                                                                onBlur={[Function]}
+                                                                onClick={[Function]}
+                                                                onKeyDown={[Function]}
+                                                                onKeyUp={[Function]}
+                                                                role="button"
+                                                                tabIndex={0}
                                                               >
-                                                                <Icon
-                                                                  className="emotion-3"
-                                                                  rtl={false}
-                                                                  size="1.5em"
+                                                                <div
+                                                                  aria-activedescendant="select-75-menu"
+                                                                  aria-describedby="select-75-content"
+                                                                  aria-expanded={true}
+                                                                  aria-haspopup="listbox"
+                                                                  aria-owns="select-75-content"
+                                                                  className="emotion-7"
+                                                                  onBlur={[Function]}
+                                                                  onClick={[Function]}
+                                                                  onKeyDown={[Function]}
+                                                                  onKeyUp={[Function]}
+                                                                  role="button"
+                                                                  tabIndex={0}
                                                                 >
-                                                                  <Styled(svg)
-                                                                    aria-hidden={true}
-                                                                    className="emotion-3"
-                                                                    focusable="false"
-                                                                    role="img"
-                                                                    rtl={false}
-                                                                    size="1.5em"
-                                                                    viewBox="0 0 24 24"
+                                                                  <Control
+                                                                    controlPropsIn={
+                                                                      Object {
+                                                                        "hasPlaceholder": true,
+                                                                        "variant": undefined,
+                                                                      }
+                                                                    }
+                                                                    hasPlaceholder={true}
+                                                                    key="control"
+                                                                    size="large"
                                                                   >
-                                                                    <svg
-                                                                      aria-hidden={true}
-                                                                      className="emotion-2"
-                                                                      focusable="false"
-                                                                      role="img"
-                                                                      viewBox="0 0 24 24"
+                                                                    <div
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <g>
-                                                                        <path
-                                                                          d="M12 7.5l8 8H4z"
-                                                                        />
-                                                                      </g>
-                                                                    </svg>
-                                                                  </Styled(svg)>
-                                                                </Icon>
-                                                              </IconArrowDropdownUp>
-                                                            </Styled(IconArrowDropdownUp)>
-                                                          </withProps(Styled(IconArrowDropdownUp))>
-                                                          <input
-                                                            key="input"
-                                                            type="hidden"
-                                                            value=""
-                                                          />
-                                                          <Underlay>
-                                                            <div
-                                                              className="emotion-6"
-                                                            />
-                                                          </Underlay>
-                                                        </div>
-                                                      </FauxControl>
+                                                                      <TriggerContent>
+                                                                        <span
+                                                                          className="emotion-0"
+                                                                        >
+                                                                          Select...
+                                                                        </span>
+                                                                      </TriggerContent>
+                                                                    </div>
+                                                                  </Control>
+                                                                  <withProps(Styled(IconArrowDropdownUp))
+                                                                    key="arrow"
+                                                                  >
+                                                                    <Styled(IconArrowDropdownUp)
+                                                                      size="1.5em"
+                                                                    >
+                                                                      <IconArrowDropdownUp
+                                                                        className="emotion-3"
+                                                                        size="1.5em"
+                                                                      >
+                                                                        <Icon
+                                                                          className="emotion-3"
+                                                                          rtl={false}
+                                                                          size="1.5em"
+                                                                        >
+                                                                          <Styled(svg)
+                                                                            aria-hidden={true}
+                                                                            className="emotion-3"
+                                                                            focusable="false"
+                                                                            role="img"
+                                                                            rtl={false}
+                                                                            size="1.5em"
+                                                                            viewBox="0 0 24 24"
+                                                                          >
+                                                                            <svg
+                                                                              aria-hidden={true}
+                                                                              className="emotion-2"
+                                                                              focusable="false"
+                                                                              role="img"
+                                                                              viewBox="0 0 24 24"
+                                                                            >
+                                                                              <g>
+                                                                                <path
+                                                                                  d="M12 7.5l8 8H4z"
+                                                                                />
+                                                                              </g>
+                                                                            </svg>
+                                                                          </Styled(svg)>
+                                                                        </Icon>
+                                                                      </IconArrowDropdownUp>
+                                                                    </Styled(IconArrowDropdownUp)>
+                                                                  </withProps(Styled(IconArrowDropdownUp))>
+                                                                  <input
+                                                                    key="input"
+                                                                    type="hidden"
+                                                                    value=""
+                                                                  />
+                                                                  <Underlay>
+                                                                    <div
+                                                                      className="emotion-6"
+                                                                    />
+                                                                  </Underlay>
+                                                                </div>
+                                                              </FauxControl>
+                                                            </FauxControl>
+                                                          </ThemeProvider>
+                                                        </ThemeProvider>
+                                                      </Themed(FauxControl)>
                                                     </SelectTrigger>
                                                   </SelectTrigger>
                                                 </SelectTrigger>
@@ -16259,7 +17411,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                             placement="bottom-start"
                                           >
                                             <DropdownContent
-                                              className="emotion-29"
+                                              className="emotion-31"
                                               id="select-75-content"
                                               modifiers={
                                                 Object {
@@ -16273,7 +17425,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                               placement="bottom-start"
                                             >
                                               <RtlPopper
-                                                className="emotion-29"
+                                                className="emotion-31"
                                                 id="select-75-content"
                                                 modifiers={
                                                   Object {
@@ -16505,7 +17657,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                 }
                                               >
                                                 <Popper
-                                                  className="emotion-29"
+                                                  className="emotion-31"
                                                   component="div"
                                                   eventsEnabled={true}
                                                   id="select-75-content"
@@ -16522,7 +17674,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                   positionFixed={false}
                                                 >
                                                   <div
-                                                    className="emotion-29"
+                                                    className="emotion-31"
                                                     id="select-75-content"
                                                     onBlur={[Function]}
                                                     style={
@@ -16562,7 +17714,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                         role="listbox"
                                                       >
                                                         <div
-                                                          className="emotion-28"
+                                                          className="emotion-30"
                                                           id="select-75-menu"
                                                           role="listbox"
                                                         >
@@ -16571,7 +17723,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                           >
                                                             <MenuGroup>
                                                               <div
-                                                                className="emotion-27"
+                                                                className="emotion-29"
                                                               >
                                                                 <MenuItem
                                                                   index={0}
@@ -16624,7 +17776,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                     >
                                                                       <div
                                                                         aria-selected={false}
-                                                                        className="emotion-16"
+                                                                        className="emotion-18"
                                                                         id="select-75-item-0"
                                                                         onClick={[Function]}
                                                                         onKeyDown={[Function]}
@@ -16633,22 +17785,22 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                       >
                                                                         <Styled(span)>
                                                                           <span
-                                                                            className="emotion-15"
+                                                                            className="emotion-17"
                                                                           >
                                                                             <Styled(span)>
                                                                               <span
-                                                                                className="emotion-14"
+                                                                                className="emotion-16"
                                                                               >
                                                                                 <Styled(span)>
                                                                                   <span
-                                                                                    className="emotion-12"
+                                                                                    className="emotion-14"
                                                                                   >
                                                                                     Alpha
                                                                                   </span>
                                                                                 </Styled(span)>
                                                                                 <Styled(span)>
                                                                                   <span
-                                                                                    className="emotion-13"
+                                                                                    className="emotion-15"
                                                                                   />
                                                                                 </Styled(span)>
                                                                               </span>
@@ -16710,7 +17862,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                     >
                                                                       <div
                                                                         aria-selected={false}
-                                                                        className="emotion-16"
+                                                                        className="emotion-18"
                                                                         id="select-75-item-1"
                                                                         onClick={[Function]}
                                                                         onKeyDown={[Function]}
@@ -16719,22 +17871,22 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                       >
                                                                         <Styled(span)>
                                                                           <span
-                                                                            className="emotion-15"
+                                                                            className="emotion-17"
                                                                           >
                                                                             <Styled(span)>
                                                                               <span
-                                                                                className="emotion-14"
+                                                                                className="emotion-16"
                                                                               >
                                                                                 <Styled(span)>
                                                                                   <span
-                                                                                    className="emotion-12"
+                                                                                    className="emotion-14"
                                                                                   >
                                                                                     Beta
                                                                                   </span>
                                                                                 </Styled(span)>
                                                                                 <Styled(span)>
                                                                                   <span
-                                                                                    className="emotion-13"
+                                                                                    className="emotion-15"
                                                                                   />
                                                                                 </Styled(span)>
                                                                               </span>
@@ -16796,7 +17948,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                     >
                                                                       <div
                                                                         aria-selected={false}
-                                                                        className="emotion-16"
+                                                                        className="emotion-18"
                                                                         id="select-75-item-2"
                                                                         onClick={[Function]}
                                                                         onKeyDown={[Function]}
@@ -16805,22 +17957,22 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                       >
                                                                         <Styled(span)>
                                                                           <span
-                                                                            className="emotion-15"
+                                                                            className="emotion-17"
                                                                           >
                                                                             <Styled(span)>
                                                                               <span
-                                                                                className="emotion-14"
+                                                                                className="emotion-16"
                                                                               >
                                                                                 <Styled(span)>
                                                                                   <span
-                                                                                    className="emotion-12"
+                                                                                    className="emotion-14"
                                                                                   >
                                                                                     Gamma
                                                                                   </span>
                                                                                 </Styled(span)>
                                                                                 <Styled(span)>
                                                                                   <span
-                                                                                    className="emotion-13"
+                                                                                    className="emotion-15"
                                                                                   />
                                                                                 </Styled(span)>
                                                                               </span>
@@ -16886,7 +18038,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
         type="button"
       >
         <Button
-          className="emotion-45"
+          className="emotion-47"
           element="button"
           minimal={true}
           onClick={[Function]}
@@ -16894,7 +18046,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
           type="button"
         >
           <Button
-            className="emotion-45"
+            className="emotion-47"
             element="button"
             minimal={true}
             onClick={[Function]}
@@ -16903,19 +18055,19 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
             type="button"
           >
             <button
-              className="emotion-44"
+              className="emotion-46"
               onClick={[Function]}
               type="button"
             >
               <Styled(span)>
                 <span
-                  className="emotion-43"
+                  className="emotion-45"
                 >
                   <Styled(span)
                     size="small"
                   >
                     <span
-                      className="emotion-42"
+                      className="emotion-44"
                     >
                       Re-center
                     </span>
@@ -16932,15 +18084,15 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: size 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -16952,17 +18104,17 @@ exports[`Select demo examples Snapshots: size 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -17077,11 +18229,11 @@ exports[`Select demo examples Snapshots: size 1`] = `
   width: 100%;
 }
 
-.emotion-22 {
+.emotion-24 {
   margin: 0.5em;
 }
 
-.emotion-40 {
+.emotion-44 {
   fill: currentcolor;
   font-size: 16px;
   height: 1.5em;
@@ -17103,7 +18255,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
   z-index: -1;
 }
 
-.emotion-39 {
+.emotion-43 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -17127,52 +18279,52 @@ exports[`Select demo examples Snapshots: size 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-39::-webkit-input-placeholder {
+.emotion-43::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-39::-moz-placeholder {
+.emotion-43::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-39:-ms-input-placeholder {
+.emotion-43:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-39::placeholder {
+.emotion-43::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-39::-ms-input-placeholder {
+.emotion-43::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-39:-ms-input-placeholder {
+.emotion-43:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-39::-ms-clear {
+.emotion-43::-ms-clear {
   display: none;
 }
 
-.emotion-39:focus ~ div:last-child {
+.emotion-43:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-76[class] > *:not(:last-child) {
+.emotion-84[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -17257,7 +18409,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
   margin: 0.25em;
 }
 
-.emotion-20 {
+.emotion-22 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -17281,52 +18433,52 @@ exports[`Select demo examples Snapshots: size 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-20::-webkit-input-placeholder {
+.emotion-22::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::-moz-placeholder {
+.emotion-22::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20:-ms-input-placeholder {
+.emotion-22:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::placeholder {
+.emotion-22::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::-ms-input-placeholder {
+.emotion-22::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20:-ms-input-placeholder {
+.emotion-22:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-20::-ms-clear {
+.emotion-22::-ms-clear {
   display: none;
 }
 
-.emotion-20:focus ~ div:last-child {
+.emotion-22:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-21 {
+.emotion-23 {
   fill: currentcolor;
   font-size: 16px;
   height: 1em;
@@ -17334,7 +18486,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
   margin: 0.5em;
 }
 
-.emotion-58 {
+.emotion-64 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -17358,56 +18510,56 @@ exports[`Select demo examples Snapshots: size 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-58::-webkit-input-placeholder {
+.emotion-64::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-58::-moz-placeholder {
+.emotion-64::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-58:-ms-input-placeholder {
+.emotion-64:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-58::placeholder {
+.emotion-64::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-58::-ms-input-placeholder {
+.emotion-64::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-58:-ms-input-placeholder {
+.emotion-64:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-58::-ms-clear {
+.emotion-64::-ms-clear {
   display: none;
 }
 
-.emotion-58:focus ~ div:last-child {
+.emotion-64:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-60 {
+.emotion-66 {
   margin: 0.875em;
 }
 
-.emotion-59 {
+.emotion-65 {
   fill: currentcolor;
   font-size: 16px;
   height: 1.5em;
@@ -17417,7 +18569,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
 
 <Styled(div)>
   <div
-    className="emotion-76"
+    className="emotion-84"
   >
     <Select
       data={
@@ -17477,7 +18629,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         size="small"
       >
         <Select
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -17513,7 +18665,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
           size="small"
         >
           <Themed(Dropdown)
-            className="emotion-14"
+            className="emotion-16"
             data={
               Array [
                 Object {
@@ -17551,7 +18703,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -17587,7 +18739,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                   size="small"
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -17610,7 +18762,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-14"
+                      className="emotion-16"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -17634,12 +18786,12 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-33"
                         tag="span"
                       >
                         <span
-                          className="emotion-12"
+                          className="emotion-14"
                           id="select-33"
                         >
                           <PopoverTrigger
@@ -17662,11 +18814,11 @@ exports[`Select demo examples Snapshots: size 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-33-content"
@@ -17747,111 +18899,181 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         size="small"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-33-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-33-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="small"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-describedby="select-33-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-33-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="small"
-                                            >
-                                              <div
-                                                className="emotion-1"
+                                                aria-describedby="select-33-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-33-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="small"
+                                                tabIndex={0}
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Small
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="medium"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-3"
-                                                  size="medium"
+                                                <FauxControl
+                                                  aria-describedby="select-33-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-33-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-3"
-                                                    rtl={false}
-                                                    size="medium"
+                                                  <div
+                                                    aria-describedby="select-33-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-33-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-3"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="medium"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="small"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-2"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-1"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Small
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="medium"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-3"
+                                                          size="medium"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-3"
+                                                            rtl={false}
+                                                            size="medium"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-3"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="medium"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-2"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -17928,7 +19150,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         size="medium"
       >
         <Select
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -17964,7 +19186,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
           size="medium"
         >
           <Themed(Dropdown)
-            className="emotion-14"
+            className="emotion-16"
             data={
               Array [
                 Object {
@@ -18002,7 +19224,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -18038,7 +19260,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                   size="medium"
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -18061,7 +19283,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-14"
+                      className="emotion-16"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -18085,12 +19307,12 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-35"
                         tag="span"
                       >
                         <span
-                          className="emotion-12"
+                          className="emotion-14"
                           id="select-35"
                         >
                           <PopoverTrigger
@@ -18113,11 +19335,11 @@ exports[`Select demo examples Snapshots: size 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-35-content"
@@ -18198,111 +19420,181 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         size="medium"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-35-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-35-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="medium"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-describedby="select-35-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-35-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="medium"
-                                            >
-                                              <div
-                                                className="emotion-20"
-                                              >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Medium
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
+                                                aria-describedby="select-35-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-35-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
                                                 size="medium"
+                                                tabIndex={0}
                                               >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-22"
-                                                  size="medium"
+                                                <FauxControl
+                                                  aria-describedby="select-35-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-35-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-22"
-                                                    rtl={false}
-                                                    size="medium"
+                                                  <div
+                                                    aria-describedby="select-35-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-35-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-22"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
                                                       size="medium"
-                                                      viewBox="0 0 24 24"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-21"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-22"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Medium
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="medium"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-24"
+                                                          size="medium"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-24"
+                                                            rtl={false}
+                                                            size="medium"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-24"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="medium"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-23"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -18379,7 +19671,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         size="large"
       >
         <Select
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -18415,7 +19707,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
           size="large"
         >
           <Themed(Dropdown)
-            className="emotion-14"
+            className="emotion-16"
             data={
               Array [
                 Object {
@@ -18453,7 +19745,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -18489,7 +19781,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                   size="large"
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -18512,7 +19804,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-14"
+                      className="emotion-16"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -18536,12 +19828,12 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-37"
                         tag="span"
                       >
                         <span
-                          className="emotion-12"
+                          className="emotion-14"
                           id="select-37"
                         >
                           <PopoverTrigger
@@ -18564,11 +19856,11 @@ exports[`Select demo examples Snapshots: size 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-37-content"
@@ -18649,111 +19941,181 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         size="large"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-37-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-37-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-describedby="select-37-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-37-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                            >
-                                              <div
-                                                className="emotion-39"
+                                                aria-describedby="select-37-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-37-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Large
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-22"
-                                                  size="1.5em"
+                                                <FauxControl
+                                                  aria-describedby="select-37-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-37-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-22"
-                                                    rtl={false}
-                                                    size="1.5em"
+                                                  <div
+                                                    aria-describedby="select-37-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-37-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-22"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-40"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-43"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Large
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-24"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-24"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-24"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-44"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -18830,7 +20192,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         size="jumbo"
       >
         <Select
-          className="emotion-14"
+          className="emotion-16"
           data={
             Array [
               Object {
@@ -18866,7 +20228,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
           size="jumbo"
         >
           <Themed(Dropdown)
-            className="emotion-14"
+            className="emotion-16"
             data={
               Array [
                 Object {
@@ -18904,7 +20266,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-14"
+                  className="emotion-16"
                   data={
                     Array [
                       Object {
@@ -18940,7 +20302,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                   size="jumbo"
                 >
                   <Popover
-                    className="emotion-14"
+                    className="emotion-16"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -18963,7 +20325,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                     triggerRef={[Function]}
                   >
                     <Popover
-                      className="emotion-14"
+                      className="emotion-16"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -18987,12 +20349,12 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-12"
+                        className="emotion-14"
                         id="select-39"
                         tag="span"
                       >
                         <span
-                          className="emotion-12"
+                          className="emotion-14"
                           id="select-39"
                         >
                           <PopoverTrigger
@@ -19015,11 +20377,11 @@ exports[`Select demo examples Snapshots: size 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-10"
+                                className="emotion-12"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-10"
+                                  className="emotion-12"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-39-content"
@@ -19100,111 +20462,181 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         size="jumbo"
                                         tabIndex={0}
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-39-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-39-content"
                                           className="emotion-8"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="jumbo"
                                           tabIndex={0}
                                         >
-                                          <div
-                                            aria-describedby="select-39-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-39-content"
-                                            className="emotion-7"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="jumbo"
-                                            >
-                                              <div
-                                                className="emotion-58"
+                                                aria-describedby="select-39-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-39-content"
+                                                className="emotion-8"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="jumbo"
+                                                tabIndex={0}
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Jumbo
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-60"
-                                                  size="1.5em"
+                                                <FauxControl
+                                                  aria-describedby="select-39-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-39-content"
+                                                  className="emotion-8"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
                                                 >
-                                                  <Icon
-                                                    className="emotion-60"
-                                                    rtl={false}
-                                                    size="1.5em"
+                                                  <div
+                                                    aria-describedby="select-39-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-39-content"
+                                                    className="emotion-7"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-60"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="jumbo"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-59"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-64"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay>
-                                              <div
-                                                className="emotion-6"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Jumbo
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-66"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-66"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-66"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-65"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay>
+                                                      <div
+                                                        className="emotion-6"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -19228,15 +20660,15 @@ exports[`Select demo examples Snapshots: size 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: trigger-ref 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -19248,17 +20680,17 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -19468,11 +20900,11 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-22[class] > *:not(:last-child) {
+.emotion-24[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-20 {
+.emotion-22 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -19490,7 +20922,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   width: 100%;
 }
 
-.emotion-21 {
+.emotion-23 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -19516,13 +20948,13 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   vertical-align: middle;
 }
 
-.emotion-21 *,
-.emotion-21 *::before,
-.emotion-21 *::after {
+.emotion-23 *,
+.emotion-23 *::before,
+.emotion-23 *::after {
   box-sizing: inherit;
 }
 
-.emotion-21:focus {
+.emotion-23:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -19530,41 +20962,41 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   text-decoration: none;
 }
 
-.emotion-21:hover {
+.emotion-23:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-21:active {
+.emotion-23:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-21::-moz-focus-inner {
+.emotion-23::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-21 [role="img"] {
+.emotion-23 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-21 [role="img"]:first-child {
+.emotion-23 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-21 [role="img"]:last-child {
+.emotion-23 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-21 [role="img"]:only-child {
+.emotion-23 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-19 {
+.emotion-21 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -19575,11 +21007,11 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-19:first-child {
+.emotion-21:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-19:last-child {
+.emotion-21:last-child {
   padding-right: 0.5714285714285714em;
 }
 
@@ -19587,7 +21019,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
   <MyForm>
     <Styled(div)>
       <div
-        className="emotion-22"
+        className="emotion-24"
       >
         <Select
           data={
@@ -19649,7 +21081,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
             triggerRef={[Function]}
           >
             <Select
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -19686,7 +21118,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
               triggerRef={[Function]}
             >
               <Themed(Dropdown)
-                className="emotion-14"
+                className="emotion-16"
                 data={
                   Array [
                     Object {
@@ -19725,7 +21157,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                 <ThemeProvider>
                   <ThemeProvider>
                     <Dropdown
-                      className="emotion-14"
+                      className="emotion-16"
                       data={
                         Array [
                           Object {
@@ -19762,7 +21194,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                       triggerRef={[Function]}
                     >
                       <Popover
-                        className="emotion-14"
+                        className="emotion-16"
                         content={[Function]}
                         focusTriggerOnClose={true}
                         hasArrow={true}
@@ -19785,7 +21217,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                         triggerRef={[Function]}
                       >
                         <Popover
-                          className="emotion-14"
+                          className="emotion-16"
                           content={[Function]}
                           focusTriggerOnClose={true}
                           hasArrow={true}
@@ -19809,12 +21241,12 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                           triggerRef={[Function]}
                         >
                           <Popover
-                            className="emotion-12"
+                            className="emotion-14"
                             id="select-83"
                             tag="span"
                           >
                             <span
-                              className="emotion-12"
+                              className="emotion-14"
                               id="select-83"
                             >
                               <PopoverTrigger
@@ -19837,11 +21269,11 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                   component="span"
                                 >
                                   <PopoverTrigger
-                                    className="emotion-10"
+                                    className="emotion-12"
                                     component="span"
                                   >
                                     <span
-                                      className="emotion-10"
+                                      className="emotion-12"
                                     >
                                       <SelectTrigger
                                         aria-describedby="select-83-content"
@@ -19922,111 +21354,181 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                             size="large"
                                             tabIndex={0}
                                           >
-                                            <FauxControl
+                                            <Themed(FauxControl)
+                                              afterItems={
+                                                Array [
+                                                  <withProps(Styled(IconArrowDropdownDown)) />,
+                                                  <input
+                                                    name={undefined}
+                                                    type="hidden"
+                                                    value=""
+                                                  />,
+                                                ]
+                                              }
                                               aria-describedby="select-83-content"
                                               aria-expanded={false}
                                               aria-haspopup="listbox"
                                               aria-owns="select-83-content"
                                               className="emotion-8"
                                               control={[Function]}
-                                              innerRef={[Function]}
+                                              controlProps={
+                                                Object {
+                                                  "hasPlaceholder": true,
+                                                  "variant": undefined,
+                                                }
+                                              }
+                                              fauxControlRef={[Function]}
                                               onBlur={[Function]}
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
                                               onKeyUp={[Function]}
                                               role="button"
+                                              size="large"
                                               tabIndex={0}
                                             >
-                                              <div
-                                                aria-describedby="select-83-content"
-                                                aria-expanded={false}
-                                                aria-haspopup="listbox"
-                                                aria-owns="select-83-content"
-                                                className="emotion-7"
-                                                onBlur={[Function]}
-                                                onClick={[Function]}
-                                                onKeyDown={[Function]}
-                                                onKeyUp={[Function]}
-                                                role="button"
-                                                tabIndex={0}
-                                              >
-                                                <Control
-                                                  controlPropsIn={
-                                                    Object {
-                                                      "hasPlaceholder": true,
-                                                      "variant": undefined,
+                                              <ThemeProvider>
+                                                <ThemeProvider>
+                                                  <FauxControl
+                                                    afterItems={
+                                                      Array [
+                                                        <withProps(Styled(IconArrowDropdownDown)) />,
+                                                        <input
+                                                          name={undefined}
+                                                          type="hidden"
+                                                          value=""
+                                                        />,
+                                                      ]
                                                     }
-                                                  }
-                                                  hasPlaceholder={true}
-                                                  key="control"
-                                                  size="large"
-                                                >
-                                                  <div
-                                                    className="emotion-1"
+                                                    aria-describedby="select-83-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-83-content"
+                                                    className="emotion-8"
+                                                    control={[Function]}
+                                                    controlProps={
+                                                      Object {
+                                                        "hasPlaceholder": true,
+                                                        "variant": undefined,
+                                                      }
+                                                    }
+                                                    fauxControlRef={[Function]}
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    size="large"
+                                                    tabIndex={0}
                                                   >
-                                                    <TriggerContent>
-                                                      <span
-                                                        className="emotion-0"
-                                                      >
-                                                        Select...
-                                                      </span>
-                                                    </TriggerContent>
-                                                  </div>
-                                                </Control>
-                                                <withProps(Styled(IconArrowDropdownDown))
-                                                  key="arrow"
-                                                >
-                                                  <Styled(IconArrowDropdownDown)
-                                                    size="1.5em"
-                                                  >
-                                                    <IconArrowDropdownDown
-                                                      className="emotion-3"
-                                                      size="1.5em"
+                                                    <FauxControl
+                                                      aria-describedby="select-83-content"
+                                                      aria-expanded={false}
+                                                      aria-haspopup="listbox"
+                                                      aria-owns="select-83-content"
+                                                      className="emotion-8"
+                                                      control={[Function]}
+                                                      innerRef={[Function]}
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      role="button"
+                                                      tabIndex={0}
                                                     >
-                                                      <Icon
-                                                        className="emotion-3"
-                                                        rtl={false}
-                                                        size="1.5em"
+                                                      <div
+                                                        aria-describedby="select-83-content"
+                                                        aria-expanded={false}
+                                                        aria-haspopup="listbox"
+                                                        aria-owns="select-83-content"
+                                                        className="emotion-7"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        role="button"
+                                                        tabIndex={0}
                                                       >
-                                                        <Styled(svg)
-                                                          aria-hidden={true}
-                                                          className="emotion-3"
-                                                          focusable="false"
-                                                          role="img"
-                                                          rtl={false}
-                                                          size="1.5em"
-                                                          viewBox="0 0 24 24"
+                                                        <Control
+                                                          controlPropsIn={
+                                                            Object {
+                                                              "hasPlaceholder": true,
+                                                              "variant": undefined,
+                                                            }
+                                                          }
+                                                          hasPlaceholder={true}
+                                                          key="control"
+                                                          size="large"
                                                         >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="emotion-2"
-                                                            focusable="false"
-                                                            role="img"
-                                                            viewBox="0 0 24 24"
+                                                          <div
+                                                            className="emotion-1"
                                                           >
-                                                            <g>
-                                                              <path
-                                                                d="M12 17.5l-8-8h16z"
-                                                              />
-                                                            </g>
-                                                          </svg>
-                                                        </Styled(svg)>
-                                                      </Icon>
-                                                    </IconArrowDropdownDown>
-                                                  </Styled(IconArrowDropdownDown)>
-                                                </withProps(Styled(IconArrowDropdownDown))>
-                                                <input
-                                                  key="input"
-                                                  type="hidden"
-                                                  value=""
-                                                />
-                                                <Underlay>
-                                                  <div
-                                                    className="emotion-6"
-                                                  />
-                                                </Underlay>
-                                              </div>
-                                            </FauxControl>
+                                                            <TriggerContent>
+                                                              <span
+                                                                className="emotion-0"
+                                                              >
+                                                                Select...
+                                                              </span>
+                                                            </TriggerContent>
+                                                          </div>
+                                                        </Control>
+                                                        <withProps(Styled(IconArrowDropdownDown))
+                                                          key="arrow"
+                                                        >
+                                                          <Styled(IconArrowDropdownDown)
+                                                            size="1.5em"
+                                                          >
+                                                            <IconArrowDropdownDown
+                                                              className="emotion-3"
+                                                              size="1.5em"
+                                                            >
+                                                              <Icon
+                                                                className="emotion-3"
+                                                                rtl={false}
+                                                                size="1.5em"
+                                                              >
+                                                                <Styled(svg)
+                                                                  aria-hidden={true}
+                                                                  className="emotion-3"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  rtl={false}
+                                                                  size="1.5em"
+                                                                  viewBox="0 0 24 24"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="emotion-2"
+                                                                    focusable="false"
+                                                                    role="img"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <g>
+                                                                      <path
+                                                                        d="M12 17.5l-8-8h16z"
+                                                                      />
+                                                                    </g>
+                                                                  </svg>
+                                                                </Styled(svg)>
+                                                              </Icon>
+                                                            </IconArrowDropdownDown>
+                                                          </Styled(IconArrowDropdownDown)>
+                                                        </withProps(Styled(IconArrowDropdownDown))>
+                                                        <input
+                                                          key="input"
+                                                          type="hidden"
+                                                          value=""
+                                                        />
+                                                        <Underlay>
+                                                          <div
+                                                            className="emotion-6"
+                                                          />
+                                                        </Underlay>
+                                                      </div>
+                                                    </FauxControl>
+                                                  </FauxControl>
+                                                </ThemeProvider>
+                                              </ThemeProvider>
+                                            </Themed(FauxControl)>
                                           </SelectTrigger>
                                         </SelectTrigger>
                                       </SelectTrigger>
@@ -20059,19 +21561,19 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
             type="button"
           >
             <button
-              className="emotion-21"
+              className="emotion-23"
               onClick={[Function]}
               type="button"
             >
               <Styled(span)>
                 <span
-                  className="emotion-20"
+                  className="emotion-22"
                 >
                   <Styled(span)
                     size="large"
                   >
                     <span
-                      className="emotion-19"
+                      className="emotion-21"
                     >
                       Focus the control
                     </span>
@@ -20088,15 +21590,15 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: uncontrolled 1`] = `
+.emotion-16 {
+  width: 100%;
+}
+
+.emotion-16 > span {
+  width: 100%;
+}
+
 .emotion-14 {
-  width: 100%;
-}
-
-.emotion-14 > span {
-  width: 100%;
-}
-
-.emotion-12 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -20108,17 +21610,17 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 > span {
+.emotion-14 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -20775,7 +22277,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
     size="large"
   >
     <Select
-      className="emotion-14"
+      className="emotion-16"
       data={
         Array [
           Object {
@@ -21006,7 +22508,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-14"
+        className="emotion-16"
         data={
           Array [
             Object {
@@ -21239,7 +22741,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-14"
+              className="emotion-16"
               data={
                 Array [
                   Object {
@@ -21470,7 +22972,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
               size="large"
             >
               <Popover
-                className="emotion-14"
+                className="emotion-16"
                 content={[Function]}
                 defaultSelectedItem={
                   Object {
@@ -21500,7 +23002,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-14"
+                  className="emotion-16"
                   content={[Function]}
                   defaultSelectedItem={
                     Object {
@@ -21531,12 +23033,12 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-12"
+                    className="emotion-14"
                     id="select-1"
                     tag="span"
                   >
                     <span
-                      className="emotion-12"
+                      className="emotion-14"
                       id="select-1"
                     >
                       <PopoverTrigger
@@ -21566,11 +23068,11 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-describedby="select-1-content"
@@ -21670,14 +23172,30 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownDown)) />,
+                                          <input
+                                            name="state"
+                                            type="hidden"
+                                            value="CO"
+                                          />,
+                                        ]
+                                      }
                                       aria-describedby="select-1-content"
                                       aria-expanded={false}
                                       aria-haspopup="listbox"
                                       aria-owns="select-1-content"
                                       className="emotion-8"
                                       control={[Function]}
-                                      innerRef={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": false,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
                                       item={
                                         Object {
                                           "text": "Colorado",
@@ -21689,99 +23207,165 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
                                       role="button"
+                                      size="large"
                                       tabIndex={0}
                                     >
-                                      <div
-                                        aria-describedby="select-1-content"
-                                        aria-expanded={false}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-1-content"
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": false,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                <input
+                                                  name="state"
+                                                  type="hidden"
+                                                  value="CO"
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          hasPlaceholder={false}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-describedby="select-1-content"
+                                            aria-expanded={false}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-1-content"
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": false,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            item={
+                                              Object {
+                                                "text": "Colorado",
+                                                "value": "CO",
+                                              }
+                                            }
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Colorado
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownDown))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownDown)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownDown
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-describedby="select-1-content"
+                                              aria-expanded={false}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-1-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              item={
+                                                Object {
+                                                  "text": "Colorado",
+                                                  "value": "CO",
+                                                }
+                                              }
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-describedby="select-1-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-1-content"
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": false,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={false}
+                                                  key="control"
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 17.5l-8-8h16z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownDown>
-                                          </Styled(IconArrowDropdownDown)>
-                                        </withProps(Styled(IconArrowDropdownDown))>
-                                        <input
-                                          key="input"
-                                          name="state"
-                                          type="hidden"
-                                          value="CO"
-                                        />
-                                        <Underlay>
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Colorado
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownDown))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownDown)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownDown
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 17.5l-8-8h16z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownDown>
+                                                  </Styled(IconArrowDropdownDown)>
+                                                </withProps(Styled(IconArrowDropdownDown))>
+                                                <input
+                                                  key="input"
+                                                  name="state"
+                                                  type="hidden"
+                                                  value="CO"
+                                                />
+                                                <Underlay>
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -21803,15 +23387,15 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
 `;
 
 exports[`Select demo examples Snapshots: variants 1`] = `
+.emotion-17 {
+  width: 100%;
+}
+
+.emotion-17 > span {
+  width: 100%;
+}
+
 .emotion-15 {
-  width: 100%;
-}
-
-.emotion-15 > span {
-  width: 100%;
-}
-
-.emotion-13 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -21823,17 +23407,17 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-13 *,
-.emotion-13 *::before,
-.emotion-13 *::after {
+.emotion-15 *,
+.emotion-15 *::before,
+.emotion-15 *::after {
   box-sizing: inherit;
 }
 
-.emotion-13 > span {
+.emotion-15 > span {
   width: 100%;
 }
 
-.emotion-11 {
+.emotion-13 {
   display: inline-block;
 }
 
@@ -21862,7 +23446,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   margin: 0.5em;
 }
 
-.emotion-60[class] > *:not(:last-child) {
+.emotion-66[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -22054,7 +23638,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-29 {
+.emotion-31 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22066,7 +23650,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-29 [role="img"] {
+.emotion-31 [role="img"] {
   display: block;
   color: #3272d9;
   -webkit-flex: 0 0 auto;
@@ -22074,21 +23658,21 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-29 [role="img"]:first-child {
+.emotion-31 [role="img"]:first-child {
   color: #3272d9;
   margin: 0 0.5em;
 }
 
-.emotion-29 :not([role="img"]) ~ [role="img"] {
+.emotion-31 :not([role="img"]) ~ [role="img"] {
   color: #2a854e;
 }
 
-.emotion-29 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+.emotion-31 :not([role="img"]) + [role="img"]:not(:last-of-type) {
   color: #2a854e;
   margin-left: 0.5em;
 }
 
-.emotion-28 {
+.emotion-30 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -22110,27 +23694,27 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-28 *,
-.emotion-28 *::before,
-.emotion-28 *::after {
+.emotion-30 *,
+.emotion-30 *::before,
+.emotion-30 *::after {
   box-sizing: inherit;
 }
 
-.emotion-28:hover > div:last-child {
+.emotion-30:hover > div:last-child {
   border-color: #3ba164;
 }
 
-.emotion-28:focus > div:last-child {
+.emotion-30:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-28:active > div:last-child {
+.emotion-30:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-28 [role="img"] {
+.emotion-30 [role="img"] {
   display: block;
   color: #3272d9;
   -webkit-flex: 0 0 auto;
@@ -22138,21 +23722,21 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-28 [role="img"]:first-child {
+.emotion-30 [role="img"]:first-child {
   color: #3272d9;
   margin: 0 0.5em;
 }
 
-.emotion-28 :not([role="img"]) ~ [role="img"] {
+.emotion-30 :not([role="img"]) ~ [role="img"] {
   color: #2a854e;
 }
 
-.emotion-28 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+.emotion-30 :not([role="img"]) + [role="img"]:not(:last-of-type) {
   color: #2a854e;
   margin-left: 0.5em;
 }
 
-.emotion-21 {
+.emotion-23 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22176,52 +23760,52 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-21::-webkit-input-placeholder {
+.emotion-23::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-21::-moz-placeholder {
+.emotion-23::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-21:-ms-input-placeholder {
+.emotion-23:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-21::placeholder {
+.emotion-23::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-21::-ms-input-placeholder {
+.emotion-23::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-21:-ms-input-placeholder {
+.emotion-23:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-21::-ms-clear {
+.emotion-23::-ms-clear {
   display: none;
 }
 
-.emotion-21:focus ~ div:last-child {
+.emotion-23:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-27 {
+.emotion-29 {
   background-color: #ffffff;
   border-color: #2a854e;
   border-radius: 0.1875em;
@@ -22235,7 +23819,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-49 {
+.emotion-53 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22247,7 +23831,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-49 [role="img"] {
+.emotion-53 [role="img"] {
   display: block;
   color: #3272d9;
   -webkit-flex: 0 0 auto;
@@ -22255,21 +23839,21 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-49 [role="img"]:first-child {
+.emotion-53 [role="img"]:first-child {
   color: #3272d9;
   margin: 0 0.5em;
 }
 
-.emotion-49 :not([role="img"]) ~ [role="img"] {
+.emotion-53 :not([role="img"]) ~ [role="img"] {
   color: #ad5f00;
 }
 
-.emotion-49 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+.emotion-53 :not([role="img"]) + [role="img"]:not(:last-of-type) {
   color: #ad5f00;
   margin-left: 0.5em;
 }
 
-.emotion-48 {
+.emotion-52 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -22291,27 +23875,27 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-48 *,
-.emotion-48 *::before,
-.emotion-48 *::after {
+.emotion-52 *,
+.emotion-52 *::before,
+.emotion-52 *::after {
   box-sizing: inherit;
 }
 
-.emotion-48:hover > div:last-child {
+.emotion-52:hover > div:last-child {
   border-color: #cf7911;
 }
 
-.emotion-48:focus > div:last-child {
+.emotion-52:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-48:active > div:last-child {
+.emotion-52:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-48 [role="img"] {
+.emotion-52 [role="img"] {
   display: block;
   color: #3272d9;
   -webkit-flex: 0 0 auto;
@@ -22319,21 +23903,21 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   flex: 0 0 auto;
 }
 
-.emotion-48 [role="img"]:first-child {
+.emotion-52 [role="img"]:first-child {
   color: #3272d9;
   margin: 0 0.5em;
 }
 
-.emotion-48 :not([role="img"]) ~ [role="img"] {
+.emotion-52 :not([role="img"]) ~ [role="img"] {
   color: #ad5f00;
 }
 
-.emotion-48 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+.emotion-52 :not([role="img"]) + [role="img"]:not(:last-of-type) {
   color: #ad5f00;
   margin-left: 0.5em;
 }
 
-.emotion-41 {
+.emotion-45 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -22357,52 +23941,52 @@ exports[`Select demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-41::-webkit-input-placeholder {
+.emotion-45::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::-moz-placeholder {
+.emotion-45::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41:-ms-input-placeholder {
+.emotion-45:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::placeholder {
+.emotion-45::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::-ms-input-placeholder {
+.emotion-45::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41:-ms-input-placeholder {
+.emotion-45:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::-ms-clear {
+.emotion-45::-ms-clear {
   display: none;
 }
 
-.emotion-41:focus ~ div:last-child {
+.emotion-45:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-47 {
+.emotion-51 {
   background-color: #ffffff;
   border-color: #ad5f00;
   border-radius: 0.1875em;
@@ -22418,7 +24002,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
 
 <Styled(div)>
   <div
-    className="emotion-60"
+    className="emotion-66"
   >
     <Select
       data={
@@ -22480,7 +24064,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
         variant="danger"
       >
         <Select
-          className="emotion-15"
+          className="emotion-17"
           data={
             Array [
               Object {
@@ -22517,7 +24101,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
           variant="danger"
         >
           <Themed(Dropdown)
-            className="emotion-15"
+            className="emotion-17"
             data={
               Array [
                 Object {
@@ -22556,7 +24140,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-15"
+                  className="emotion-17"
                   data={
                     Array [
                       Object {
@@ -22593,7 +24177,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                   variant="danger"
                 >
                   <Popover
-                    className="emotion-15"
+                    className="emotion-17"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -22617,7 +24201,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                     variant="danger"
                   >
                     <Popover
-                      className="emotion-15"
+                      className="emotion-17"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -22642,12 +24226,12 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                       variant="danger"
                     >
                       <Popover
-                        className="emotion-13"
+                        className="emotion-15"
                         id="select-49"
                         tag="span"
                       >
                         <span
-                          className="emotion-13"
+                          className="emotion-15"
                           id="select-49"
                         >
                           <PopoverTrigger
@@ -22671,11 +24255,11 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-11"
+                                className="emotion-13"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-11"
+                                  className="emotion-13"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-49-content"
@@ -22759,147 +24343,219 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         tabIndex={0}
                                         variant="danger"
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-49-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-49-content"
                                           className="emotion-9"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                           variant="danger"
                                         >
-                                          <div
-                                            aria-describedby="select-49-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-49-content"
-                                            className="emotion-8"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                              variant="danger"
-                                            >
-                                              <div
-                                                className="emotion-1"
+                                                aria-describedby="select-49-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-49-content"
+                                                className="emotion-9"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
+                                                variant="danger"
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Select...
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <IconDanger
-                                              key="iconEnd"
-                                              size="1.5em"
-                                            >
-                                              <Icon
-                                                rtl={false}
-                                                size="1.5em"
-                                              >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <FauxControl
+                                                  aria-describedby="select-49-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-49-content"
+                                                  className="emotion-9"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
+                                                  variant="danger"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    aria-describedby="select-49-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-49-content"
+                                                    className="emotion-8"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconDanger>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-4"
-                                                  size="1.5em"
-                                                >
-                                                  <Icon
-                                                    className="emotion-4"
-                                                    rtl={false}
-                                                    size="1.5em"
-                                                  >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-4"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
+                                                      variant="danger"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-3"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-1"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay
-                                              variant="danger"
-                                            >
-                                              <div
-                                                className="emotion-7"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Select...
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <IconDanger
+                                                      key="iconEnd"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconDanger>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-4"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-4"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-4"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-3"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay
+                                                      variant="danger"
+                                                    >
+                                                      <div
+                                                        className="emotion-7"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -22978,7 +24634,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
         variant="success"
       >
         <Select
-          className="emotion-15"
+          className="emotion-17"
           data={
             Array [
               Object {
@@ -23015,7 +24671,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
           variant="success"
         >
           <Themed(Dropdown)
-            className="emotion-15"
+            className="emotion-17"
             data={
               Array [
                 Object {
@@ -23054,7 +24710,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-15"
+                  className="emotion-17"
                   data={
                     Array [
                       Object {
@@ -23091,7 +24747,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                   variant="success"
                 >
                   <Popover
-                    className="emotion-15"
+                    className="emotion-17"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -23115,7 +24771,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                     variant="success"
                   >
                     <Popover
-                      className="emotion-15"
+                      className="emotion-17"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -23140,12 +24796,12 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                       variant="success"
                     >
                       <Popover
-                        className="emotion-13"
+                        className="emotion-15"
                         id="select-52"
                         tag="span"
                       >
                         <span
-                          className="emotion-13"
+                          className="emotion-15"
                           id="select-52"
                         >
                           <PopoverTrigger
@@ -23169,11 +24825,11 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-11"
+                                className="emotion-13"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-11"
+                                  className="emotion-13"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-52-content"
@@ -23239,7 +24895,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-owns="select-52-content"
-                                        className="emotion-29"
+                                        className="emotion-31"
                                         control={[Function]}
                                         controlProps={
                                           Object {
@@ -23257,147 +24913,219 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         tabIndex={0}
                                         variant="success"
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-52-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-52-content"
-                                          className="emotion-29"
+                                          className="emotion-31"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                           variant="success"
                                         >
-                                          <div
-                                            aria-describedby="select-52-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-52-content"
-                                            className="emotion-28"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                              variant="success"
-                                            >
-                                              <div
-                                                className="emotion-21"
+                                                aria-describedby="select-52-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-52-content"
+                                                className="emotion-31"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
+                                                variant="success"
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Select...
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <IconSuccess
-                                              key="iconEnd"
-                                              size="1.5em"
-                                            >
-                                              <Icon
-                                                rtl={false}
-                                                size="1.5em"
-                                              >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <FauxControl
+                                                  aria-describedby="select-52-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-52-content"
+                                                  className="emotion-31"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
+                                                  variant="success"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    aria-describedby="select-52-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-52-content"
+                                                    className="emotion-30"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconSuccess>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-4"
-                                                  size="1.5em"
-                                                >
-                                                  <Icon
-                                                    className="emotion-4"
-                                                    rtl={false}
-                                                    size="1.5em"
-                                                  >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-4"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
+                                                      variant="success"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-3"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-23"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay
-                                              variant="success"
-                                            >
-                                              <div
-                                                className="emotion-27"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Select...
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <IconSuccess
+                                                      key="iconEnd"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconSuccess>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-4"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-4"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-4"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-3"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay
+                                                      variant="success"
+                                                    >
+                                                      <div
+                                                        className="emotion-29"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -23476,7 +25204,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
         variant="warning"
       >
         <Select
-          className="emotion-15"
+          className="emotion-17"
           data={
             Array [
               Object {
@@ -23513,7 +25241,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
           variant="warning"
         >
           <Themed(Dropdown)
-            className="emotion-15"
+            className="emotion-17"
             data={
               Array [
                 Object {
@@ -23552,7 +25280,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
             <ThemeProvider>
               <ThemeProvider>
                 <Dropdown
-                  className="emotion-15"
+                  className="emotion-17"
                   data={
                     Array [
                       Object {
@@ -23589,7 +25317,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                   variant="warning"
                 >
                   <Popover
-                    className="emotion-15"
+                    className="emotion-17"
                     content={[Function]}
                     focusTriggerOnClose={true}
                     hasArrow={true}
@@ -23613,7 +25341,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                     variant="warning"
                   >
                     <Popover
-                      className="emotion-15"
+                      className="emotion-17"
                       content={[Function]}
                       focusTriggerOnClose={true}
                       hasArrow={true}
@@ -23638,12 +25366,12 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                       variant="warning"
                     >
                       <Popover
-                        className="emotion-13"
+                        className="emotion-15"
                         id="select-55"
                         tag="span"
                       >
                         <span
-                          className="emotion-13"
+                          className="emotion-15"
                           id="select-55"
                         >
                           <PopoverTrigger
@@ -23667,11 +25395,11 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                               component="span"
                             >
                               <PopoverTrigger
-                                className="emotion-11"
+                                className="emotion-13"
                                 component="span"
                               >
                                 <span
-                                  className="emotion-11"
+                                  className="emotion-13"
                                 >
                                   <SelectTrigger
                                     aria-describedby="select-55-content"
@@ -23737,7 +25465,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         aria-expanded={false}
                                         aria-haspopup="listbox"
                                         aria-owns="select-55-content"
-                                        className="emotion-49"
+                                        className="emotion-53"
                                         control={[Function]}
                                         controlProps={
                                           Object {
@@ -23755,147 +25483,219 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         tabIndex={0}
                                         variant="warning"
                                       >
-                                        <FauxControl
+                                        <Themed(FauxControl)
+                                          afterItems={
+                                            Array [
+                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                              <input
+                                                name={undefined}
+                                                type="hidden"
+                                                value=""
+                                              />,
+                                            ]
+                                          }
                                           aria-describedby="select-55-content"
                                           aria-expanded={false}
                                           aria-haspopup="listbox"
                                           aria-owns="select-55-content"
-                                          className="emotion-49"
+                                          className="emotion-53"
                                           control={[Function]}
-                                          innerRef={[Function]}
+                                          controlProps={
+                                            Object {
+                                              "hasPlaceholder": true,
+                                              "variant": undefined,
+                                            }
+                                          }
+                                          fauxControlRef={[Function]}
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           onKeyUp={[Function]}
                                           role="button"
+                                          size="large"
                                           tabIndex={0}
                                           variant="warning"
                                         >
-                                          <div
-                                            aria-describedby="select-55-content"
-                                            aria-expanded={false}
-                                            aria-haspopup="listbox"
-                                            aria-owns="select-55-content"
-                                            className="emotion-48"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            onKeyUp={[Function]}
-                                            role="button"
-                                            tabIndex={0}
-                                          >
-                                            <Control
-                                              controlPropsIn={
-                                                Object {
-                                                  "hasPlaceholder": true,
-                                                  "variant": undefined,
+                                          <ThemeProvider>
+                                            <ThemeProvider>
+                                              <FauxControl
+                                                afterItems={
+                                                  Array [
+                                                    <withProps(Styled(IconArrowDropdownDown)) />,
+                                                    <input
+                                                      name={undefined}
+                                                      type="hidden"
+                                                      value=""
+                                                    />,
+                                                  ]
                                                 }
-                                              }
-                                              hasPlaceholder={true}
-                                              key="control"
-                                              size="large"
-                                              variant="warning"
-                                            >
-                                              <div
-                                                className="emotion-41"
+                                                aria-describedby="select-55-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-55-content"
+                                                className="emotion-53"
+                                                control={[Function]}
+                                                controlProps={
+                                                  Object {
+                                                    "hasPlaceholder": true,
+                                                    "variant": undefined,
+                                                  }
+                                                }
+                                                fauxControlRef={[Function]}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
+                                                variant="warning"
                                               >
-                                                <TriggerContent>
-                                                  <span
-                                                    className="emotion-0"
-                                                  >
-                                                    Select...
-                                                  </span>
-                                                </TriggerContent>
-                                              </div>
-                                            </Control>
-                                            <IconWarning
-                                              key="iconEnd"
-                                              size="1.5em"
-                                            >
-                                              <Icon
-                                                rtl={false}
-                                                size="1.5em"
-                                              >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <FauxControl
+                                                  aria-describedby="select-55-content"
+                                                  aria-expanded={false}
+                                                  aria-haspopup="listbox"
+                                                  aria-owns="select-55-content"
+                                                  className="emotion-53"
+                                                  control={[Function]}
+                                                  innerRef={[Function]}
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onKeyUp={[Function]}
+                                                  role="button"
+                                                  tabIndex={0}
+                                                  variant="warning"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    aria-describedby="select-55-content"
+                                                    aria-expanded={false}
+                                                    aria-haspopup="listbox"
+                                                    aria-owns="select-55-content"
+                                                    className="emotion-52"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    role="button"
+                                                    tabIndex={0}
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M13.414 2.718l7.868 7.868c.78.78.78 2.047 0 2.828l-7.868 7.868c-.78.78-2.047.78-2.828 0l-7.868-7.868a2.001 2.001 0 0 1 0-2.828l7.868-7.868c.78-.78 2.047-.78 2.828 0zM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm1-3.958V8h-2v5.042h2z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconWarning>
-                                            <withProps(Styled(IconArrowDropdownDown))
-                                              key="arrow"
-                                            >
-                                              <Styled(IconArrowDropdownDown)
-                                                size="1.5em"
-                                              >
-                                                <IconArrowDropdownDown
-                                                  className="emotion-4"
-                                                  size="1.5em"
-                                                >
-                                                  <Icon
-                                                    className="emotion-4"
-                                                    rtl={false}
-                                                    size="1.5em"
-                                                  >
-                                                    <Styled(svg)
-                                                      aria-hidden={true}
-                                                      className="emotion-4"
-                                                      focusable="false"
-                                                      role="img"
-                                                      rtl={false}
-                                                      size="1.5em"
-                                                      viewBox="0 0 24 24"
+                                                    <Control
+                                                      controlPropsIn={
+                                                        Object {
+                                                          "hasPlaceholder": true,
+                                                          "variant": undefined,
+                                                        }
+                                                      }
+                                                      hasPlaceholder={true}
+                                                      key="control"
+                                                      size="large"
+                                                      variant="warning"
                                                     >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="emotion-3"
-                                                        focusable="false"
-                                                        role="img"
-                                                        viewBox="0 0 24 24"
+                                                      <div
+                                                        className="emotion-45"
                                                       >
-                                                        <g>
-                                                          <path
-                                                            d="M12 17.5l-8-8h16z"
-                                                          />
-                                                        </g>
-                                                      </svg>
-                                                    </Styled(svg)>
-                                                  </Icon>
-                                                </IconArrowDropdownDown>
-                                              </Styled(IconArrowDropdownDown)>
-                                            </withProps(Styled(IconArrowDropdownDown))>
-                                            <input
-                                              key="input"
-                                              type="hidden"
-                                              value=""
-                                            />
-                                            <Underlay
-                                              variant="warning"
-                                            >
-                                              <div
-                                                className="emotion-47"
-                                              />
-                                            </Underlay>
-                                          </div>
-                                        </FauxControl>
+                                                        <TriggerContent>
+                                                          <span
+                                                            className="emotion-0"
+                                                          >
+                                                            Select...
+                                                          </span>
+                                                        </TriggerContent>
+                                                      </div>
+                                                    </Control>
+                                                    <IconWarning
+                                                      key="iconEnd"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M13.414 2.718l7.868 7.868c.78.78.78 2.047 0 2.828l-7.868 7.868c-.78.78-2.047.78-2.828 0l-7.868-7.868a2.001 2.001 0 0 1 0-2.828l7.868-7.868c.78-.78 2.047-.78 2.828 0zM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm1-3.958V8h-2v5.042h2z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconWarning>
+                                                    <withProps(Styled(IconArrowDropdownDown))
+                                                      key="arrow"
+                                                    >
+                                                      <Styled(IconArrowDropdownDown)
+                                                        size="1.5em"
+                                                      >
+                                                        <IconArrowDropdownDown
+                                                          className="emotion-4"
+                                                          size="1.5em"
+                                                        >
+                                                          <Icon
+                                                            className="emotion-4"
+                                                            rtl={false}
+                                                            size="1.5em"
+                                                          >
+                                                            <Styled(svg)
+                                                              aria-hidden={true}
+                                                              className="emotion-4"
+                                                              focusable="false"
+                                                              role="img"
+                                                              rtl={false}
+                                                              size="1.5em"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <svg
+                                                                aria-hidden={true}
+                                                                className="emotion-3"
+                                                                focusable="false"
+                                                                role="img"
+                                                                viewBox="0 0 24 24"
+                                                              >
+                                                                <g>
+                                                                  <path
+                                                                    d="M12 17.5l-8-8h16z"
+                                                                  />
+                                                                </g>
+                                                              </svg>
+                                                            </Styled(svg)>
+                                                          </Icon>
+                                                        </IconArrowDropdownDown>
+                                                      </Styled(IconArrowDropdownDown)>
+                                                    </withProps(Styled(IconArrowDropdownDown))>
+                                                    <input
+                                                      key="input"
+                                                      type="hidden"
+                                                      value=""
+                                                    />
+                                                    <Underlay
+                                                      variant="warning"
+                                                    >
+                                                      <div
+                                                        className="emotion-51"
+                                                      />
+                                                    </Underlay>
+                                                  </div>
+                                                </FauxControl>
+                                              </FauxControl>
+                                            </ThemeProvider>
+                                          </ThemeProvider>
+                                        </Themed(FauxControl)>
                                       </SelectTrigger>
                                     </SelectTrigger>
                                   </SelectTrigger>
@@ -23919,15 +25719,15 @@ exports[`Select demo examples Snapshots: variants 1`] = `
 `;
 
 exports[`Select mounted in DOM render props item renders expected content 1`] = `
+.emotion-22 {
+  width: 100%;
+}
+
+.emotion-22 > span {
+  width: 100%;
+}
+
 .emotion-20 {
-  width: 100%;
-}
-
-.emotion-20 > span {
-  width: 100%;
-}
-
-.emotion-18 {
   box-sizing: border-box;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 16px;
@@ -23939,17 +25739,17 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
   width: 100%;
 }
 
-.emotion-18 *,
-.emotion-18 *::before,
-.emotion-18 *::after {
+.emotion-20 *,
+.emotion-20 *::before,
+.emotion-20 *::after {
   box-sizing: inherit;
 }
 
-.emotion-18 > span {
+.emotion-20 > span {
   width: 100%;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: inline-block;
 }
 
@@ -24159,7 +25959,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-14 {
+.emotion-16 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -24182,33 +25982,33 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
   z-index: 100;
 }
 
-.emotion-14 *,
-.emotion-14 *::before,
-.emotion-14 *::after {
+.emotion-16 *,
+.emotion-16 *::before,
+.emotion-16 *::after {
   box-sizing: inherit;
 }
 
-.emotion-14[data-placement^="top"] {
+.emotion-16[data-placement^="top"] {
   margin-bottom: 5px;
 }
 
-.emotion-14[data-placement^="bottom"] {
+.emotion-16[data-placement^="bottom"] {
   margin-top: 5px;
 }
 
-.emotion-14[data-placement^="left"] {
+.emotion-16[data-placement^="left"] {
   margin-right: 5px;
 }
 
-.emotion-14[data-placement^="right"] {
+.emotion-16[data-placement^="right"] {
   margin-left: 5px;
 }
 
-.emotion-14[data-x-out-of-boundaries] {
+.emotion-16[data-x-out-of-boundaries] {
   visibility: hidden;
 }
 
-.emotion-13 {
+.emotion-15 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -24219,22 +26019,22 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-13 *,
-.emotion-13 *::before,
-.emotion-13 *::after {
+.emotion-15 *,
+.emotion-15 *::before,
+.emotion-15 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12 {
+.emotion-14 {
   margin: 0.5em 0;
 }
 
-.emotion-12:first-child,
-.emotion-12 + .emotion-12 {
+.emotion-14:first-child,
+.emotion-14 + .emotion-14 {
   margin-top: 0;
 }
 
-.emotion-12:last-child {
+.emotion-14:last-child {
   margin-bottom: 0;
 }
 
@@ -24519,7 +26319,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
     size="large"
   >
     <Select
-      className="emotion-20"
+      className="emotion-22"
       data={
         Array [
           Object {
@@ -24666,7 +26466,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
       size="large"
     >
       <Themed(Dropdown)
-        className="emotion-20"
+        className="emotion-22"
         data={
           Array [
             Object {
@@ -24815,7 +26615,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
         <ThemeProvider>
           <ThemeProvider>
             <Dropdown
-              className="emotion-20"
+              className="emotion-22"
               data={
                 Array [
                   Object {
@@ -24962,7 +26762,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
               size="large"
             >
               <Popover
-                className="emotion-20"
+                className="emotion-22"
                 content={[Function]}
                 focusTriggerOnClose={true}
                 hasArrow={true}
@@ -24985,7 +26785,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                 triggerRef={[Function]}
               >
                 <Popover
-                  className="emotion-20"
+                  className="emotion-22"
                   content={[Function]}
                   focusTriggerOnClose={true}
                   hasArrow={true}
@@ -25009,12 +26809,12 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                   triggerRef={[Function]}
                 >
                   <Popover
-                    className="emotion-18"
+                    className="emotion-20"
                     id="select-122"
                     tag="span"
                   >
                     <span
-                      className="emotion-18"
+                      className="emotion-20"
                       id="select-122"
                     >
                       <PopoverTrigger
@@ -25038,11 +26838,11 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                           component="span"
                         >
                           <PopoverTrigger
-                            className="emotion-10"
+                            className="emotion-12"
                             component="span"
                           >
                             <span
-                              className="emotion-10"
+                              className="emotion-12"
                             >
                               <SelectTrigger
                                 aria-activedescendant="select-122-menu"
@@ -25126,7 +26926,17 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <FauxControl
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownUp)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value=""
+                                          />,
+                                        ]
+                                      }
                                       aria-activedescendant="select-122-menu"
                                       aria-describedby="select-122-content"
                                       aria-expanded={true}
@@ -25134,105 +26944,167 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                                       aria-owns="select-122-content"
                                       className="emotion-8"
                                       control={[Function]}
-                                      innerRef={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": true,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onKeyDown={[Function]}
                                       onKeyUp={[Function]}
                                       role="button"
+                                      size="large"
                                       tabIndex={0}
                                     >
-                                      <div
-                                        aria-activedescendant="select-122-menu"
-                                        aria-describedby="select-122-content"
-                                        aria-expanded={true}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-122-content"
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": true,
-                                              "variant": undefined,
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownUp)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value=""
+                                                />,
+                                              ]
                                             }
-                                          }
-                                          hasPlaceholder={true}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
+                                            aria-activedescendant="select-122-menu"
+                                            aria-describedby="select-122-content"
+                                            aria-expanded={true}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-122-content"
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": true,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
                                           >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Select...
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownUp))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownUp)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownUp
-                                              className="emotion-3"
-                                              size="1.5em"
+                                            <FauxControl
+                                              aria-activedescendant="select-122-menu"
+                                              aria-describedby="select-122-content"
+                                              aria-expanded={true}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-122-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
                                             >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
+                                              <div
+                                                aria-activedescendant="select-122-menu"
+                                                aria-describedby="select-122-content"
+                                                aria-expanded={true}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-122-content"
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
                                               >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={true}
+                                                  key="control"
+                                                  size="large"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
+                                                  <div
+                                                    className="emotion-1"
                                                   >
-                                                    <g>
-                                                      <path
-                                                        d="M12 7.5l8 8H4z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownUp>
-                                          </Styled(IconArrowDropdownUp)>
-                                        </withProps(Styled(IconArrowDropdownUp))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value=""
-                                        />
-                                        <Underlay>
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Select...
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownUp))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownUp)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownUp
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 7.5l8 8H4z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownUp>
+                                                  </Styled(IconArrowDropdownUp)>
+                                                </withProps(Styled(IconArrowDropdownUp))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value=""
+                                                />
+                                                <Underlay>
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </SelectTrigger>
@@ -25269,7 +27141,7 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                           placement="bottom-start"
                         >
                           <DropdownContent
-                            className="emotion-14"
+                            className="emotion-16"
                             id="select-122-content"
                             modifiers={
                               Object {
@@ -25283,8 +27155,1345 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                             placement="bottom-start"
                           >
                             <RtlPopper
-                              className="emotion-14"
+                              className="emotion-16"
                               id="select-122-content"
+                              modifiers={
+                                Object {
+                                  "contentWidth": Object {
+                                    "enabled": true,
+                                    "fn": [Function],
+                                  },
+                                }
+                              }
+                              onBlur={[Function]}
+                              placement="bottom-start"
+                              theme={
+                                Object {
+                                  "DropdownContent_backgroundColor": "#ffffff",
+                                  "DropdownContent_borderColor": "#ebeff5",
+                                  "DropdownContent_borderRadius": "0.1875em",
+                                  "DropdownContent_boxShadow": "0 2px 4px 0 rgba(0,0,0,0.2), 0 4px 8px 0 rgba(0,0,0,0.2)",
+                                  "DropdownContent_margin": "5px",
+                                  "DropdownContent_zIndex": 100,
+                                  "DropdownIcon_color": "#3272d9",
+                                  "DropdownIcon_marginHorizontal": "0.5em",
+                                  "Dropdown_backgroundColor": "#ffffff",
+                                  "Dropdown_borderColor": "#c8d1e0",
+                                  "Dropdown_borderColor_active": "#c8d1e0",
+                                  "Dropdown_borderColor_focus": "#c8d1e0",
+                                  "Dropdown_borderColor_hover": "#5691f0",
+                                  "Dropdown_borderRadius": "0.1875em",
+                                  "Dropdown_borderWidth": "1px",
+                                  "Dropdown_boxShadow_active": "0 0 0 1px #ffffff, 0 0 0 2px #1d5bbf",
+                                  "Dropdown_boxShadow_focus": "0 0 0 1px #ffffff, 0 0 0 2px #1d5bbf",
+                                  "Dropdown_color": "#333840",
+                                  "Dropdown_color_placeholder": "#8e99ab",
+                                  "Dropdown_color_readOnly": "#58606e",
+                                  "Dropdown_fontSize": "0.875em",
+                                  "Dropdown_fontSize_small": "0.75em",
+                                  "Dropdown_height_jumbo": "3.25em",
+                                  "Dropdown_height_large": "2.5em",
+                                  "Dropdown_height_medium": "2em",
+                                  "Dropdown_height_small": "1.5em",
+                                  "Dropdown_paddingHorizontal": "1em",
+                                  "Dropdown_paddingHorizontal_small": "0.5em",
+                                  "backgroundColor_active": "#ebeff5",
+                                  "backgroundColor_dangerPrimary": "#de1b1b",
+                                  "backgroundColor_dangerPrimary_active": "#b80d0d",
+                                  "backgroundColor_dangerPrimary_focus": "#de1b1b",
+                                  "backgroundColor_dangerPrimary_hover": "#f55353",
+                                  "backgroundColor_danger_active": "#fad4d4",
+                                  "backgroundColor_danger_focus": "#faf0f0",
+                                  "backgroundColor_danger_hover": "#faf0f0",
+                                  "backgroundColor_disabled": "#dde3ed",
+                                  "backgroundColor_focus": "#f5f7fa",
+                                  "backgroundColor_hover": "#f5f7fa",
+                                  "backgroundColor_successPrimary": "#2a854e",
+                                  "backgroundColor_successPrimary_active": "#20693d",
+                                  "backgroundColor_successPrimary_focus": "#2a854e",
+                                  "backgroundColor_successPrimary_hover": "#3ba164",
+                                  "backgroundColor_success_active": "#abedc5",
+                                  "backgroundColor_success_focus": "#e1faeb",
+                                  "backgroundColor_success_hover": "#e1faeb",
+                                  "backgroundColor_themePrimary": "#3272d9",
+                                  "backgroundColor_themePrimary_active": "#1d5bbf",
+                                  "backgroundColor_themePrimary_focus": "#3272d9",
+                                  "backgroundColor_themePrimary_hover": "#5691f0",
+                                  "backgroundColor_theme_selected": "#f0f5fc",
+                                  "backgroundColor_theme_selectedActive": "#accbfc",
+                                  "backgroundColor_theme_selectedHover": "#cfe0fc",
+                                  "backgroundColor_warningPrimary": "#ad5f00",
+                                  "backgroundColor_warningPrimary_active": "#8a4d03",
+                                  "backgroundColor_warningPrimary_focus": "#ad5f00",
+                                  "backgroundColor_warningPrimary_hover": "#cf7911",
+                                  "backgroundColor_warning_active": "#fad8af",
+                                  "backgroundColor_warning_focus": "#fcf2e6",
+                                  "backgroundColor_warning_hover": "#fcf2e6",
+                                  "borderColor": "#c8d1e0",
+                                  "borderColor_danger": "#de1b1b",
+                                  "borderColor_danger_active": "#b80d0d",
+                                  "borderColor_danger_focus": "#b80d0d",
+                                  "borderColor_danger_hover": "#f55353",
+                                  "borderColor_success": "#2a854e",
+                                  "borderColor_success_active": "#20693d",
+                                  "borderColor_success_focus": "#20693d",
+                                  "borderColor_success_hover": "#3ba164",
+                                  "borderColor_theme": "#3272d9",
+                                  "borderColor_theme_active": "#1d5bbf",
+                                  "borderColor_theme_focus": "#1d5bbf",
+                                  "borderColor_theme_hover": "#5691f0",
+                                  "borderColor_warning": "#ad5f00",
+                                  "borderColor_warning_active": "#8a4d03",
+                                  "borderColor_warning_focus": "#8a4d03",
+                                  "borderColor_warning_hover": "#cf7911",
+                                  "borderRadius_1": "0.1875em",
+                                  "boxShadow_1": "0 1px 2px 0 rgba(0,0,0,0.2), 0 2px 4px 0 rgba(0,0,0,0.2)",
+                                  "boxShadow_2": "0 2px 4px 0 rgba(0,0,0,0.2), 0 4px 8px 0 rgba(0,0,0,0.2)",
+                                  "boxShadow_3": "0 4px 8px 0 rgba(0,0,0,0.2), 0 8px 16px 0 rgba(0,0,0,0.2)",
+                                  "boxShadow_4": "0 8px 16px 0 rgba(0,0,0,0.2), 0 20px 16px -8px rgba(0,0,0,0.2)",
+                                  "boxShadow_5": "0 16px 24px 0 rgba(0,0,0,0.2), 0 32px 24px -16px rgba(0,0,0,0.2)",
+                                  "boxShadow_focusInner": "#ffffff",
+                                  "breakpoint_medium": "768px",
+                                  "breakpoint_narrow": "512px",
+                                  "breakpoint_wide": "1024px",
+                                  "color": "#333840",
+                                  "color_black": "#1d1f24",
+                                  "color_danger": "#de1b1b",
+                                  "color_dangerPrimary": "#ffffff",
+                                  "color_danger_active": "#b80d0d",
+                                  "color_danger_focus": "#de1b1b",
+                                  "color_danger_hover": "#f55353",
+                                  "color_disabled": "#afbacc",
+                                  "color_gray_10": "#f5f7fa",
+                                  "color_gray_100": "#333840",
+                                  "color_gray_20": "#ebeff5",
+                                  "color_gray_30": "#dde3ed",
+                                  "color_gray_40": "#c8d1e0",
+                                  "color_gray_50": "#afbacc",
+                                  "color_gray_60": "#8e99ab",
+                                  "color_gray_70": "#707a8a",
+                                  "color_gray_80": "#58606e",
+                                  "color_gray_90": "#434a54",
+                                  "color_inverted": "#ffffff",
+                                  "color_mouse": "#58606e",
+                                  "color_readOnly": "#58606e",
+                                  "color_required": "#de1b1b",
+                                  "color_success": "#2a854e",
+                                  "color_successPrimary": "#ffffff",
+                                  "color_success_active": "#20693d",
+                                  "color_success_focus": "#2a854e",
+                                  "color_success_hover": "#3ba164",
+                                  "color_theme": "#3272d9",
+                                  "color_themePrimary": "#ffffff",
+                                  "color_theme_10": "#f0f5fc",
+                                  "color_theme_100": "#15233b",
+                                  "color_theme_20": "#cfe0fc",
+                                  "color_theme_30": "#accbfc",
+                                  "color_theme_40": "#84b1fa",
+                                  "color_theme_50": "#5691f0",
+                                  "color_theme_60": "#3272d9",
+                                  "color_theme_70": "#1d5bbf",
+                                  "color_theme_80": "#114599",
+                                  "color_theme_90": "#103570",
+                                  "color_theme_active": "#1d5bbf",
+                                  "color_theme_focus": "#3272d9",
+                                  "color_theme_hover": "#5691f0",
+                                  "color_warning": "#ad5f00",
+                                  "color_warningPrimary": "#ffffff",
+                                  "color_warning_active": "#8a4d03",
+                                  "color_warning_focus": "#ad5f00",
+                                  "color_warning_hover": "#cf7911",
+                                  "color_white": "#ffffff",
+                                  "direction": "ltr",
+                                  "fontFamily": "\\"Open Sans\\"",
+                                  "fontFamily_monospace": "\\"SF Mono\\", \\"Droid Sans Mono\\", \\"Source Code Pro\\", Monaco, Consolas, \\"Courier New\\", Courier, monospace",
+                                  "fontFamily_system": "-apple-system, system-ui, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
+                                  "fontSize_base": "16px",
+                                  "fontSize_mouse": "0.6875em",
+                                  "fontSize_prose": "1em",
+                                  "fontSize_ui": "0.875em",
+                                  "fontWeight_bold": 700,
+                                  "fontWeight_extraBold": 800,
+                                  "fontWeight_regular": 400,
+                                  "fontWeight_semiBold": 600,
+                                  "h1_color": "#333840",
+                                  "h1_fontSize": "2.125em",
+                                  "h1_fontWeight": 800,
+                                  "h2_color": "#58606e",
+                                  "h2_fontSize": "1.75em",
+                                  "h2_fontWeight": 700,
+                                  "h3_color": "#58606e",
+                                  "h3_fontSize": "1.375em",
+                                  "h3_fontWeight": 700,
+                                  "h4_color": "#58606e",
+                                  "h4_fontSize": "1.125em",
+                                  "h4_fontWeight": 700,
+                                  "h5_color": "#333840",
+                                  "h5_fontSize": "0.875em",
+                                  "h5_fontWeight": 700,
+                                  "h6_color": "#58606e",
+                                  "h6_fontSize": "0.875em",
+                                  "h6_fontWeight": 400,
+                                  "icon_color": "#58606e",
+                                  "icon_color_danger": "#de1b1b",
+                                  "icon_color_success": "#2a854e",
+                                  "icon_color_theme": "#3272d9",
+                                  "icon_color_warning": "#ad5f00",
+                                  "input_backgroundColor": "#ffffff",
+                                  "input_backgroundColor_disabled": "#ebeff5",
+                                  "input_color_placeholder": "#8e99ab",
+                                  "lineHeight": 1.25,
+                                  "lineHeight_heading": 1.25,
+                                  "lineHeight_heading_small": 1.5,
+                                  "lineHeight_prose": 1.5,
+                                  "panel_backgroundColor": "#ffffff",
+                                  "panel_backgroundColor_inverted": "#434a54",
+                                  "panel_borderColor": "#ebeff5",
+                                  "panel_borderColor_inverted": "#434a54",
+                                  "size_jumbo": "3.25em",
+                                  "size_large": "2.5em",
+                                  "size_medium": "2em",
+                                  "size_small": "1.5em",
+                                  "space_inline_lg": "1.5em",
+                                  "space_inline_md": "1em",
+                                  "space_inline_sm": "0.5em",
+                                  "space_inline_xl": "2em",
+                                  "space_inline_xs": "0.25em",
+                                  "space_inline_xxl": "4em",
+                                  "space_inline_xxs": "0.125em",
+                                  "space_inset_lg": "1.5em",
+                                  "space_inset_md": "1em",
+                                  "space_inset_sm": "0.5em",
+                                  "space_stack_lg": "1.5em",
+                                  "space_stack_md": "1em",
+                                  "space_stack_sm": "0.5em",
+                                  "space_stack_xl": "2em",
+                                  "space_stack_xs": "0.25em",
+                                  "space_stack_xxl": "4em",
+                                  "space_stack_xxs": "0.125em",
+                                  "well_backgroundColor": "#ebeff5",
+                                  "well_backgroundColor_danger": "#fad4d4",
+                                  "well_backgroundColor_success": "#abedc5",
+                                  "well_backgroundColor_warning": "#fad8af",
+                                  "well_borderColor_danger": "#fa8e8e",
+                                  "well_borderColor_success": "#57c282",
+                                  "well_borderColor_warning": "#e89c3f",
+                                  "zIndex_100": 100,
+                                  "zIndex_1600": 1600,
+                                  "zIndex_200": 200,
+                                  "zIndex_400": 400,
+                                  "zIndex_800": 800,
+                                }
+                              }
+                            >
+                              <Popper
+                                className="emotion-16"
+                                component="div"
+                                eventsEnabled={true}
+                                id="select-122-content"
+                                modifiers={
+                                  Object {
+                                    "contentWidth": Object {
+                                      "enabled": true,
+                                      "fn": [Function],
+                                    },
+                                  }
+                                }
+                                onBlur={[Function]}
+                                placement="bottom-start"
+                                positionFixed={false}
+                              >
+                                <div
+                                  className="emotion-16"
+                                  id="select-122-content"
+                                  onBlur={[Function]}
+                                  style={
+                                    Object {
+                                      "opacity": 0,
+                                      "pointerEvents": "none",
+                                      "position": "absolute",
+                                    }
+                                  }
+                                >
+                                  <Menu
+                                    data={
+                                      Array [
+                                        Object {
+                                          "onClick": [MockFunction],
+                                          "text": "A item",
+                                          "value": "A",
+                                        },
+                                        Object {
+                                          "onClick": [MockFunction],
+                                          "text": "B item",
+                                          "value": "B",
+                                        },
+                                        Object {
+                                          "onClick": [MockFunction],
+                                          "text": "C item",
+                                          "value": "C",
+                                        },
+                                      ]
+                                    }
+                                    id="select-122-menu"
+                                    item={[Function]}
+                                    itemKey="value"
+                                    role="listbox"
+                                  >
+                                    <Menu
+                                      id="select-122-menu"
+                                      item={[Function]}
+                                      itemKey="value"
+                                      role="listbox"
+                                    >
+                                      <div
+                                        className="emotion-15"
+                                        id="select-122-menu"
+                                        role="listbox"
+                                      >
+                                        <MenuGroup
+                                          key="0"
+                                        >
+                                          <MenuGroup>
+                                            <div
+                                              className="emotion-14"
+                                            >
+                                              <MenuItem
+                                                index={0}
+                                                item={
+                                                  Object {
+                                                    "onClick": [MockFunction],
+                                                    "text": "A item",
+                                                    "value": "A",
+                                                  }
+                                                }
+                                                key="A"
+                                                onClick={[MockFunction]}
+                                                render={[Function]}
+                                                text="A item"
+                                                value="A"
+                                              >
+                                                <div
+                                                  aria-selected={false}
+                                                  id="select-122-item-0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  role="option"
+                                                  tabIndex={null}
+                                                  value="A"
+                                                >
+                                                  A item
+                                                </div>
+                                              </MenuItem>
+                                              <MenuItem
+                                                index={1}
+                                                item={
+                                                  Object {
+                                                    "onClick": [MockFunction],
+                                                    "text": "B item",
+                                                    "value": "B",
+                                                  }
+                                                }
+                                                key="B"
+                                                onClick={[MockFunction]}
+                                                render={[Function]}
+                                                text="B item"
+                                                value="B"
+                                              >
+                                                <div
+                                                  aria-selected={false}
+                                                  id="select-122-item-1"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  role="option"
+                                                  tabIndex={null}
+                                                  value="B"
+                                                >
+                                                  B item
+                                                </div>
+                                              </MenuItem>
+                                              <MenuItem
+                                                index={2}
+                                                item={
+                                                  Object {
+                                                    "onClick": [MockFunction],
+                                                    "text": "C item",
+                                                    "value": "C",
+                                                  }
+                                                }
+                                                key="C"
+                                                onClick={[MockFunction]}
+                                                render={[Function]}
+                                                text="C item"
+                                                value="C"
+                                              >
+                                                <div
+                                                  aria-selected={false}
+                                                  id="select-122-item-2"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  role="option"
+                                                  tabIndex={null}
+                                                  value="C"
+                                                >
+                                                  C item
+                                                </div>
+                                              </MenuItem>
+                                            </div>
+                                          </MenuGroup>
+                                        </MenuGroup>
+                                      </div>
+                                    </Menu>
+                                  </Menu>
+                                </div>
+                              </Popper>
+                            </RtlPopper>
+                          </DropdownContent>
+                        </DropdownContent>
+                      </DropdownContent>
+                      <EventListener
+                        listeners={
+                          Array [
+                            Object {
+                              "event": "click",
+                              "handler": [Function],
+                              "options": true,
+                              "target": "document",
+                            },
+                            Object {
+                              "event": "keydown",
+                              "handler": [Function],
+                              "options": true,
+                              "target": "document",
+                            },
+                          ]
+                        }
+                      />
+                    </span>
+                  </Popover>
+                </Popover>
+              </Popover>
+            </Dropdown>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(Dropdown)>
+    </Select>
+  </Select>
+</Select>
+`;
+
+exports[`Select mounted in DOM render props menu renders expected content 1`] = `
+.emotion-20 {
+  width: 100%;
+}
+
+.emotion-20 > span {
+  width: 100%;
+}
+
+.emotion-18 {
+  box-sizing: border-box;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-18 *,
+.emotion-18 *::before,
+.emotion-18 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-18 > span {
+  width: 100%;
+}
+
+.emotion-12 {
+  display: inline-block;
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-8 [role="img"] {
+  display: block;
+  color: #3272d9;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-8 [role="img"]:first-child {
+  color: #3272d9;
+  margin: 0 0.5em;
+}
+
+.emotion-8 :not([role="img"]) ~ [role="img"] {
+  color: #3272d9;
+}
+
+.emotion-8 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+  color: #3272d9;
+  margin-left: 0.5em;
+}
+
+.emotion-7 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  z-index: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-7 *,
+.emotion-7 *::before,
+.emotion-7 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-7:hover > div:last-child {
+  border-color: #5691f0;
+}
+
+.emotion-7:focus > div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-7:active > div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-7 [role="img"] {
+  display: block;
+  color: #3272d9;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-7 [role="img"]:first-child {
+  color: #3272d9;
+  margin: 0 0.5em;
+}
+
+.emotion-7 :not([role="img"]) ~ [role="img"] {
+  color: #3272d9;
+}
+
+.emotion-7 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+  color: #3272d9;
+  margin-left: 0.5em;
+}
+
+.emotion-0 {
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 100%;
+}
+
+.emotion-3 {
+  margin: 0.5em;
+}
+
+.emotion-2 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1.5em;
+  width: 1.5em;
+  margin: 0.5em;
+}
+
+.emotion-6 {
+  background-color: #ffffff;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: -1;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: teal;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  height: 2.857142857142857em;
+  min-width: 0;
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-size: 0.875em;
+  font-style: italic;
+  outline: 0;
+  padding-left: 1.1428571428571428em;
+  padding-right: 1.1428571428571428em;
+}
+
+.emotion-1::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-1::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-1:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-1::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-1::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-1:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-1::-ms-clear {
+  display: none;
+}
+
+.emotion-1:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-14 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ffffff;
+  border: 1px solid #ebeff5;
+  border-radius: 0.1875em;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.2),0 4px 8px 0 rgba(0,0,0,0.2);
+  max-height: 23em;
+  overflow-y: auto;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 14em;
+  z-index: 100;
+}
+
+.emotion-14 *,
+.emotion-14 *::before,
+.emotion-14 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-14[data-placement^="top"] {
+  margin-bottom: 5px;
+}
+
+.emotion-14[data-placement^="bottom"] {
+  margin-top: 5px;
+}
+
+.emotion-14[data-placement^="left"] {
+  margin-right: 5px;
+}
+
+.emotion-14[data-placement^="right"] {
+  margin-left: 5px;
+}
+
+.emotion-14[data-x-out-of-boundaries] {
+  visibility: hidden;
+}
+
+<Select
+  data={
+    Array [
+      Object {
+        "onClick": [MockFunction],
+        "text": "A item",
+        "value": "A",
+      },
+      Object {
+        "onClick": [MockFunction],
+        "text": "B item",
+        "value": "B",
+      },
+      Object {
+        "onClick": [MockFunction],
+        "text": "C item",
+        "value": "C",
+      },
+    ]
+  }
+  isOpen={true}
+  itemKey="value"
+  menu={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "helpers": Object {
+              "close": [Function],
+              "focusTrigger": [Function],
+              "open": [Function],
+            },
+            "props": Object {
+              "data": Array [
+                Object {
+                  "onClick": [MockFunction],
+                  "text": "A item",
+                  "value": "A",
+                },
+                Object {
+                  "onClick": [MockFunction],
+                  "text": "B item",
+                  "value": "B",
+                },
+                Object {
+                  "onClick": [MockFunction],
+                  "text": "C item",
+                  "value": "C",
+                },
+              ],
+              "id": "select-118-menu",
+              "item": [Function],
+              "itemKey": "value",
+              "role": "listbox",
+            },
+            "state": Object {
+              "highlightedIndex": undefined,
+              "isOpen": true,
+              "selectedItem": undefined,
+            },
+          },
+        ],
+      ],
+    }
+  }
+  placeholder="Select..."
+  placement="bottom-start"
+  size="large"
+>
+  <Select
+    data={
+      Array [
+        Object {
+          "onClick": [MockFunction],
+          "text": "A item",
+          "value": "A",
+        },
+        Object {
+          "onClick": [MockFunction],
+          "text": "B item",
+          "value": "B",
+        },
+        Object {
+          "onClick": [MockFunction],
+          "text": "C item",
+          "value": "C",
+        },
+      ]
+    }
+    id="select-118"
+    isOpen={true}
+    itemKey="value"
+    menu={[Function]}
+    modifiers={
+      Object {
+        "contentWidth": Object {
+          "enabled": true,
+          "fn": [Function],
+        },
+      }
+    }
+    onClose={[Function]}
+    onOpen={[Function]}
+    placeholder="Select..."
+    placement="bottom-start"
+    size="large"
+  >
+    <Select
+      className="emotion-20"
+      data={
+        Array [
+          Object {
+            "onClick": [MockFunction],
+            "text": "A item",
+            "value": "A",
+          },
+          Object {
+            "onClick": [MockFunction],
+            "text": "B item",
+            "value": "B",
+          },
+          Object {
+            "onClick": [MockFunction],
+            "text": "C item",
+            "value": "C",
+          },
+        ]
+      }
+      id="select-118"
+      isOpen={true}
+      itemKey="value"
+      menu={[Function]}
+      modifiers={
+        Object {
+          "contentWidth": Object {
+            "enabled": true,
+            "fn": [Function],
+          },
+        }
+      }
+      onClose={[Function]}
+      onOpen={[Function]}
+      placeholder="Select..."
+      placement="bottom-start"
+      size="large"
+    >
+      <Themed(Dropdown)
+        className="emotion-20"
+        data={
+          Array [
+            Object {
+              "onClick": [MockFunction],
+              "text": "A item",
+              "value": "A",
+            },
+            Object {
+              "onClick": [MockFunction],
+              "text": "B item",
+              "value": "B",
+            },
+            Object {
+              "onClick": [MockFunction],
+              "text": "C item",
+              "value": "C",
+            },
+          ]
+        }
+        id="select-118"
+        isOpen={true}
+        itemKey="value"
+        menu={[Function]}
+        modifiers={
+          Object {
+            "contentWidth": Object {
+              "enabled": true,
+              "fn": [Function],
+            },
+          }
+        }
+        onClose={[Function]}
+        onOpen={[Function]}
+        placeholder="Select..."
+        placement="bottom-start"
+        size="large"
+      >
+        <ThemeProvider>
+          <ThemeProvider>
+            <Dropdown
+              className="emotion-20"
+              data={
+                Array [
+                  Object {
+                    "onClick": [MockFunction],
+                    "text": "A item",
+                    "value": "A",
+                  },
+                  Object {
+                    "onClick": [MockFunction],
+                    "text": "B item",
+                    "value": "B",
+                  },
+                  Object {
+                    "onClick": [MockFunction],
+                    "text": "C item",
+                    "value": "C",
+                  },
+                ]
+              }
+              id="select-118"
+              isOpen={true}
+              itemKey="value"
+              menu={[Function]}
+              modifiers={
+                Object {
+                  "contentWidth": Object {
+                    "enabled": true,
+                    "fn": [Function],
+                  },
+                }
+              }
+              onClose={[Function]}
+              onOpen={[Function]}
+              placeholder="Select..."
+              placement="bottom-start"
+              size="large"
+            >
+              <Popover
+                className="emotion-20"
+                content={[Function]}
+                focusTriggerOnClose={true}
+                hasArrow={true}
+                id="select-118"
+                isOpen={true}
+                itemKey="value"
+                modifiers={
+                  Object {
+                    "contentWidth": Object {
+                      "enabled": true,
+                      "fn": [Function],
+                    },
+                  }
+                }
+                onClose={[Function]}
+                onOpen={[Function]}
+                placeholder="Select..."
+                placement="bottom-start"
+                size="large"
+                triggerRef={[Function]}
+              >
+                <Popover
+                  className="emotion-20"
+                  content={[Function]}
+                  focusTriggerOnClose={true}
+                  hasArrow={true}
+                  id="select-118"
+                  isOpen={true}
+                  itemKey="value"
+                  modifiers={
+                    Object {
+                      "contentWidth": Object {
+                        "enabled": true,
+                        "fn": [Function],
+                      },
+                    }
+                  }
+                  onClose={[Function]}
+                  onOpen={[Function]}
+                  placeholder="Select..."
+                  placement="bottom-start"
+                  size="large"
+                  tag="span"
+                  triggerRef={[Function]}
+                >
+                  <Popover
+                    className="emotion-18"
+                    id="select-118"
+                    tag="span"
+                  >
+                    <span
+                      className="emotion-18"
+                      id="select-118"
+                    >
+                      <PopoverTrigger
+                        aria-activedescendant="select-118-menu"
+                        aria-describedby="select-118-content"
+                        aria-expanded={true}
+                        aria-haspopup="listbox"
+                        aria-owns="select-118-content"
+                        isOpen={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyUp={[Function]}
+                        placeholder="Select..."
+                        role="button"
+                        size="large"
+                        tabIndex={0}
+                        triggerRef={[Function]}
+                      >
+                        <PopoverTrigger
+                          component="span"
+                        >
+                          <PopoverTrigger
+                            className="emotion-12"
+                            component="span"
+                          >
+                            <span
+                              className="emotion-12"
+                            >
+                              <SelectTrigger
+                                aria-activedescendant="select-118-menu"
+                                aria-describedby="select-118-content"
+                                aria-expanded={true}
+                                aria-haspopup="listbox"
+                                aria-owns="select-118-content"
+                                isOpen={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Select..."
+                                role="button"
+                                size="large"
+                                tabIndex={0}
+                                triggerRef={[Function]}
+                              >
+                                <SelectTrigger
+                                  afterItems={
+                                    Array [
+                                      <withProps(Styled(IconArrowDropdownUp)) />,
+                                      <input
+                                        name={undefined}
+                                        type="hidden"
+                                        value=""
+                                      />,
+                                    ]
+                                  }
+                                  aria-activedescendant="select-118-menu"
+                                  aria-describedby="select-118-content"
+                                  aria-expanded={true}
+                                  aria-haspopup="listbox"
+                                  aria-owns="select-118-content"
+                                  control={[Function]}
+                                  controlProps={
+                                    Object {
+                                      "hasPlaceholder": true,
+                                      "variant": undefined,
+                                    }
+                                  }
+                                  fauxControlRef={[Function]}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  role="button"
+                                  size="large"
+                                  tabIndex={0}
+                                >
+                                  <SelectTrigger
+                                    afterItems={
+                                      Array [
+                                        <withProps(Styled(IconArrowDropdownUp)) />,
+                                        <input
+                                          name={undefined}
+                                          type="hidden"
+                                          value=""
+                                        />,
+                                      ]
+                                    }
+                                    aria-activedescendant="select-118-menu"
+                                    aria-describedby="select-118-content"
+                                    aria-expanded={true}
+                                    aria-haspopup="listbox"
+                                    aria-owns="select-118-content"
+                                    className="emotion-8"
+                                    control={[Function]}
+                                    controlProps={
+                                      Object {
+                                        "hasPlaceholder": true,
+                                        "variant": undefined,
+                                      }
+                                    }
+                                    fauxControlRef={[Function]}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onKeyUp={[Function]}
+                                    role="button"
+                                    size="large"
+                                    tabIndex={0}
+                                  >
+                                    <Themed(FauxControl)
+                                      afterItems={
+                                        Array [
+                                          <withProps(Styled(IconArrowDropdownUp)) />,
+                                          <input
+                                            name={undefined}
+                                            type="hidden"
+                                            value=""
+                                          />,
+                                        ]
+                                      }
+                                      aria-activedescendant="select-118-menu"
+                                      aria-describedby="select-118-content"
+                                      aria-expanded={true}
+                                      aria-haspopup="listbox"
+                                      aria-owns="select-118-content"
+                                      className="emotion-8"
+                                      control={[Function]}
+                                      controlProps={
+                                        Object {
+                                          "hasPlaceholder": true,
+                                          "variant": undefined,
+                                        }
+                                      }
+                                      fauxControlRef={[Function]}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      role="button"
+                                      size="large"
+                                      tabIndex={0}
+                                    >
+                                      <ThemeProvider>
+                                        <ThemeProvider>
+                                          <FauxControl
+                                            afterItems={
+                                              Array [
+                                                <withProps(Styled(IconArrowDropdownUp)) />,
+                                                <input
+                                                  name={undefined}
+                                                  type="hidden"
+                                                  value=""
+                                                />,
+                                              ]
+                                            }
+                                            aria-activedescendant="select-118-menu"
+                                            aria-describedby="select-118-content"
+                                            aria-expanded={true}
+                                            aria-haspopup="listbox"
+                                            aria-owns="select-118-content"
+                                            className="emotion-8"
+                                            control={[Function]}
+                                            controlProps={
+                                              Object {
+                                                "hasPlaceholder": true,
+                                                "variant": undefined,
+                                              }
+                                            }
+                                            fauxControlRef={[Function]}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            onKeyUp={[Function]}
+                                            role="button"
+                                            size="large"
+                                            tabIndex={0}
+                                          >
+                                            <FauxControl
+                                              aria-activedescendant="select-118-menu"
+                                              aria-describedby="select-118-content"
+                                              aria-expanded={true}
+                                              aria-haspopup="listbox"
+                                              aria-owns="select-118-content"
+                                              className="emotion-8"
+                                              control={[Function]}
+                                              innerRef={[Function]}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              onKeyUp={[Function]}
+                                              role="button"
+                                              tabIndex={0}
+                                            >
+                                              <div
+                                                aria-activedescendant="select-118-menu"
+                                                aria-describedby="select-118-content"
+                                                aria-expanded={true}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-118-content"
+                                                className="emotion-7"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                role="button"
+                                                tabIndex={0}
+                                              >
+                                                <Control
+                                                  controlPropsIn={
+                                                    Object {
+                                                      "hasPlaceholder": true,
+                                                      "variant": undefined,
+                                                    }
+                                                  }
+                                                  hasPlaceholder={true}
+                                                  key="control"
+                                                  size="large"
+                                                >
+                                                  <div
+                                                    className="emotion-1"
+                                                  >
+                                                    <TriggerContent>
+                                                      <span
+                                                        className="emotion-0"
+                                                      >
+                                                        Select...
+                                                      </span>
+                                                    </TriggerContent>
+                                                  </div>
+                                                </Control>
+                                                <withProps(Styled(IconArrowDropdownUp))
+                                                  key="arrow"
+                                                >
+                                                  <Styled(IconArrowDropdownUp)
+                                                    size="1.5em"
+                                                  >
+                                                    <IconArrowDropdownUp
+                                                      className="emotion-3"
+                                                      size="1.5em"
+                                                    >
+                                                      <Icon
+                                                        className="emotion-3"
+                                                        rtl={false}
+                                                        size="1.5em"
+                                                      >
+                                                        <Styled(svg)
+                                                          aria-hidden={true}
+                                                          className="emotion-3"
+                                                          focusable="false"
+                                                          role="img"
+                                                          rtl={false}
+                                                          size="1.5em"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="emotion-2"
+                                                            focusable="false"
+                                                            role="img"
+                                                            viewBox="0 0 24 24"
+                                                          >
+                                                            <g>
+                                                              <path
+                                                                d="M12 7.5l8 8H4z"
+                                                              />
+                                                            </g>
+                                                          </svg>
+                                                        </Styled(svg)>
+                                                      </Icon>
+                                                    </IconArrowDropdownUp>
+                                                  </Styled(IconArrowDropdownUp)>
+                                                </withProps(Styled(IconArrowDropdownUp))>
+                                                <input
+                                                  key="input"
+                                                  type="hidden"
+                                                  value=""
+                                                />
+                                                <Underlay>
+                                                  <div
+                                                    className="emotion-6"
+                                                  />
+                                                </Underlay>
+                                              </div>
+                                            </FauxControl>
+                                          </FauxControl>
+                                        </ThemeProvider>
+                                      </ThemeProvider>
+                                    </Themed(FauxControl)>
+                                  </SelectTrigger>
+                                </SelectTrigger>
+                              </SelectTrigger>
+                            </span>
+                          </PopoverTrigger>
+                        </PopoverTrigger>
+                      </PopoverTrigger>
+                      <DropdownContent
+                        hasArrow={true}
+                        id="select-118-content"
+                        modifiers={
+                          Object {
+                            "contentWidth": Object {
+                              "enabled": true,
+                              "fn": [Function],
+                            },
+                          }
+                        }
+                        onBlur={[Function]}
+                        placement="bottom-start"
+                      >
+                        <DropdownContent
+                          hasArrow={true}
+                          id="select-118-content"
+                          modifiers={
+                            Object {
+                              "contentWidth": Object {
+                                "enabled": true,
+                                "fn": [Function],
+                              },
+                            }
+                          }
+                          onBlur={[Function]}
+                          placement="bottom-start"
+                        >
+                          <DropdownContent
+                            className="emotion-14"
+                            id="select-118-content"
+                            modifiers={
+                              Object {
+                                "contentWidth": Object {
+                                  "enabled": true,
+                                  "fn": [Function],
+                                },
+                              }
+                            }
+                            onBlur={[Function]}
+                            placement="bottom-start"
+                          >
+                            <RtlPopper
+                              className="emotion-14"
+                              id="select-118-content"
                               modifiers={
                                 Object {
                                   "contentWidth": Object {
@@ -25518,1271 +28727,6 @@ exports[`Select mounted in DOM render props item renders expected content 1`] = 
                                 className="emotion-14"
                                 component="div"
                                 eventsEnabled={true}
-                                id="select-122-content"
-                                modifiers={
-                                  Object {
-                                    "contentWidth": Object {
-                                      "enabled": true,
-                                      "fn": [Function],
-                                    },
-                                  }
-                                }
-                                onBlur={[Function]}
-                                placement="bottom-start"
-                                positionFixed={false}
-                              >
-                                <div
-                                  className="emotion-14"
-                                  id="select-122-content"
-                                  onBlur={[Function]}
-                                  style={
-                                    Object {
-                                      "opacity": 0,
-                                      "pointerEvents": "none",
-                                      "position": "absolute",
-                                    }
-                                  }
-                                >
-                                  <Menu
-                                    data={
-                                      Array [
-                                        Object {
-                                          "onClick": [MockFunction],
-                                          "text": "A item",
-                                          "value": "A",
-                                        },
-                                        Object {
-                                          "onClick": [MockFunction],
-                                          "text": "B item",
-                                          "value": "B",
-                                        },
-                                        Object {
-                                          "onClick": [MockFunction],
-                                          "text": "C item",
-                                          "value": "C",
-                                        },
-                                      ]
-                                    }
-                                    id="select-122-menu"
-                                    item={[Function]}
-                                    itemKey="value"
-                                    role="listbox"
-                                  >
-                                    <Menu
-                                      id="select-122-menu"
-                                      item={[Function]}
-                                      itemKey="value"
-                                      role="listbox"
-                                    >
-                                      <div
-                                        className="emotion-13"
-                                        id="select-122-menu"
-                                        role="listbox"
-                                      >
-                                        <MenuGroup
-                                          key="0"
-                                        >
-                                          <MenuGroup>
-                                            <div
-                                              className="emotion-12"
-                                            >
-                                              <MenuItem
-                                                index={0}
-                                                item={
-                                                  Object {
-                                                    "onClick": [MockFunction],
-                                                    "text": "A item",
-                                                    "value": "A",
-                                                  }
-                                                }
-                                                key="A"
-                                                onClick={[MockFunction]}
-                                                render={[Function]}
-                                                text="A item"
-                                                value="A"
-                                              >
-                                                <div
-                                                  aria-selected={false}
-                                                  id="select-122-item-0"
-                                                  onClick={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  role="option"
-                                                  tabIndex={null}
-                                                  value="A"
-                                                >
-                                                  A item
-                                                </div>
-                                              </MenuItem>
-                                              <MenuItem
-                                                index={1}
-                                                item={
-                                                  Object {
-                                                    "onClick": [MockFunction],
-                                                    "text": "B item",
-                                                    "value": "B",
-                                                  }
-                                                }
-                                                key="B"
-                                                onClick={[MockFunction]}
-                                                render={[Function]}
-                                                text="B item"
-                                                value="B"
-                                              >
-                                                <div
-                                                  aria-selected={false}
-                                                  id="select-122-item-1"
-                                                  onClick={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  role="option"
-                                                  tabIndex={null}
-                                                  value="B"
-                                                >
-                                                  B item
-                                                </div>
-                                              </MenuItem>
-                                              <MenuItem
-                                                index={2}
-                                                item={
-                                                  Object {
-                                                    "onClick": [MockFunction],
-                                                    "text": "C item",
-                                                    "value": "C",
-                                                  }
-                                                }
-                                                key="C"
-                                                onClick={[MockFunction]}
-                                                render={[Function]}
-                                                text="C item"
-                                                value="C"
-                                              >
-                                                <div
-                                                  aria-selected={false}
-                                                  id="select-122-item-2"
-                                                  onClick={[Function]}
-                                                  onKeyDown={[Function]}
-                                                  role="option"
-                                                  tabIndex={null}
-                                                  value="C"
-                                                >
-                                                  C item
-                                                </div>
-                                              </MenuItem>
-                                            </div>
-                                          </MenuGroup>
-                                        </MenuGroup>
-                                      </div>
-                                    </Menu>
-                                  </Menu>
-                                </div>
-                              </Popper>
-                            </RtlPopper>
-                          </DropdownContent>
-                        </DropdownContent>
-                      </DropdownContent>
-                      <EventListener
-                        listeners={
-                          Array [
-                            Object {
-                              "event": "click",
-                              "handler": [Function],
-                              "options": true,
-                              "target": "document",
-                            },
-                            Object {
-                              "event": "keydown",
-                              "handler": [Function],
-                              "options": true,
-                              "target": "document",
-                            },
-                          ]
-                        }
-                      />
-                    </span>
-                  </Popover>
-                </Popover>
-              </Popover>
-            </Dropdown>
-          </ThemeProvider>
-        </ThemeProvider>
-      </Themed(Dropdown)>
-    </Select>
-  </Select>
-</Select>
-`;
-
-exports[`Select mounted in DOM render props menu renders expected content 1`] = `
-.emotion-18 {
-  width: 100%;
-}
-
-.emotion-18 > span {
-  width: 100%;
-}
-
-.emotion-16 {
-  box-sizing: border-box;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  display: inline-block;
-  width: 100%;
-}
-
-.emotion-16 *,
-.emotion-16 *::before,
-.emotion-16 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-16 > span {
-  width: 100%;
-}
-
-.emotion-10 {
-  display: inline-block;
-}
-
-.emotion-8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-}
-
-.emotion-8 [role="img"] {
-  display: block;
-  color: #3272d9;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.emotion-8 [role="img"]:first-child {
-  color: #3272d9;
-  margin: 0 0.5em;
-}
-
-.emotion-8 :not([role="img"]) ~ [role="img"] {
-  color: #3272d9;
-}
-
-.emotion-8 :not([role="img"]) + [role="img"]:not(:last-of-type) {
-  color: #3272d9;
-  margin-left: 0.5em;
-}
-
-.emotion-7 {
-  box-sizing: border-box;
-  color: #333840;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  position: relative;
-  z-index: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-}
-
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-7:hover > div:last-child {
-  border-color: #5691f0;
-}
-
-.emotion-7:focus > div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-7:active > div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-7 [role="img"] {
-  display: block;
-  color: #3272d9;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.emotion-7 [role="img"]:first-child {
-  color: #3272d9;
-  margin: 0 0.5em;
-}
-
-.emotion-7 :not([role="img"]) ~ [role="img"] {
-  color: #3272d9;
-}
-
-.emotion-7 :not([role="img"]) + [role="img"]:not(:last-of-type) {
-  color: #3272d9;
-  margin-left: 0.5em;
-}
-
-.emotion-0 {
-  display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  width: 100%;
-}
-
-.emotion-3 {
-  margin: 0.5em;
-}
-
-.emotion-2 {
-  fill: currentcolor;
-  font-size: 16px;
-  height: 1.5em;
-  width: 1.5em;
-  margin: 0.5em;
-}
-
-.emotion-6 {
-  background-color: #ffffff;
-  border-color: #c8d1e0;
-  border-radius: 0.1875em;
-  border-style: solid;
-  border-width: 1px;
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: -1;
-}
-
-.emotion-1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: teal;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  height: 2.857142857142857em;
-  min-width: 0;
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-size: 0.875em;
-  font-style: italic;
-  outline: 0;
-  padding-left: 1.1428571428571428em;
-  padding-right: 1.1428571428571428em;
-}
-
-.emotion-1::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-1::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-1:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-1::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-1::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-1:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-1::-ms-clear {
-  display: none;
-}
-
-.emotion-1:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-12 {
-  box-sizing: border-box;
-  color: #333840;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  background-color: #ffffff;
-  border: 1px solid #ebeff5;
-  border-radius: 0.1875em;
-  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.2),0 4px 8px 0 rgba(0,0,0,0.2);
-  max-height: 23em;
-  overflow-y: auto;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  width: 14em;
-  z-index: 100;
-}
-
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-12[data-placement^="top"] {
-  margin-bottom: 5px;
-}
-
-.emotion-12[data-placement^="bottom"] {
-  margin-top: 5px;
-}
-
-.emotion-12[data-placement^="left"] {
-  margin-right: 5px;
-}
-
-.emotion-12[data-placement^="right"] {
-  margin-left: 5px;
-}
-
-.emotion-12[data-x-out-of-boundaries] {
-  visibility: hidden;
-}
-
-<Select
-  data={
-    Array [
-      Object {
-        "onClick": [MockFunction],
-        "text": "A item",
-        "value": "A",
-      },
-      Object {
-        "onClick": [MockFunction],
-        "text": "B item",
-        "value": "B",
-      },
-      Object {
-        "onClick": [MockFunction],
-        "text": "C item",
-        "value": "C",
-      },
-    ]
-  }
-  isOpen={true}
-  itemKey="value"
-  menu={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          Object {
-            "helpers": Object {
-              "close": [Function],
-              "focusTrigger": [Function],
-              "open": [Function],
-            },
-            "props": Object {
-              "data": Array [
-                Object {
-                  "onClick": [MockFunction],
-                  "text": "A item",
-                  "value": "A",
-                },
-                Object {
-                  "onClick": [MockFunction],
-                  "text": "B item",
-                  "value": "B",
-                },
-                Object {
-                  "onClick": [MockFunction],
-                  "text": "C item",
-                  "value": "C",
-                },
-              ],
-              "id": "select-118-menu",
-              "item": [Function],
-              "itemKey": "value",
-              "role": "listbox",
-            },
-            "state": Object {
-              "highlightedIndex": undefined,
-              "isOpen": true,
-              "selectedItem": undefined,
-            },
-          },
-        ],
-      ],
-    }
-  }
-  placeholder="Select..."
-  placement="bottom-start"
-  size="large"
->
-  <Select
-    data={
-      Array [
-        Object {
-          "onClick": [MockFunction],
-          "text": "A item",
-          "value": "A",
-        },
-        Object {
-          "onClick": [MockFunction],
-          "text": "B item",
-          "value": "B",
-        },
-        Object {
-          "onClick": [MockFunction],
-          "text": "C item",
-          "value": "C",
-        },
-      ]
-    }
-    id="select-118"
-    isOpen={true}
-    itemKey="value"
-    menu={[Function]}
-    modifiers={
-      Object {
-        "contentWidth": Object {
-          "enabled": true,
-          "fn": [Function],
-        },
-      }
-    }
-    onClose={[Function]}
-    onOpen={[Function]}
-    placeholder="Select..."
-    placement="bottom-start"
-    size="large"
-  >
-    <Select
-      className="emotion-18"
-      data={
-        Array [
-          Object {
-            "onClick": [MockFunction],
-            "text": "A item",
-            "value": "A",
-          },
-          Object {
-            "onClick": [MockFunction],
-            "text": "B item",
-            "value": "B",
-          },
-          Object {
-            "onClick": [MockFunction],
-            "text": "C item",
-            "value": "C",
-          },
-        ]
-      }
-      id="select-118"
-      isOpen={true}
-      itemKey="value"
-      menu={[Function]}
-      modifiers={
-        Object {
-          "contentWidth": Object {
-            "enabled": true,
-            "fn": [Function],
-          },
-        }
-      }
-      onClose={[Function]}
-      onOpen={[Function]}
-      placeholder="Select..."
-      placement="bottom-start"
-      size="large"
-    >
-      <Themed(Dropdown)
-        className="emotion-18"
-        data={
-          Array [
-            Object {
-              "onClick": [MockFunction],
-              "text": "A item",
-              "value": "A",
-            },
-            Object {
-              "onClick": [MockFunction],
-              "text": "B item",
-              "value": "B",
-            },
-            Object {
-              "onClick": [MockFunction],
-              "text": "C item",
-              "value": "C",
-            },
-          ]
-        }
-        id="select-118"
-        isOpen={true}
-        itemKey="value"
-        menu={[Function]}
-        modifiers={
-          Object {
-            "contentWidth": Object {
-              "enabled": true,
-              "fn": [Function],
-            },
-          }
-        }
-        onClose={[Function]}
-        onOpen={[Function]}
-        placeholder="Select..."
-        placement="bottom-start"
-        size="large"
-      >
-        <ThemeProvider>
-          <ThemeProvider>
-            <Dropdown
-              className="emotion-18"
-              data={
-                Array [
-                  Object {
-                    "onClick": [MockFunction],
-                    "text": "A item",
-                    "value": "A",
-                  },
-                  Object {
-                    "onClick": [MockFunction],
-                    "text": "B item",
-                    "value": "B",
-                  },
-                  Object {
-                    "onClick": [MockFunction],
-                    "text": "C item",
-                    "value": "C",
-                  },
-                ]
-              }
-              id="select-118"
-              isOpen={true}
-              itemKey="value"
-              menu={[Function]}
-              modifiers={
-                Object {
-                  "contentWidth": Object {
-                    "enabled": true,
-                    "fn": [Function],
-                  },
-                }
-              }
-              onClose={[Function]}
-              onOpen={[Function]}
-              placeholder="Select..."
-              placement="bottom-start"
-              size="large"
-            >
-              <Popover
-                className="emotion-18"
-                content={[Function]}
-                focusTriggerOnClose={true}
-                hasArrow={true}
-                id="select-118"
-                isOpen={true}
-                itemKey="value"
-                modifiers={
-                  Object {
-                    "contentWidth": Object {
-                      "enabled": true,
-                      "fn": [Function],
-                    },
-                  }
-                }
-                onClose={[Function]}
-                onOpen={[Function]}
-                placeholder="Select..."
-                placement="bottom-start"
-                size="large"
-                triggerRef={[Function]}
-              >
-                <Popover
-                  className="emotion-18"
-                  content={[Function]}
-                  focusTriggerOnClose={true}
-                  hasArrow={true}
-                  id="select-118"
-                  isOpen={true}
-                  itemKey="value"
-                  modifiers={
-                    Object {
-                      "contentWidth": Object {
-                        "enabled": true,
-                        "fn": [Function],
-                      },
-                    }
-                  }
-                  onClose={[Function]}
-                  onOpen={[Function]}
-                  placeholder="Select..."
-                  placement="bottom-start"
-                  size="large"
-                  tag="span"
-                  triggerRef={[Function]}
-                >
-                  <Popover
-                    className="emotion-16"
-                    id="select-118"
-                    tag="span"
-                  >
-                    <span
-                      className="emotion-16"
-                      id="select-118"
-                    >
-                      <PopoverTrigger
-                        aria-activedescendant="select-118-menu"
-                        aria-describedby="select-118-content"
-                        aria-expanded={true}
-                        aria-haspopup="listbox"
-                        aria-owns="select-118-content"
-                        isOpen={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        placeholder="Select..."
-                        role="button"
-                        size="large"
-                        tabIndex={0}
-                        triggerRef={[Function]}
-                      >
-                        <PopoverTrigger
-                          component="span"
-                        >
-                          <PopoverTrigger
-                            className="emotion-10"
-                            component="span"
-                          >
-                            <span
-                              className="emotion-10"
-                            >
-                              <SelectTrigger
-                                aria-activedescendant="select-118-menu"
-                                aria-describedby="select-118-content"
-                                aria-expanded={true}
-                                aria-haspopup="listbox"
-                                aria-owns="select-118-content"
-                                isOpen={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onKeyDown={[Function]}
-                                onKeyUp={[Function]}
-                                placeholder="Select..."
-                                role="button"
-                                size="large"
-                                tabIndex={0}
-                                triggerRef={[Function]}
-                              >
-                                <SelectTrigger
-                                  afterItems={
-                                    Array [
-                                      <withProps(Styled(IconArrowDropdownUp)) />,
-                                      <input
-                                        name={undefined}
-                                        type="hidden"
-                                        value=""
-                                      />,
-                                    ]
-                                  }
-                                  aria-activedescendant="select-118-menu"
-                                  aria-describedby="select-118-content"
-                                  aria-expanded={true}
-                                  aria-haspopup="listbox"
-                                  aria-owns="select-118-content"
-                                  control={[Function]}
-                                  controlProps={
-                                    Object {
-                                      "hasPlaceholder": true,
-                                      "variant": undefined,
-                                    }
-                                  }
-                                  fauxControlRef={[Function]}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onKeyDown={[Function]}
-                                  onKeyUp={[Function]}
-                                  role="button"
-                                  size="large"
-                                  tabIndex={0}
-                                >
-                                  <SelectTrigger
-                                    afterItems={
-                                      Array [
-                                        <withProps(Styled(IconArrowDropdownUp)) />,
-                                        <input
-                                          name={undefined}
-                                          type="hidden"
-                                          value=""
-                                        />,
-                                      ]
-                                    }
-                                    aria-activedescendant="select-118-menu"
-                                    aria-describedby="select-118-content"
-                                    aria-expanded={true}
-                                    aria-haspopup="listbox"
-                                    aria-owns="select-118-content"
-                                    className="emotion-8"
-                                    control={[Function]}
-                                    controlProps={
-                                      Object {
-                                        "hasPlaceholder": true,
-                                        "variant": undefined,
-                                      }
-                                    }
-                                    fauxControlRef={[Function]}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
-                                    onKeyUp={[Function]}
-                                    role="button"
-                                    size="large"
-                                    tabIndex={0}
-                                  >
-                                    <FauxControl
-                                      aria-activedescendant="select-118-menu"
-                                      aria-describedby="select-118-content"
-                                      aria-expanded={true}
-                                      aria-haspopup="listbox"
-                                      aria-owns="select-118-content"
-                                      className="emotion-8"
-                                      control={[Function]}
-                                      innerRef={[Function]}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onKeyUp={[Function]}
-                                      role="button"
-                                      tabIndex={0}
-                                    >
-                                      <div
-                                        aria-activedescendant="select-118-menu"
-                                        aria-describedby="select-118-content"
-                                        aria-expanded={true}
-                                        aria-haspopup="listbox"
-                                        aria-owns="select-118-content"
-                                        className="emotion-7"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onKeyDown={[Function]}
-                                        onKeyUp={[Function]}
-                                        role="button"
-                                        tabIndex={0}
-                                      >
-                                        <Control
-                                          controlPropsIn={
-                                            Object {
-                                              "hasPlaceholder": true,
-                                              "variant": undefined,
-                                            }
-                                          }
-                                          hasPlaceholder={true}
-                                          key="control"
-                                          size="large"
-                                        >
-                                          <div
-                                            className="emotion-1"
-                                          >
-                                            <TriggerContent>
-                                              <span
-                                                className="emotion-0"
-                                              >
-                                                Select...
-                                              </span>
-                                            </TriggerContent>
-                                          </div>
-                                        </Control>
-                                        <withProps(Styled(IconArrowDropdownUp))
-                                          key="arrow"
-                                        >
-                                          <Styled(IconArrowDropdownUp)
-                                            size="1.5em"
-                                          >
-                                            <IconArrowDropdownUp
-                                              className="emotion-3"
-                                              size="1.5em"
-                                            >
-                                              <Icon
-                                                className="emotion-3"
-                                                rtl={false}
-                                                size="1.5em"
-                                              >
-                                                <Styled(svg)
-                                                  aria-hidden={true}
-                                                  className="emotion-3"
-                                                  focusable="false"
-                                                  role="img"
-                                                  rtl={false}
-                                                  size="1.5em"
-                                                  viewBox="0 0 24 24"
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="emotion-2"
-                                                    focusable="false"
-                                                    role="img"
-                                                    viewBox="0 0 24 24"
-                                                  >
-                                                    <g>
-                                                      <path
-                                                        d="M12 7.5l8 8H4z"
-                                                      />
-                                                    </g>
-                                                  </svg>
-                                                </Styled(svg)>
-                                              </Icon>
-                                            </IconArrowDropdownUp>
-                                          </Styled(IconArrowDropdownUp)>
-                                        </withProps(Styled(IconArrowDropdownUp))>
-                                        <input
-                                          key="input"
-                                          type="hidden"
-                                          value=""
-                                        />
-                                        <Underlay>
-                                          <div
-                                            className="emotion-6"
-                                          />
-                                        </Underlay>
-                                      </div>
-                                    </FauxControl>
-                                  </SelectTrigger>
-                                </SelectTrigger>
-                              </SelectTrigger>
-                            </span>
-                          </PopoverTrigger>
-                        </PopoverTrigger>
-                      </PopoverTrigger>
-                      <DropdownContent
-                        hasArrow={true}
-                        id="select-118-content"
-                        modifiers={
-                          Object {
-                            "contentWidth": Object {
-                              "enabled": true,
-                              "fn": [Function],
-                            },
-                          }
-                        }
-                        onBlur={[Function]}
-                        placement="bottom-start"
-                      >
-                        <DropdownContent
-                          hasArrow={true}
-                          id="select-118-content"
-                          modifiers={
-                            Object {
-                              "contentWidth": Object {
-                                "enabled": true,
-                                "fn": [Function],
-                              },
-                            }
-                          }
-                          onBlur={[Function]}
-                          placement="bottom-start"
-                        >
-                          <DropdownContent
-                            className="emotion-12"
-                            id="select-118-content"
-                            modifiers={
-                              Object {
-                                "contentWidth": Object {
-                                  "enabled": true,
-                                  "fn": [Function],
-                                },
-                              }
-                            }
-                            onBlur={[Function]}
-                            placement="bottom-start"
-                          >
-                            <RtlPopper
-                              className="emotion-12"
-                              id="select-118-content"
-                              modifiers={
-                                Object {
-                                  "contentWidth": Object {
-                                    "enabled": true,
-                                    "fn": [Function],
-                                  },
-                                }
-                              }
-                              onBlur={[Function]}
-                              placement="bottom-start"
-                              theme={
-                                Object {
-                                  "DropdownContent_backgroundColor": "#ffffff",
-                                  "DropdownContent_borderColor": "#ebeff5",
-                                  "DropdownContent_borderRadius": "0.1875em",
-                                  "DropdownContent_boxShadow": "0 2px 4px 0 rgba(0,0,0,0.2), 0 4px 8px 0 rgba(0,0,0,0.2)",
-                                  "DropdownContent_margin": "5px",
-                                  "DropdownContent_zIndex": 100,
-                                  "DropdownIcon_color": "#3272d9",
-                                  "DropdownIcon_marginHorizontal": "0.5em",
-                                  "Dropdown_backgroundColor": "#ffffff",
-                                  "Dropdown_borderColor": "#c8d1e0",
-                                  "Dropdown_borderColor_active": "#c8d1e0",
-                                  "Dropdown_borderColor_focus": "#c8d1e0",
-                                  "Dropdown_borderColor_hover": "#5691f0",
-                                  "Dropdown_borderRadius": "0.1875em",
-                                  "Dropdown_borderWidth": "1px",
-                                  "Dropdown_boxShadow_active": "0 0 0 1px #ffffff, 0 0 0 2px #1d5bbf",
-                                  "Dropdown_boxShadow_focus": "0 0 0 1px #ffffff, 0 0 0 2px #1d5bbf",
-                                  "Dropdown_color": "#333840",
-                                  "Dropdown_color_placeholder": "#8e99ab",
-                                  "Dropdown_color_readOnly": "#58606e",
-                                  "Dropdown_fontSize": "0.875em",
-                                  "Dropdown_fontSize_small": "0.75em",
-                                  "Dropdown_height_jumbo": "3.25em",
-                                  "Dropdown_height_large": "2.5em",
-                                  "Dropdown_height_medium": "2em",
-                                  "Dropdown_height_small": "1.5em",
-                                  "Dropdown_paddingHorizontal": "1em",
-                                  "Dropdown_paddingHorizontal_small": "0.5em",
-                                  "backgroundColor_active": "#ebeff5",
-                                  "backgroundColor_dangerPrimary": "#de1b1b",
-                                  "backgroundColor_dangerPrimary_active": "#b80d0d",
-                                  "backgroundColor_dangerPrimary_focus": "#de1b1b",
-                                  "backgroundColor_dangerPrimary_hover": "#f55353",
-                                  "backgroundColor_danger_active": "#fad4d4",
-                                  "backgroundColor_danger_focus": "#faf0f0",
-                                  "backgroundColor_danger_hover": "#faf0f0",
-                                  "backgroundColor_disabled": "#dde3ed",
-                                  "backgroundColor_focus": "#f5f7fa",
-                                  "backgroundColor_hover": "#f5f7fa",
-                                  "backgroundColor_successPrimary": "#2a854e",
-                                  "backgroundColor_successPrimary_active": "#20693d",
-                                  "backgroundColor_successPrimary_focus": "#2a854e",
-                                  "backgroundColor_successPrimary_hover": "#3ba164",
-                                  "backgroundColor_success_active": "#abedc5",
-                                  "backgroundColor_success_focus": "#e1faeb",
-                                  "backgroundColor_success_hover": "#e1faeb",
-                                  "backgroundColor_themePrimary": "#3272d9",
-                                  "backgroundColor_themePrimary_active": "#1d5bbf",
-                                  "backgroundColor_themePrimary_focus": "#3272d9",
-                                  "backgroundColor_themePrimary_hover": "#5691f0",
-                                  "backgroundColor_theme_selected": "#f0f5fc",
-                                  "backgroundColor_theme_selectedActive": "#accbfc",
-                                  "backgroundColor_theme_selectedHover": "#cfe0fc",
-                                  "backgroundColor_warningPrimary": "#ad5f00",
-                                  "backgroundColor_warningPrimary_active": "#8a4d03",
-                                  "backgroundColor_warningPrimary_focus": "#ad5f00",
-                                  "backgroundColor_warningPrimary_hover": "#cf7911",
-                                  "backgroundColor_warning_active": "#fad8af",
-                                  "backgroundColor_warning_focus": "#fcf2e6",
-                                  "backgroundColor_warning_hover": "#fcf2e6",
-                                  "borderColor": "#c8d1e0",
-                                  "borderColor_danger": "#de1b1b",
-                                  "borderColor_danger_active": "#b80d0d",
-                                  "borderColor_danger_focus": "#b80d0d",
-                                  "borderColor_danger_hover": "#f55353",
-                                  "borderColor_success": "#2a854e",
-                                  "borderColor_success_active": "#20693d",
-                                  "borderColor_success_focus": "#20693d",
-                                  "borderColor_success_hover": "#3ba164",
-                                  "borderColor_theme": "#3272d9",
-                                  "borderColor_theme_active": "#1d5bbf",
-                                  "borderColor_theme_focus": "#1d5bbf",
-                                  "borderColor_theme_hover": "#5691f0",
-                                  "borderColor_warning": "#ad5f00",
-                                  "borderColor_warning_active": "#8a4d03",
-                                  "borderColor_warning_focus": "#8a4d03",
-                                  "borderColor_warning_hover": "#cf7911",
-                                  "borderRadius_1": "0.1875em",
-                                  "boxShadow_1": "0 1px 2px 0 rgba(0,0,0,0.2), 0 2px 4px 0 rgba(0,0,0,0.2)",
-                                  "boxShadow_2": "0 2px 4px 0 rgba(0,0,0,0.2), 0 4px 8px 0 rgba(0,0,0,0.2)",
-                                  "boxShadow_3": "0 4px 8px 0 rgba(0,0,0,0.2), 0 8px 16px 0 rgba(0,0,0,0.2)",
-                                  "boxShadow_4": "0 8px 16px 0 rgba(0,0,0,0.2), 0 20px 16px -8px rgba(0,0,0,0.2)",
-                                  "boxShadow_5": "0 16px 24px 0 rgba(0,0,0,0.2), 0 32px 24px -16px rgba(0,0,0,0.2)",
-                                  "boxShadow_focusInner": "#ffffff",
-                                  "breakpoint_medium": "768px",
-                                  "breakpoint_narrow": "512px",
-                                  "breakpoint_wide": "1024px",
-                                  "color": "#333840",
-                                  "color_black": "#1d1f24",
-                                  "color_danger": "#de1b1b",
-                                  "color_dangerPrimary": "#ffffff",
-                                  "color_danger_active": "#b80d0d",
-                                  "color_danger_focus": "#de1b1b",
-                                  "color_danger_hover": "#f55353",
-                                  "color_disabled": "#afbacc",
-                                  "color_gray_10": "#f5f7fa",
-                                  "color_gray_100": "#333840",
-                                  "color_gray_20": "#ebeff5",
-                                  "color_gray_30": "#dde3ed",
-                                  "color_gray_40": "#c8d1e0",
-                                  "color_gray_50": "#afbacc",
-                                  "color_gray_60": "#8e99ab",
-                                  "color_gray_70": "#707a8a",
-                                  "color_gray_80": "#58606e",
-                                  "color_gray_90": "#434a54",
-                                  "color_inverted": "#ffffff",
-                                  "color_mouse": "#58606e",
-                                  "color_readOnly": "#58606e",
-                                  "color_required": "#de1b1b",
-                                  "color_success": "#2a854e",
-                                  "color_successPrimary": "#ffffff",
-                                  "color_success_active": "#20693d",
-                                  "color_success_focus": "#2a854e",
-                                  "color_success_hover": "#3ba164",
-                                  "color_theme": "#3272d9",
-                                  "color_themePrimary": "#ffffff",
-                                  "color_theme_10": "#f0f5fc",
-                                  "color_theme_100": "#15233b",
-                                  "color_theme_20": "#cfe0fc",
-                                  "color_theme_30": "#accbfc",
-                                  "color_theme_40": "#84b1fa",
-                                  "color_theme_50": "#5691f0",
-                                  "color_theme_60": "#3272d9",
-                                  "color_theme_70": "#1d5bbf",
-                                  "color_theme_80": "#114599",
-                                  "color_theme_90": "#103570",
-                                  "color_theme_active": "#1d5bbf",
-                                  "color_theme_focus": "#3272d9",
-                                  "color_theme_hover": "#5691f0",
-                                  "color_warning": "#ad5f00",
-                                  "color_warningPrimary": "#ffffff",
-                                  "color_warning_active": "#8a4d03",
-                                  "color_warning_focus": "#ad5f00",
-                                  "color_warning_hover": "#cf7911",
-                                  "color_white": "#ffffff",
-                                  "direction": "ltr",
-                                  "fontFamily": "\\"Open Sans\\"",
-                                  "fontFamily_monospace": "\\"SF Mono\\", \\"Droid Sans Mono\\", \\"Source Code Pro\\", Monaco, Consolas, \\"Courier New\\", Courier, monospace",
-                                  "fontFamily_system": "-apple-system, system-ui, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
-                                  "fontSize_base": "16px",
-                                  "fontSize_mouse": "0.6875em",
-                                  "fontSize_prose": "1em",
-                                  "fontSize_ui": "0.875em",
-                                  "fontWeight_bold": 700,
-                                  "fontWeight_extraBold": 800,
-                                  "fontWeight_regular": 400,
-                                  "fontWeight_semiBold": 600,
-                                  "h1_color": "#333840",
-                                  "h1_fontSize": "2.125em",
-                                  "h1_fontWeight": 800,
-                                  "h2_color": "#58606e",
-                                  "h2_fontSize": "1.75em",
-                                  "h2_fontWeight": 700,
-                                  "h3_color": "#58606e",
-                                  "h3_fontSize": "1.375em",
-                                  "h3_fontWeight": 700,
-                                  "h4_color": "#58606e",
-                                  "h4_fontSize": "1.125em",
-                                  "h4_fontWeight": 700,
-                                  "h5_color": "#333840",
-                                  "h5_fontSize": "0.875em",
-                                  "h5_fontWeight": 700,
-                                  "h6_color": "#58606e",
-                                  "h6_fontSize": "0.875em",
-                                  "h6_fontWeight": 400,
-                                  "icon_color": "#58606e",
-                                  "icon_color_danger": "#de1b1b",
-                                  "icon_color_success": "#2a854e",
-                                  "icon_color_theme": "#3272d9",
-                                  "icon_color_warning": "#ad5f00",
-                                  "input_backgroundColor": "#ffffff",
-                                  "input_backgroundColor_disabled": "#ebeff5",
-                                  "input_color_placeholder": "#8e99ab",
-                                  "lineHeight": 1.25,
-                                  "lineHeight_heading": 1.25,
-                                  "lineHeight_heading_small": 1.5,
-                                  "lineHeight_prose": 1.5,
-                                  "panel_backgroundColor": "#ffffff",
-                                  "panel_backgroundColor_inverted": "#434a54",
-                                  "panel_borderColor": "#ebeff5",
-                                  "panel_borderColor_inverted": "#434a54",
-                                  "size_jumbo": "3.25em",
-                                  "size_large": "2.5em",
-                                  "size_medium": "2em",
-                                  "size_small": "1.5em",
-                                  "space_inline_lg": "1.5em",
-                                  "space_inline_md": "1em",
-                                  "space_inline_sm": "0.5em",
-                                  "space_inline_xl": "2em",
-                                  "space_inline_xs": "0.25em",
-                                  "space_inline_xxl": "4em",
-                                  "space_inline_xxs": "0.125em",
-                                  "space_inset_lg": "1.5em",
-                                  "space_inset_md": "1em",
-                                  "space_inset_sm": "0.5em",
-                                  "space_stack_lg": "1.5em",
-                                  "space_stack_md": "1em",
-                                  "space_stack_sm": "0.5em",
-                                  "space_stack_xl": "2em",
-                                  "space_stack_xs": "0.25em",
-                                  "space_stack_xxl": "4em",
-                                  "space_stack_xxs": "0.125em",
-                                  "well_backgroundColor": "#ebeff5",
-                                  "well_backgroundColor_danger": "#fad4d4",
-                                  "well_backgroundColor_success": "#abedc5",
-                                  "well_backgroundColor_warning": "#fad8af",
-                                  "well_borderColor_danger": "#fa8e8e",
-                                  "well_borderColor_success": "#57c282",
-                                  "well_borderColor_warning": "#e89c3f",
-                                  "zIndex_100": 100,
-                                  "zIndex_1600": 1600,
-                                  "zIndex_200": 200,
-                                  "zIndex_400": 400,
-                                  "zIndex_800": 800,
-                                }
-                              }
-                            >
-                              <Popper
-                                className="emotion-12"
-                                component="div"
-                                eventsEnabled={true}
                                 id="select-118-content"
                                 modifiers={
                                   Object {
@@ -26797,7 +28741,7 @@ exports[`Select mounted in DOM render props menu renders expected content 1`] = 
                                 positionFixed={false}
                               >
                                 <div
-                                  className="emotion-12"
+                                  className="emotion-14"
                                   id="select-118-content"
                                   onBlur={[Function]}
                                   style={

--- a/src/library/TextArea/TextArea.js
+++ b/src/library/TextArea/TextArea.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { canUseDOM } from 'exenv';
 import FontFaceObserver from 'fontfaceobserver';
 import { createStyledComponent, getNormalizedValue, pxToEm } from '../styles';
-import { mapComponentThemes } from '../themes';
+import { createThemedComponent, mapComponentThemes } from '../themes';
 import FauxControl, {
   componentTheme as fauxControlComponentTheme
 } from '../FauxControl/FauxControl';
@@ -50,8 +50,8 @@ type Props = {
   variant?: 'success' | 'warning' | 'danger'
 };
 
-export const componentTheme = (baseTheme: Object) => ({
-  ...mapComponentThemes(
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
     {
       name: 'FauxControl',
       theme: fauxControlComponentTheme(baseTheme)
@@ -68,8 +68,23 @@ export const componentTheme = (baseTheme: Object) => ({
       }
     },
     baseTheme
-  )
-});
+  );
+
+const ThemedFauxControl = createThemedComponent(
+  FauxControl,
+  ({ theme: baseTheme }) =>
+    mapComponentThemes(
+      {
+        name: 'TextArea',
+        theme: componentTheme(baseTheme)
+      },
+      {
+        name: 'FauxControl',
+        theme: {}
+      },
+      baseTheme
+    )
+);
 
 const styles = {
   textArea: ({ resizeable, size, theme: baseTheme }) => {
@@ -114,7 +129,7 @@ const styles = {
   }
 };
 
-const Root = createStyledComponent(FauxControl, styles.root, {
+const Root = createStyledComponent(ThemedFauxControl, styles.root, {
   displayName: 'TextArea'
 });
 const _TextArea = createStyledComponent('textarea', styles.textArea, {

--- a/src/library/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
+++ b/src/library/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
@@ -71,7 +71,7 @@ exports[`TextArea demo examples Snapshots: autosize 1`] = `
   z-index: -1;
 }
 
-.emotion-15[class] > *:not(:last-child) {
+.emotion-21[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -145,7 +145,7 @@ exports[`TextArea demo examples Snapshots: autosize 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-10 {
+.emotion-14 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -170,47 +170,47 @@ exports[`TextArea demo examples Snapshots: autosize 1`] = `
   padding-right: 0.6666666666666666em;
 }
 
-.emotion-10::-webkit-input-placeholder {
+.emotion-14::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-moz-placeholder {
+.emotion-14::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::placeholder {
+.emotion-14::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-input-placeholder {
+.emotion-14::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-clear {
+.emotion-14::-ms-clear {
   display: none;
 }
 
-.emotion-10:focus ~ div:last-child {
+.emotion-14:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -220,7 +220,7 @@ exports[`TextArea demo examples Snapshots: autosize 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-15"
+      className="emotion-21"
     >
       <TextArea
         autoSize={true}
@@ -253,7 +253,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
           iconEnd={null}
           size="large"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -278,65 +278,121 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
             iconEnd={null}
             size="large"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
-            >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  autoSize={true}
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": true,
-                      "controlRef": [Function],
-                      "defaultValue": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": true,
+                  "controlRef": [Function],
+                  "defaultValue": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
 
 Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pellentesque, vestibulum odio sit amet, vehicula ante. Curabitur et turpis velit. Pellentesque in tincidunt nulla. Aenean malesuada ornare condimentum. Vivamus maximus efficitur sem, non consectetur arcu pretium in. Integer sodales quis quam nec iaculis. Donec accumsan tortor et magna tristique euismod. Nullam pellentesque, ligula nec condimentum rhoncus, arcu dui mollis lectus, ac porttitor purus nisi sed lacus.",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": false,
-                      "rows": 8,
-                      "size": "large",
-                      "spellCheck": false,
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": false,
+                  "rows": 8,
+                  "size": "large",
+                  "spellCheck": false,
+                }
+              }
+              iconEnd={null}
+              size="large"
+            >
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": true,
+                        "controlRef": [Function],
+                        "defaultValue": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
+
+Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pellentesque, vestibulum odio sit amet, vehicula ante. Curabitur et turpis velit. Pellentesque in tincidunt nulla. Aenean malesuada ornare condimentum. Vivamus maximus efficitur sem, non consectetur arcu pretium in. Integer sodales quis quam nec iaculis. Donec accumsan tortor et magna tristique euismod. Nullam pellentesque, ligula nec condimentum rhoncus, arcu dui mollis lectus, ac porttitor purus nisi sed lacus.",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": false,
+                        "rows": 8,
+                        "size": "large",
+                        "spellCheck": false,
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
+                    iconEnd={null}
+                    size="large"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          autoSize={true}
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": true,
+                              "controlRef": [Function],
+                              "defaultValue": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
+
+Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pellentesque, vestibulum odio sit amet, vehicula ante. Curabitur et turpis velit. Pellentesque in tincidunt nulla. Aenean malesuada ornare condimentum. Vivamus maximus efficitur sem, non consectetur arcu pretium in. Integer sodales quis quam nec iaculis. Donec accumsan tortor et magna tristique euismod. Nullam pellentesque, ligula nec condimentum rhoncus, arcu dui mollis lectus, ac porttitor purus nisi sed lacus.",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": false,
+                              "rows": 8,
+                              "size": "large",
+                              "spellCheck": false,
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
 
 Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pellentesque, vestibulum odio sit amet, vehicula ante. Curabitur et turpis velit. Pellentesque in tincidunt nulla. Aenean malesuada ornare condimentum. Vivamus maximus efficitur sem, non consectetur arcu pretium in. Integer sodales quis quam nec iaculis. Donec accumsan tortor et magna tristique euismod. Nullam pellentesque, ligula nec condimentum rhoncus, arcu dui mollis lectus, ac porttitor purus nisi sed lacus."
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={false}
-                  rows={8}
-                  size="large"
-                  spellCheck={false}
-                >
-                  <textarea
-                    className="emotion-0"
-                    defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={false}
+                          rows={8}
+                          size="large"
+                          spellCheck={false}
+                        >
+                          <textarea
+                            className="emotion-0"
+                            defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ornare velit nec dui molestie posuere. Nulla facilisi. Nulla tempor turpis vel aliquam viverra. In eu sagittis elit. Integer scelerisque purus nulla, sit amet dictum ipsum elementum finibus. Suspendisse et erat nisl. Sed aliquet finibus odio, ut volutpat metus dictum sed. Nullam nunc mi, consequat sit amet magna ut, faucibus placerat tortor. Duis porttitor tellus vitae condimentum convallis. Fusce hendrerit, nunc vitae tempor tempor, urna dolor fringilla eros, non condimentum urna dui id tellus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Pellentesque tempor metus eget ipsum volutpat, venenatis imperdiet lacus commodo. Morbi quis dictum urna, vel facilisis magna. Phasellus nec vehicula lectus. Nulla laoreet nisi nec varius rhoncus. Integer at risus blandit, commodo urna sed, viverra dui.
 
 Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pellentesque, vestibulum odio sit amet, vehicula ante. Curabitur et turpis velit. Pellentesque in tincidunt nulla. Aenean malesuada ornare condimentum. Vivamus maximus efficitur sem, non consectetur arcu pretium in. Integer sodales quis quam nec iaculis. Donec accumsan tortor et magna tristique euismod. Nullam pellentesque, ligula nec condimentum rhoncus, arcu dui mollis lectus, ac porttitor purus nisi sed lacus."
-                    onInput={[Function]}
-                    rows={8}
-                    spellCheck={false}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                            onInput={[Function]}
+                            rows={8}
+                            spellCheck={false}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -365,7 +421,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
           iconEnd={null}
           size="large"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -387,56 +443,106 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
             iconEnd={null}
             size="large"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": true,
+                  "controlRef": [Function],
+                  "defaultValue": "Hello World",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": false,
+                  "rows": 1,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  autoSize={true}
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": true,
-                      "controlRef": [Function],
-                      "defaultValue": "Hello World",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": false,
-                      "rows": 1,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": true,
+                        "controlRef": [Function],
+                        "defaultValue": "Hello World",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": false,
+                        "rows": 1,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Hello World"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={false}
-                  rows={1}
-                  size="large"
-                >
-                  <textarea
-                    className="emotion-0"
-                    defaultValue="Hello World"
-                    onInput={[Function]}
-                    rows={1}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          autoSize={true}
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": true,
+                              "controlRef": [Function],
+                              "defaultValue": "Hello World",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": false,
+                              "rows": 1,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Hello World"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={false}
+                          rows={1}
+                          size="large"
+                        >
+                          <textarea
+                            className="emotion-0"
+                            defaultValue="Hello World"
+                            onInput={[Function]}
+                            rows={1}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -466,7 +572,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
           iconEnd={null}
           size="small"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -488,56 +594,106 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
             iconEnd={null}
             size="small"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": true,
+                  "controlRef": [Function],
+                  "defaultValue": "Hello World",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": false,
+                  "rows": 1,
+                  "size": "small",
+                }
+              }
+              iconEnd={null}
+              size="small"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  autoSize={true}
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": true,
-                      "controlRef": [Function],
-                      "defaultValue": "Hello World",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": false,
-                      "rows": 1,
-                      "size": "small",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": true,
+                        "controlRef": [Function],
+                        "defaultValue": "Hello World",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": false,
+                        "rows": 1,
+                        "size": "small",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Hello World"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={false}
-                  rows={1}
-                  size="small"
-                >
-                  <textarea
-                    className="emotion-10"
-                    defaultValue="Hello World"
-                    onInput={[Function]}
-                    rows={1}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="small"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          autoSize={true}
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": true,
+                              "controlRef": [Function],
+                              "defaultValue": "Hello World",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": false,
+                              "rows": 1,
+                              "size": "small",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Hello World"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={false}
+                          rows={1}
+                          size="small"
+                        >
+                          <textarea
+                            className="emotion-14"
+                            defaultValue="Hello World"
+                            onInput={[Function]}
+                            rows={1}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
     </div>
@@ -714,7 +870,7 @@ exports[`TextArea demo examples Snapshots: controlled 1`] = `
         iconEnd={null}
         size="large"
       >
-        <TextInput
+        <TextArea
           className="emotion-3"
           control={[Function]}
           controlProps={
@@ -737,58 +893,110 @@ exports[`TextArea demo examples Snapshots: controlled 1`] = `
           iconEnd={null}
           size="large"
         >
-          <FauxControl
+          <Themed(FauxControl)
             className="emotion-3"
             control={[Function]}
+            controlProps={
+              Object {
+                "aria-invalid": undefined,
+                "aria-required": undefined,
+                "autoSize": undefined,
+                "controlRef": [Function],
+                "disabled": undefined,
+                "onChange": [Function],
+                "onInput": [Function],
+                "readOnly": undefined,
+                "required": undefined,
+                "resizeable": true,
+                "rows": 8,
+                "size": "large",
+                "value": "Hello World",
+              }
+            }
+            iconEnd={null}
+            size="large"
           >
-            <div
-              className="emotion-2"
-            >
-              <Control
-                controlPropsIn={
-                  Object {
-                    "aria-invalid": undefined,
-                    "aria-required": undefined,
-                    "autoSize": undefined,
-                    "controlRef": [Function],
-                    "disabled": undefined,
-                    "onChange": [Function],
-                    "onInput": [Function],
-                    "readOnly": undefined,
-                    "required": undefined,
-                    "resizeable": true,
-                    "rows": 8,
-                    "size": "large",
-                    "value": "Hello World",
+            <ThemeProvider>
+              <ThemeProvider>
+                <FauxControl
+                  className="emotion-3"
+                  control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": undefined,
+                      "controlRef": [Function],
+                      "disabled": undefined,
+                      "onChange": [Function],
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": true,
+                      "rows": 8,
+                      "size": "large",
+                      "value": "Hello World",
+                    }
                   }
-                }
-                controlRef={[Function]}
-                iconEnd={null}
-                innerRef={[Function]}
-                key="control"
-                onChange={[Function]}
-                onInput={[Function]}
-                resizeable={true}
-                rows={8}
-                size="large"
-                value="Hello World"
-              >
-                <textarea
-                  className="emotion-0"
-                  onChange={[Function]}
-                  onInput={[Function]}
-                  rows={8}
-                  value="Hello World"
-                />
-              </Control>
-              <Underlay>
-                <div
-                  className="emotion-1"
-                />
-              </Underlay>
-            </div>
-          </FauxControl>
-        </TextInput>
+                  iconEnd={null}
+                  size="large"
+                >
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                  >
+                    <div
+                      className="emotion-2"
+                    >
+                      <Control
+                        controlPropsIn={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": undefined,
+                            "controlRef": [Function],
+                            "disabled": undefined,
+                            "onChange": [Function],
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": true,
+                            "rows": 8,
+                            "size": "large",
+                            "value": "Hello World",
+                          }
+                        }
+                        controlRef={[Function]}
+                        iconEnd={null}
+                        innerRef={[Function]}
+                        key="control"
+                        onChange={[Function]}
+                        onInput={[Function]}
+                        resizeable={true}
+                        rows={8}
+                        size="large"
+                        value="Hello World"
+                      >
+                        <textarea
+                          className="emotion-0"
+                          onChange={[Function]}
+                          onInput={[Function]}
+                          rows={8}
+                          value="Hello World"
+                        />
+                      </Control>
+                      <Underlay>
+                        <div
+                          className="emotion-1"
+                        />
+                      </Underlay>
+                    </div>
+                  </FauxControl>
+                </FauxControl>
+              </ThemeProvider>
+            </ThemeProvider>
+          </Themed(FauxControl)>
+        </TextArea>
       </TextArea>
     </TextArea>
   </MyForm>
@@ -953,7 +1161,7 @@ exports[`TextArea demo examples Snapshots: disabled 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextInput
+    <TextArea
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -976,60 +1184,112 @@ exports[`TextArea demo examples Snapshots: disabled 1`] = `
       iconEnd={null}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "autoSize": undefined,
+            "controlRef": [Function],
+            "defaultValue": "Hello World",
+            "disabled": true,
+            "onInput": [Function],
+            "readOnly": undefined,
+            "required": undefined,
+            "resizeable": true,
+            "rows": 8,
+            "size": "large",
+          }
+        }
         disabled={true}
+        iconEnd={null}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "autoSize": undefined,
-                "controlRef": [Function],
-                "defaultValue": "Hello World",
-                "disabled": true,
-                "onInput": [Function],
-                "readOnly": undefined,
-                "required": undefined,
-                "resizeable": true,
-                "rows": 8,
-                "size": "large",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Hello World",
+                  "disabled": true,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
               }
-            }
-            controlRef={[Function]}
-            defaultValue="Hello World"
-            disabled={true}
-            iconEnd={null}
-            innerRef={[Function]}
-            key="control"
-            onInput={[Function]}
-            resizeable={true}
-            rows={8}
-            size="large"
-          >
-            <textarea
-              className="emotion-0"
-              defaultValue="Hello World"
               disabled={true}
-              onInput={[Function]}
-              rows={8}
-            />
-          </Control>
-          <Underlay
-            disabled={true}
-          >
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
-    </TextInput>
+              iconEnd={null}
+              size="large"
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+                disabled={true}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Hello World",
+                        "disabled": true,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
+                    }
+                    controlRef={[Function]}
+                    defaultValue="Hello World"
+                    disabled={true}
+                    iconEnd={null}
+                    innerRef={[Function]}
+                    key="control"
+                    onInput={[Function]}
+                    resizeable={true}
+                    rows={8}
+                    size="large"
+                  >
+                    <textarea
+                      className="emotion-0"
+                      defaultValue="Hello World"
+                      disabled={true}
+                      onInput={[Function]}
+                      rows={8}
+                    />
+                  </Control>
+                  <Underlay
+                    disabled={true}
+                  >
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
+    </TextArea>
   </TextArea>
 </TextArea>
 `;
@@ -1105,7 +1365,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
   z-index: -1;
 }
 
-.emotion-9[class] > *:not(:last-child) {
+.emotion-11[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -1179,7 +1439,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-8 {
+.emotion-10 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -1190,9 +1450,9 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-8 *,
-.emotion-8 *::before,
-.emotion-8 *::after {
+.emotion-10 *,
+.emotion-10 *::before,
+.emotion-10 *::after {
   box-sizing: inherit;
 }
 
@@ -1224,7 +1484,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
   font-weight: 400;
 }
 
-.emotion-7 {
+.emotion-9 {
   color: #58606e;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
@@ -1235,7 +1495,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-9"
+      className="emotion-11"
     >
       <FormField
         autoSize={true}
@@ -1248,7 +1508,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
       >
         <FormField>
           <div
-            className="emotion-8"
+            className="emotion-10"
           >
             <label>
               <Styled(div)
@@ -1299,7 +1559,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
                   iconEnd={null}
                   size="large"
                 >
-                  <TextInput
+                  <TextArea
                     className="emotion-5"
                     control={[Function]}
                     controlProps={
@@ -1321,60 +1581,110 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
                     iconEnd={null}
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-5"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": "formField-1-caption",
+                          "aria-invalid": undefined,
+                          "aria-required": true,
+                          "autoSize": true,
+                          "controlRef": [Function],
+                          "disabled": undefined,
+                          "onInput": [Function],
+                          "readOnly": undefined,
+                          "required": true,
+                          "resizeable": false,
+                          "rows": 2,
+                          "size": "large",
+                        }
+                      }
+                      iconEnd={null}
+                      size="large"
                     >
-                      <div
-                        className="emotion-4"
-                      >
-                        <Control
-                          aria-describedby="formField-1-caption"
-                          aria-required={true}
-                          autoSize={true}
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": "formField-1-caption",
-                              "aria-invalid": undefined,
-                              "aria-required": true,
-                              "autoSize": true,
-                              "controlRef": [Function],
-                              "disabled": undefined,
-                              "onInput": [Function],
-                              "readOnly": undefined,
-                              "required": true,
-                              "resizeable": false,
-                              "rows": 2,
-                              "size": "large",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-5"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": "formField-1-caption",
+                                "aria-invalid": undefined,
+                                "aria-required": true,
+                                "autoSize": true,
+                                "controlRef": [Function],
+                                "disabled": undefined,
+                                "onInput": [Function],
+                                "readOnly": undefined,
+                                "required": true,
+                                "resizeable": false,
+                                "rows": 2,
+                                "size": "large",
+                              }
                             }
-                          }
-                          controlRef={[Function]}
-                          iconEnd={null}
-                          innerRef={[Function]}
-                          key="control"
-                          onInput={[Function]}
-                          required={true}
-                          resizeable={false}
-                          rows={2}
-                          size="large"
-                        >
-                          <textarea
-                            aria-describedby="formField-1-caption"
-                            aria-required={true}
-                            className="emotion-2"
-                            onInput={[Function]}
-                            required={true}
-                            rows={2}
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-3"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
-                  </TextInput>
+                            iconEnd={null}
+                            size="large"
+                          >
+                            <FauxControl
+                              className="emotion-5"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-4"
+                              >
+                                <Control
+                                  aria-describedby="formField-1-caption"
+                                  aria-required={true}
+                                  autoSize={true}
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": "formField-1-caption",
+                                      "aria-invalid": undefined,
+                                      "aria-required": true,
+                                      "autoSize": true,
+                                      "controlRef": [Function],
+                                      "disabled": undefined,
+                                      "onInput": [Function],
+                                      "readOnly": undefined,
+                                      "required": true,
+                                      "resizeable": false,
+                                      "rows": 2,
+                                      "size": "large",
+                                    }
+                                  }
+                                  controlRef={[Function]}
+                                  iconEnd={null}
+                                  innerRef={[Function]}
+                                  key="control"
+                                  onInput={[Function]}
+                                  required={true}
+                                  resizeable={false}
+                                  rows={2}
+                                  size="large"
+                                >
+                                  <textarea
+                                    aria-describedby="formField-1-caption"
+                                    aria-required={true}
+                                    className="emotion-2"
+                                    onInput={[Function]}
+                                    required={true}
+                                    rows={2}
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-3"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
+                  </TextArea>
                 </TextArea>
               </TextArea>
             </label>
@@ -1383,7 +1693,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
               id="formField-1-caption"
             >
               <div
-                className="emotion-7"
+                className="emotion-9"
                 id="formField-1-caption"
               >
                 Please keep comments brief and descriptive
@@ -1538,11 +1848,11 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   z-index: -1;
 }
 
-.emotion-8[class] > *:not(:last-child) {
+.emotion-10[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -1568,13 +1878,13 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   vertical-align: middle;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
-.emotion-7:focus {
+.emotion-9:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -1582,41 +1892,41 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   text-decoration: none;
 }
 
-.emotion-7:hover {
+.emotion-9:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-7:active {
+.emotion-9:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-7::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-7 [role="img"] {
+.emotion-9 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-7 [role="img"]:first-child {
+.emotion-9 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-7 [role="img"]:last-child {
+.emotion-9 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-7 [role="img"]:only-child {
+.emotion-9 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-6 {
+.emotion-8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1634,7 +1944,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   width: 100%;
 }
 
-.emotion-5 {
+.emotion-7 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -1645,11 +1955,11 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-5:first-child {
+.emotion-7:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-5:last-child {
+.emotion-7:last-child {
   padding-right: 0.5714285714285714em;
 }
 
@@ -1660,7 +1970,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
         marginBottom="1rem"
       >
         <div
-          className="emotion-8"
+          className="emotion-10"
         >
           <TextArea
             inputRef={[Function]}
@@ -1685,7 +1995,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
               iconEnd={null}
               size="large"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -1706,52 +2016,100 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
                 iconEnd={null}
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": undefined,
+                      "controlRef": [Function],
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": true,
+                      "rows": 8,
+                      "size": "large",
+                    }
+                  }
+                  iconEnd={null}
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": undefined,
-                          "controlRef": [Function],
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": true,
-                          "rows": 8,
-                          "size": "large",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": undefined,
+                            "controlRef": [Function],
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": true,
+                            "rows": 8,
+                            "size": "large",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={true}
-                      rows={8}
-                      size="large"
-                    >
-                      <textarea
-                        className="emotion-0"
-                        onInput={[Function]}
-                        rows={8}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="large"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": undefined,
+                                  "controlRef": [Function],
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": true,
+                                  "rows": 8,
+                                  "size": "large",
+                                }
+                              }
+                              controlRef={[Function]}
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={true}
+                              rows={8}
+                              size="large"
+                            >
+                              <textarea
+                                className="emotion-0"
+                                onInput={[Function]}
+                                rows={8}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <Button
@@ -1768,19 +2126,19 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
               type="button"
             >
               <button
-                className="emotion-7"
+                className="emotion-9"
                 onClick={[Function]}
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-6"
+                    className="emotion-8"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-5"
+                        className="emotion-7"
                       >
                         Focus the input
                       </span>
@@ -1961,7 +2319,7 @@ exports[`TextArea demo examples Snapshots: invalid 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextInput
+    <TextArea
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -1982,54 +2340,102 @@ exports[`TextArea demo examples Snapshots: invalid 1`] = `
       iconEnd={null}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": true,
+            "aria-required": undefined,
+            "autoSize": undefined,
+            "controlRef": [Function],
+            "disabled": undefined,
+            "onInput": [Function],
+            "readOnly": undefined,
+            "required": undefined,
+            "resizeable": true,
+            "rows": 8,
+            "size": "large",
+          }
+        }
+        iconEnd={null}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            aria-invalid={true}
-            controlPropsIn={
-              Object {
-                "aria-invalid": true,
-                "aria-required": undefined,
-                "autoSize": undefined,
-                "controlRef": [Function],
-                "disabled": undefined,
-                "onInput": [Function],
-                "readOnly": undefined,
-                "required": undefined,
-                "resizeable": true,
-                "rows": 8,
-                "size": "large",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": true,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
               }
-            }
-            controlRef={[Function]}
-            iconEnd={null}
-            innerRef={[Function]}
-            key="control"
-            onInput={[Function]}
-            resizeable={true}
-            rows={8}
-            size="large"
-          >
-            <textarea
-              aria-invalid={true}
-              className="emotion-0"
-              onInput={[Function]}
-              rows={8}
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
-    </TextInput>
+              iconEnd={null}
+              size="large"
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    aria-invalid={true}
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": true,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
+                    }
+                    controlRef={[Function]}
+                    iconEnd={null}
+                    innerRef={[Function]}
+                    key="control"
+                    onInput={[Function]}
+                    resizeable={true}
+                    rows={8}
+                    size="large"
+                  >
+                    <textarea
+                      aria-invalid={true}
+                      className="emotion-0"
+                      onInput={[Function]}
+                      rows={8}
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
+    </TextArea>
   </TextArea>
 </TextArea>
 `;
@@ -2091,7 +2497,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-36 {
+.emotion-48 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2116,47 +2522,47 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-36::-webkit-input-placeholder {
+.emotion-48::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-36::-moz-placeholder {
+.emotion-48::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-36:-ms-input-placeholder {
+.emotion-48:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-36::placeholder {
+.emotion-48::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-36::-ms-input-placeholder {
+.emotion-48::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-36:-ms-input-placeholder {
+.emotion-48:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-36::-ms-clear {
+.emotion-48::-ms-clear {
   display: none;
 }
 
-.emotion-36:focus ~ div:last-child {
+.emotion-48:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -2245,7 +2651,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-18 {
+.emotion-24 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2270,52 +2676,52 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-24::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-24::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-24:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::placeholder {
+.emotion-24::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-24::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-24:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-clear {
+.emotion-24::-ms-clear {
   display: none;
 }
 
-.emotion-18:focus ~ div:last-child {
+.emotion-24:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-54 {
+.emotion-72 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2340,52 +2746,52 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-54::-webkit-input-placeholder {
+.emotion-72::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-54::-moz-placeholder {
+.emotion-72::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-54:-ms-input-placeholder {
+.emotion-72:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-54::placeholder {
+.emotion-72::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-54::-ms-input-placeholder {
+.emotion-72::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-54:-ms-input-placeholder {
+.emotion-72:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-54::-ms-clear {
+.emotion-72::-ms-clear {
   display: none;
 }
 
-.emotion-54:focus ~ div:last-child {
+.emotion-72:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-41 {
+.emotion-55 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2410,52 +2816,52 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-41::-webkit-input-placeholder {
+.emotion-55::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::-moz-placeholder {
+.emotion-55::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41:-ms-input-placeholder {
+.emotion-55:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::placeholder {
+.emotion-55::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::-ms-input-placeholder {
+.emotion-55::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41:-ms-input-placeholder {
+.emotion-55:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-41::-ms-clear {
+.emotion-55::-ms-clear {
   display: none;
 }
 
-.emotion-41:focus ~ div:last-child {
+.emotion-55:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2480,878 +2886,47 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 0.6666666666666666em;
 }
 
-.emotion-5::-webkit-input-placeholder {
+.emotion-7::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-moz-placeholder {
+.emotion-7::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::placeholder {
+.emotion-7::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-input-placeholder {
+.emotion-7::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-clear {
+.emotion-7::-ms-clear {
   display: none;
 }
 
-.emotion-5:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-53 {
-  box-sizing: border-box;
-  color: #333840;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  background-color: #ebeff5;
-  border-color: #c8d1e0;
-  border-radius: 0.1875em;
-  border-style: solid;
-  border-width: 1px;
-  cursor: pointer;
-  display: inline-block;
-  font-weight: 600;
-  height: 2.5em;
-  margin: 0;
-  min-width: 2.5em;
-  padding: 0 0.5em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: middle;
-}
-
-.emotion-53 *,
-.emotion-53 *::before,
-.emotion-53 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-53:focus {
-  background-color: #ebeff5;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-  color: #333840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-53:hover {
-  background-color: #f5f7fa;
-  color: #333840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-53:active {
-  background-color: #dde3ed;
-  color: #333840;
-}
-
-.emotion-53::-moz-focus-inner {
-  border: 0;
-}
-
-.emotion-53 [role="img"] {
-  box-sizing: content-box;
-  color: #3272d9;
-  display: block;
-}
-
-.emotion-53 [role="img"]:first-child {
-  margin-right: 0.5em;
-}
-
-.emotion-53 [role="img"]:last-child {
-  margin-left: 0.5em;
-}
-
-.emotion-53 [role="img"]:only-child {
-  margin: 0;
-}
-
-.emotion-16 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  max-height: 100%;
-  pointer-events: none;
-  width: 100%;
-}
-
-.emotion-51 {
-  display: block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
-  font-size: 0.875em;
-  line-height: 2.857142857142857em;
-}
-
-.emotion-51:first-child {
-  padding-left: 0.5714285714285714em;
-}
-
-.emotion-51:last-child {
-  padding-right: 0.5714285714285714em;
-}
-
-.emotion-73 > * {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-73 > * > div {
-  -webkit-flex: 0 0 8rem;
-  -ms-flex: 0 0 8rem;
-  flex: 0 0 8rem;
-  margin-right: 0.5rem;
-}
-
-.emotion-72[class] > *:not(:last-child) {
-  margin-bottom: 1rem;
-}
-
-.emotion-72 > * {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-72 > * > div {
-  -webkit-flex: 0 0 8rem;
-  -ms-flex: 0 0 8rem;
-  flex: 0 0 8rem;
-  margin-right: 0.5rem;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: text;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-}
-
-.emotion-13 [role="img"] {
-  color: #c8d1e0;
-  display: block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  margin: 0 0.5em;
-}
-
-.emotion-13 [role="img"]:last-of-type {
-  color: #c8d1e0;
-}
-
-.emotion-12 {
-  box-sizing: border-box;
-  color: #333840;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  position: relative;
-  z-index: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: text;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-}
-
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-12:hover > div:last-child {
-  border-color: #5691f0;
-}
-
-.emotion-12:focus > div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-12:active > div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-12 [role="img"] {
-  color: #c8d1e0;
-  display: block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  margin: 0 0.5em;
-}
-
-.emotion-12 [role="img"]:last-of-type {
-  color: #c8d1e0;
-}
-
-.emotion-10 {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  font-family: inherit;
-  height: 2em;
-  min-width: 0;
-  width: 100%;
-  color: #333840;
-  -webkit-text-fill-color: #333840;
-  font-size: 0.75em;
-  outline: 0;
-  padding-left: 0.6666666666666666em;
-  padding-right: 0.6666666666666666em;
-}
-
-.emotion-10[type="search"] {
-  -webkit-appearance: none;
-}
-
-.emotion-10[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.emotion-10::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-10::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-10:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-10::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-10::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-10:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-10::-ms-clear {
-  display: none;
-}
-
-.emotion-10:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-17 {
-  box-sizing: border-box;
-  color: #333840;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  background-color: #ebeff5;
-  border-color: #c8d1e0;
-  border-radius: 0.1875em;
-  border-style: solid;
-  border-width: 1px;
-  cursor: pointer;
-  display: inline-block;
-  font-weight: 600;
-  height: 1.5em;
-  margin: 0;
-  min-width: 1.5em;
-  padding: 0 0.5em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: middle;
-}
-
-.emotion-17 *,
-.emotion-17 *::before,
-.emotion-17 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-17:focus {
-  background-color: #ebeff5;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-  color: #333840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-17:hover {
-  background-color: #f5f7fa;
-  color: #333840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-17:active {
-  background-color: #dde3ed;
-  color: #333840;
-}
-
-.emotion-17::-moz-focus-inner {
-  border: 0;
-}
-
-.emotion-17 [role="img"] {
-  box-sizing: content-box;
-  color: #3272d9;
-  display: block;
-}
-
-.emotion-17 [role="img"]:first-child {
-  margin-right: 0.5em;
-}
-
-.emotion-17 [role="img"]:last-child {
-  margin-left: 0.5em;
-}
-
-.emotion-17 [role="img"]:only-child {
-  margin: 0;
-}
-
-.emotion-15 {
-  display: block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
-  font-size: 0.75em;
-  line-height: 2em;
-}
-
-.emotion-23 {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  font-family: inherit;
-  line-height: 1.5;
-  margin: 1px;
-  min-height: 1.9866071428571428em;
-  min-width: 0;
-  outline: 0;
-  padding-bottom: 0.32142857142857145em;
-  padding-top: 0.32142857142857145em;
-  resize: none;
-  width: 100%;
-  color: #333840;
-  -webkit-text-fill-color: #333840;
-  font-size: 0.875em;
-  outline: 0;
-  padding-left: 0.5714285714285714em;
-  padding-right: 0.5714285714285714em;
-}
-
-.emotion-23::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-23::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-23:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-23::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-23::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-23:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-23::-ms-clear {
-  display: none;
-}
-
-.emotion-23:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-28 {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  font-family: inherit;
-  height: 2.2857142857142856em;
-  min-width: 0;
-  width: 100%;
-  color: #333840;
-  -webkit-text-fill-color: #333840;
-  font-size: 0.875em;
-  outline: 0;
-  padding-left: 0.5714285714285714em;
-  padding-right: 0.5714285714285714em;
-}
-
-.emotion-28[type="search"] {
-  -webkit-appearance: none;
-}
-
-.emotion-28[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.emotion-28::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-28::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-28:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-28::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-28::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-28:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-28::-ms-clear {
-  display: none;
-}
-
-.emotion-28:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-35 {
-  box-sizing: border-box;
-  color: #333840;
-  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 16px;
-  line-height: 1.25;
-  outline: 0;
-  -moz-osx-font-smoothing: auto;
-  -webkit-font-smoothing: antialiased;
-  background-color: #ebeff5;
-  border-color: #c8d1e0;
-  border-radius: 0.1875em;
-  border-style: solid;
-  border-width: 1px;
-  cursor: pointer;
-  display: inline-block;
-  font-weight: 600;
-  height: 2em;
-  margin: 0;
-  min-width: 2em;
-  padding: 0 0.5em;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: middle;
-}
-
-.emotion-35 *,
-.emotion-35 *::before,
-.emotion-35 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-35:focus {
-  background-color: #ebeff5;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-  color: #333840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-35:hover {
-  background-color: #f5f7fa;
-  color: #333840;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-35:active {
-  background-color: #dde3ed;
-  color: #333840;
-}
-
-.emotion-35::-moz-focus-inner {
-  border: 0;
-}
-
-.emotion-35 [role="img"] {
-  box-sizing: content-box;
-  color: #3272d9;
-  display: block;
-}
-
-.emotion-35 [role="img"]:first-child {
-  margin-right: 0.5em;
-}
-
-.emotion-35 [role="img"]:last-child {
-  margin-left: 0.5em;
-}
-
-.emotion-35 [role="img"]:only-child {
-  margin: 0;
-}
-
-.emotion-33 {
-  display: block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
-  font-size: 0.875em;
-  line-height: 2.2857142857142856em;
-}
-
-.emotion-46 {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  font-family: inherit;
-  height: 2.857142857142857em;
-  min-width: 0;
-  width: 100%;
-  color: #333840;
-  -webkit-text-fill-color: #333840;
-  font-size: 0.875em;
-  outline: 0;
-  padding-left: 1.1428571428571428em;
-  padding-right: 1.1428571428571428em;
-}
-
-.emotion-46[type="search"] {
-  -webkit-appearance: none;
-}
-
-.emotion-46[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.emotion-46::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-46::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-46:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-46::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-46::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-46:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-46::-ms-clear {
-  display: none;
-}
-
-.emotion-46:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-59 {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  font-family: inherit;
-  line-height: 1.5;
-  margin: 1px;
-  min-height: 3.4151785714285716em;
-  min-width: 0;
-  outline: 0;
-  padding-bottom: 1.0357142857142858em;
-  padding-top: 1.0357142857142858em;
-  resize: none;
-  width: 100%;
-  color: #333840;
-  -webkit-text-fill-color: #333840;
-  font-size: 0.875em;
-  outline: 0;
-  padding-left: 1.1428571428571428em;
-  padding-right: 1.1428571428571428em;
-}
-
-.emotion-59::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-59::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-59:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-59::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-59::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-59:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-59::-ms-clear {
-  display: none;
-}
-
-.emotion-59:focus ~ div:last-child {
-  border-color: #c8d1e0;
-  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
-}
-
-.emotion-64 {
-  background-color: transparent;
-  border: 0;
-  box-shadow: none;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  font-family: inherit;
-  height: 3.7142857142857144em;
-  min-width: 0;
-  width: 100%;
-  color: #333840;
-  -webkit-text-fill-color: #333840;
-  font-size: 0.875em;
-  outline: 0;
-  padding-left: 1.1428571428571428em;
-  padding-right: 1.1428571428571428em;
-}
-
-.emotion-64[type="search"] {
-  -webkit-appearance: none;
-}
-
-.emotion-64[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.emotion-64::-webkit-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-64::-moz-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-64:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-64::placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-64::-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-64:-ms-input-placeholder {
-  color: #8e99ab;
-  -webkit-text-fill-color: #8e99ab;
-  font-style: italic;
-}
-
-.emotion-64::-ms-clear {
-  display: none;
-}
-
-.emotion-64:focus ~ div:last-child {
+.emotion-7:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -3373,9 +2948,9 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   cursor: pointer;
   display: inline-block;
   font-weight: 600;
-  height: 3.25em;
+  height: 2.5em;
   margin: 0;
-  min-width: 3.25em;
+  min-width: 2.5em;
   padding: 0 0.5em;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3430,6 +3005,24 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   margin: 0;
 }
 
+.emotion-22 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
 .emotion-69 {
   display: block;
   max-width: 100%;
@@ -3438,7 +3031,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   white-space: nowrap;
   word-wrap: normal;
   font-size: 0.875em;
-  line-height: 3.7142857142857144em;
+  line-height: 2.857142857142857em;
 }
 
 .emotion-69:first-child {
@@ -3449,16 +3042,829 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
+.emotion-97 > * {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-97 > * > div {
+  -webkit-flex: 0 0 8rem;
+  -ms-flex: 0 0 8rem;
+  flex: 0 0 8rem;
+  margin-right: 0.5rem;
+}
+
+.emotion-96[class] > *:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.emotion-96 > * {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-96 > * > div {
+  -webkit-flex: 0 0 8rem;
+  -ms-flex: 0 0 8rem;
+  flex: 0 0 8rem;
+  margin-right: 0.5rem;
+}
+
+.emotion-17 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: text;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-17 [role="img"] {
+  color: #c8d1e0;
+  display: block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0 0.5em;
+}
+
+.emotion-17 [role="img"]:last-of-type {
+  color: #c8d1e0;
+}
+
+.emotion-16 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  z-index: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: text;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-16 *,
+.emotion-16 *::before,
+.emotion-16 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-16:hover > div:last-child {
+  border-color: #5691f0;
+}
+
+.emotion-16:focus > div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-16:active > div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-16 [role="img"] {
+  color: #c8d1e0;
+  display: block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0 0.5em;
+}
+
+.emotion-16 [role="img"]:last-of-type {
+  color: #c8d1e0;
+}
+
+.emotion-14 {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  font-family: inherit;
+  height: 2em;
+  min-width: 0;
+  width: 100%;
+  color: #333840;
+  -webkit-text-fill-color: #333840;
+  font-size: 0.75em;
+  outline: 0;
+  padding-left: 0.6666666666666666em;
+  padding-right: 0.6666666666666666em;
+}
+
+.emotion-14[type="search"] {
+  -webkit-appearance: none;
+}
+
+.emotion-14[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.emotion-14::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-14::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-14:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-14::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-14::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-14:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-14::-ms-clear {
+  display: none;
+}
+
+.emotion-14:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-23 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 1.5em;
+  margin: 0;
+  min-width: 1.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-23 *,
+.emotion-23 *::before,
+.emotion-23 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-23:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-23:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-23:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-23::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-23 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-23 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-23 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-23 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-21 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.75em;
+  line-height: 2em;
+}
+
+.emotion-31 {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  font-family: inherit;
+  line-height: 1.5;
+  margin: 1px;
+  min-height: 1.9866071428571428em;
+  min-width: 0;
+  outline: 0;
+  padding-bottom: 0.32142857142857145em;
+  padding-top: 0.32142857142857145em;
+  resize: none;
+  width: 100%;
+  color: #333840;
+  -webkit-text-fill-color: #333840;
+  font-size: 0.875em;
+  outline: 0;
+  padding-left: 0.5714285714285714em;
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-31::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-31::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-31:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-31::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-31::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-31:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-31::-ms-clear {
+  display: none;
+}
+
+.emotion-31:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-38 {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  font-family: inherit;
+  height: 2.2857142857142856em;
+  min-width: 0;
+  width: 100%;
+  color: #333840;
+  -webkit-text-fill-color: #333840;
+  font-size: 0.875em;
+  outline: 0;
+  padding-left: 0.5714285714285714em;
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-38[type="search"] {
+  -webkit-appearance: none;
+}
+
+.emotion-38[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.emotion-38::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-38::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-38:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-38::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-38::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-38:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-38::-ms-clear {
+  display: none;
+}
+
+.emotion-38:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-47 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2em;
+  margin: 0;
+  min-width: 2em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-47 *,
+.emotion-47 *::before,
+.emotion-47 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-47:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-47:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-47:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-47::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-47 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-47 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-47 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-47 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-45 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.2857142857142856em;
+}
+
+.emotion-62 {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  font-family: inherit;
+  height: 2.857142857142857em;
+  min-width: 0;
+  width: 100%;
+  color: #333840;
+  -webkit-text-fill-color: #333840;
+  font-size: 0.875em;
+  outline: 0;
+  padding-left: 1.1428571428571428em;
+  padding-right: 1.1428571428571428em;
+}
+
+.emotion-62[type="search"] {
+  -webkit-appearance: none;
+}
+
+.emotion-62[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.emotion-62::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-62::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-62:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-62::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-62::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-62:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-62::-ms-clear {
+  display: none;
+}
+
+.emotion-62:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-79 {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  font-family: inherit;
+  line-height: 1.5;
+  margin: 1px;
+  min-height: 3.4151785714285716em;
+  min-width: 0;
+  outline: 0;
+  padding-bottom: 1.0357142857142858em;
+  padding-top: 1.0357142857142858em;
+  resize: none;
+  width: 100%;
+  color: #333840;
+  -webkit-text-fill-color: #333840;
+  font-size: 0.875em;
+  outline: 0;
+  padding-left: 1.1428571428571428em;
+  padding-right: 1.1428571428571428em;
+}
+
+.emotion-79::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-79::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-79:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-79::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-79::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-79:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-79::-ms-clear {
+  display: none;
+}
+
+.emotion-79:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-86 {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  font-family: inherit;
+  height: 3.7142857142857144em;
+  min-width: 0;
+  width: 100%;
+  color: #333840;
+  -webkit-text-fill-color: #333840;
+  font-size: 0.875em;
+  outline: 0;
+  padding-left: 1.1428571428571428em;
+  padding-right: 1.1428571428571428em;
+}
+
+.emotion-86[type="search"] {
+  -webkit-appearance: none;
+}
+
+.emotion-86[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.emotion-86::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-86::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-86:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-86::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-86::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-86:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-86::-ms-clear {
+  display: none;
+}
+
+.emotion-86:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-95 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ebeff5;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 3.25em;
+  margin: 0;
+  min-width: 3.25em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-95 *,
+.emotion-95 *::before,
+.emotion-95 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-95:focus {
+  background-color: #ebeff5;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-95:hover {
+  background-color: #f5f7fa;
+  color: #333840;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-95:active {
+  background-color: #dde3ed;
+  color: #333840;
+}
+
+.emotion-95::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-95 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+}
+
+.emotion-95 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-95 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-95 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-93 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 3.7142857142857144em;
+}
+
+.emotion-93:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-93:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
 <Styled(DemoLayout)>
   <DemoLayout
-    className="emotion-73"
+    className="emotion-97"
   >
     <Styled(div)
-      className="emotion-73"
+      className="emotion-97"
       marginBottom="1rem"
     >
       <div
-        className="emotion-72"
+        className="emotion-96"
       >
         <div>
           <TextArea
@@ -3487,7 +3893,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="small"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3509,55 +3915,105 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="small"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": undefined,
+                      "controlRef": [Function],
+                      "defaultValue": "Small",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": true,
+                      "rows": 1,
+                      "size": "small",
+                    }
+                  }
+                  iconEnd={null}
+                  size="small"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": undefined,
-                          "controlRef": [Function],
-                          "defaultValue": "Small",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": true,
-                          "rows": 1,
-                          "size": "small",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": undefined,
+                            "controlRef": [Function],
+                            "defaultValue": "Small",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": true,
+                            "rows": 1,
+                            "size": "small",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Small"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={true}
-                      rows={1}
-                      size="small"
-                    >
-                      <textarea
-                        className="emotion-0"
-                        defaultValue="Small"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="small"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": undefined,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Small",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": true,
+                                  "rows": 1,
+                                  "size": "small",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Small"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={true}
+                              rows={1}
+                              size="small"
+                            >
+                              <textarea
+                                className="emotion-0"
+                                defaultValue="Small"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextArea
@@ -3587,7 +4043,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="small"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3609,56 +4065,106 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="small"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": true,
+                      "controlRef": [Function],
+                      "defaultValue": "Small",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": false,
+                      "rows": 1,
+                      "size": "small",
+                    }
+                  }
+                  iconEnd={null}
+                  size="small"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      autoSize={true}
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": true,
-                          "controlRef": [Function],
-                          "defaultValue": "Small",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": false,
-                          "rows": 1,
-                          "size": "small",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": true,
+                            "controlRef": [Function],
+                            "defaultValue": "Small",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": false,
+                            "rows": 1,
+                            "size": "small",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Small"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={false}
-                      rows={1}
-                      size="small"
-                    >
-                      <textarea
-                        className="emotion-5"
-                        defaultValue="Small"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="small"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              autoSize={true}
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": true,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Small",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": false,
+                                  "rows": 1,
+                                  "size": "small",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Small"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={false}
+                              rows={1}
+                              size="small"
+                            >
+                              <textarea
+                                className="emotion-7"
+                                defaultValue="Small"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextInput
@@ -3683,7 +4189,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               size="small"
             >
               <TextInput
-                className="emotion-13"
+                className="emotion-17"
                 control={[Function]}
                 controlProps={
                   Object {
@@ -3699,45 +4205,85 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="small"
               >
-                <FauxControl
-                  className="emotion-13"
+                <Themed(FauxControl)
+                  className="emotion-17"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Small",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="small"
                 >
-                  <div
-                    className="emotion-12"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Small",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-17"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Small",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Small"
-                      key="control"
-                      size="small"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-10"
-                        defaultValue="Small"
                         size="small"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-17"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-16"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Small",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Small"
+                              key="control"
+                              size="small"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-14"
+                                defaultValue="Small"
+                                size="small"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3753,18 +4299,18 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-17"
+                className="emotion-23"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-16"
+                    className="emotion-22"
                   >
                     <Styled(span)
                       size="small"
                     >
                       <span
-                        className="emotion-15"
+                        className="emotion-21"
                       >
                         Small
                       </span>
@@ -3802,7 +4348,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="medium"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3824,55 +4370,105 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="medium"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": undefined,
+                      "controlRef": [Function],
+                      "defaultValue": "Medium",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": true,
+                      "rows": 1,
+                      "size": "medium",
+                    }
+                  }
+                  iconEnd={null}
+                  size="medium"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": undefined,
-                          "controlRef": [Function],
-                          "defaultValue": "Medium",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": true,
-                          "rows": 1,
-                          "size": "medium",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": undefined,
+                            "controlRef": [Function],
+                            "defaultValue": "Medium",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": true,
+                            "rows": 1,
+                            "size": "medium",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Medium"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={true}
-                      rows={1}
-                      size="medium"
-                    >
-                      <textarea
-                        className="emotion-18"
-                        defaultValue="Medium"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="medium"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": undefined,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Medium",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": true,
+                                  "rows": 1,
+                                  "size": "medium",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Medium"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={true}
+                              rows={1}
+                              size="medium"
+                            >
+                              <textarea
+                                className="emotion-24"
+                                defaultValue="Medium"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextArea
@@ -3902,7 +4498,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="medium"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3924,56 +4520,106 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="medium"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": true,
+                      "controlRef": [Function],
+                      "defaultValue": "Medium",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": false,
+                      "rows": 1,
+                      "size": "medium",
+                    }
+                  }
+                  iconEnd={null}
+                  size="medium"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      autoSize={true}
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": true,
-                          "controlRef": [Function],
-                          "defaultValue": "Medium",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": false,
-                          "rows": 1,
-                          "size": "medium",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": true,
+                            "controlRef": [Function],
+                            "defaultValue": "Medium",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": false,
+                            "rows": 1,
+                            "size": "medium",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Medium"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={false}
-                      rows={1}
-                      size="medium"
-                    >
-                      <textarea
-                        className="emotion-23"
-                        defaultValue="Medium"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="medium"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              autoSize={true}
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": true,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Medium",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": false,
+                                  "rows": 1,
+                                  "size": "medium",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Medium"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={false}
+                              rows={1}
+                              size="medium"
+                            >
+                              <textarea
+                                className="emotion-31"
+                                defaultValue="Medium"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextInput
@@ -3998,7 +4644,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               size="medium"
             >
               <TextInput
-                className="emotion-13"
+                className="emotion-17"
                 control={[Function]}
                 controlProps={
                   Object {
@@ -4014,45 +4660,85 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="medium"
               >
-                <FauxControl
-                  className="emotion-13"
+                <Themed(FauxControl)
+                  className="emotion-17"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Medium",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="medium"
                 >
-                  <div
-                    className="emotion-12"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Medium",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-17"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Medium",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Medium"
-                      key="control"
-                      size="medium"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-28"
-                        defaultValue="Medium"
                         size="medium"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-17"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-16"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Medium",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Medium"
+                              key="control"
+                              size="medium"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-38"
+                                defaultValue="Medium"
+                                size="medium"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4068,18 +4754,18 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-35"
+                className="emotion-47"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-16"
+                    className="emotion-22"
                   >
                     <Styled(span)
                       size="medium"
                     >
                       <span
-                        className="emotion-33"
+                        className="emotion-45"
                       >
                         Medium
                       </span>
@@ -4116,7 +4802,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="large"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4138,55 +4824,105 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": undefined,
+                      "controlRef": [Function],
+                      "defaultValue": "Large",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": true,
+                      "rows": 1,
+                      "size": "large",
+                    }
+                  }
+                  iconEnd={null}
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": undefined,
-                          "controlRef": [Function],
-                          "defaultValue": "Large",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": true,
-                          "rows": 1,
-                          "size": "large",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": undefined,
+                            "controlRef": [Function],
+                            "defaultValue": "Large",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": true,
+                            "rows": 1,
+                            "size": "large",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Large"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={true}
-                      rows={1}
-                      size="large"
-                    >
-                      <textarea
-                        className="emotion-36"
-                        defaultValue="Large"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="large"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": undefined,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Large",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": true,
+                                  "rows": 1,
+                                  "size": "large",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Large"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={true}
+                              rows={1}
+                              size="large"
+                            >
+                              <textarea
+                                className="emotion-48"
+                                defaultValue="Large"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextArea
@@ -4215,7 +4951,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="large"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4237,56 +4973,106 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": true,
+                      "controlRef": [Function],
+                      "defaultValue": "Large",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": false,
+                      "rows": 1,
+                      "size": "large",
+                    }
+                  }
+                  iconEnd={null}
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      autoSize={true}
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": true,
-                          "controlRef": [Function],
-                          "defaultValue": "Large",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": false,
-                          "rows": 1,
-                          "size": "large",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": true,
+                            "controlRef": [Function],
+                            "defaultValue": "Large",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": false,
+                            "rows": 1,
+                            "size": "large",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Large"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={false}
-                      rows={1}
-                      size="large"
-                    >
-                      <textarea
-                        className="emotion-41"
-                        defaultValue="Large"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="large"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              autoSize={true}
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": true,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Large",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": false,
+                                  "rows": 1,
+                                  "size": "large",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Large"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={false}
+                              rows={1}
+                              size="large"
+                            >
+                              <textarea
+                                className="emotion-55"
+                                defaultValue="Large"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextInput
@@ -4311,7 +5097,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               size="large"
             >
               <TextInput
-                className="emotion-13"
+                className="emotion-17"
                 control={[Function]}
                 controlProps={
                   Object {
@@ -4327,45 +5113,85 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="large"
               >
-                <FauxControl
-                  className="emotion-13"
+                <Themed(FauxControl)
+                  className="emotion-17"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Large",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="large"
                 >
-                  <div
-                    className="emotion-12"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Large",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-17"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Large",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Large"
-                      key="control"
-                      size="large"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-46"
-                        defaultValue="Large"
                         size="large"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-17"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-16"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Large",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Large"
+                              key="control"
+                              size="large"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-62"
+                                defaultValue="Large"
+                                size="large"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4381,18 +5207,18 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-53"
+                className="emotion-71"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-16"
+                    className="emotion-22"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-51"
+                        className="emotion-69"
                       >
                         Large
                       </span>
@@ -4430,7 +5256,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="jumbo"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4452,55 +5278,105 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="jumbo"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": undefined,
+                      "controlRef": [Function],
+                      "defaultValue": "Jumbo",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": true,
+                      "rows": 1,
+                      "size": "jumbo",
+                    }
+                  }
+                  iconEnd={null}
+                  size="jumbo"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": undefined,
-                          "controlRef": [Function],
-                          "defaultValue": "Jumbo",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": true,
-                          "rows": 1,
-                          "size": "jumbo",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": undefined,
+                            "controlRef": [Function],
+                            "defaultValue": "Jumbo",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": true,
+                            "rows": 1,
+                            "size": "jumbo",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Jumbo"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={true}
-                      rows={1}
-                      size="jumbo"
-                    >
-                      <textarea
-                        className="emotion-54"
-                        defaultValue="Jumbo"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="jumbo"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": undefined,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Jumbo",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": true,
+                                  "rows": 1,
+                                  "size": "jumbo",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Jumbo"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={true}
+                              rows={1}
+                              size="jumbo"
+                            >
+                              <textarea
+                                className="emotion-72"
+                                defaultValue="Jumbo"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextArea
@@ -4530,7 +5406,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="jumbo"
             >
-              <TextInput
+              <TextArea
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4552,56 +5428,106 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 iconEnd={null}
                 size="jumbo"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "autoSize": true,
+                      "controlRef": [Function],
+                      "defaultValue": "Jumbo",
+                      "disabled": undefined,
+                      "onInput": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "resizeable": false,
+                      "rows": 1,
+                      "size": "jumbo",
+                    }
+                  }
+                  iconEnd={null}
+                  size="jumbo"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      autoSize={true}
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "autoSize": true,
-                          "controlRef": [Function],
-                          "defaultValue": "Jumbo",
-                          "disabled": undefined,
-                          "onInput": [Function],
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "resizeable": false,
-                          "rows": 1,
-                          "size": "jumbo",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "autoSize": true,
+                            "controlRef": [Function],
+                            "defaultValue": "Jumbo",
+                            "disabled": undefined,
+                            "onInput": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "resizeable": false,
+                            "rows": 1,
+                            "size": "jumbo",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      defaultValue="Jumbo"
-                      iconEnd={null}
-                      innerRef={[Function]}
-                      key="control"
-                      onInput={[Function]}
-                      resizeable={false}
-                      rows={1}
-                      size="jumbo"
-                    >
-                      <textarea
-                        className="emotion-59"
-                        defaultValue="Jumbo"
-                        onInput={[Function]}
-                        rows={1}
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
-              </TextInput>
+                        iconEnd={null}
+                        size="jumbo"
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              autoSize={true}
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "autoSize": true,
+                                  "controlRef": [Function],
+                                  "defaultValue": "Jumbo",
+                                  "disabled": undefined,
+                                  "onInput": [Function],
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "resizeable": false,
+                                  "rows": 1,
+                                  "size": "jumbo",
+                                }
+                              }
+                              controlRef={[Function]}
+                              defaultValue="Jumbo"
+                              iconEnd={null}
+                              innerRef={[Function]}
+                              key="control"
+                              onInput={[Function]}
+                              resizeable={false}
+                              rows={1}
+                              size="jumbo"
+                            >
+                              <textarea
+                                className="emotion-79"
+                                defaultValue="Jumbo"
+                                onInput={[Function]}
+                                rows={1}
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
+              </TextArea>
             </TextArea>
           </TextArea>
           <TextInput
@@ -4626,7 +5552,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               size="jumbo"
             >
               <TextInput
-                className="emotion-13"
+                className="emotion-17"
                 control={[Function]}
                 controlProps={
                   Object {
@@ -4642,45 +5568,85 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                 }
                 size="jumbo"
               >
-                <FauxControl
-                  className="emotion-13"
+                <Themed(FauxControl)
+                  className="emotion-17"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Jumbo",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="jumbo"
                 >
-                  <div
-                    className="emotion-12"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Jumbo",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-17"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Jumbo",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Jumbo"
-                      key="control"
-                      size="jumbo"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-64"
-                        defaultValue="Jumbo"
                         size="jumbo"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-17"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-16"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Jumbo",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Jumbo"
+                              key="control"
+                              size="jumbo"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-86"
+                                defaultValue="Jumbo"
+                                size="jumbo"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4696,18 +5662,18 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               type="button"
             >
               <button
-                className="emotion-71"
+                className="emotion-95"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-16"
+                    className="emotion-22"
                   >
                     <Styled(span)
                       size="jumbo"
                     >
                       <span
-                        className="emotion-69"
+                        className="emotion-93"
                       >
                         Jumbo
                       </span>
@@ -4889,7 +5855,7 @@ exports[`TextArea demo examples Snapshots: placeholder 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextInput
+    <TextArea
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -4911,55 +5877,105 @@ exports[`TextArea demo examples Snapshots: placeholder 1`] = `
       iconEnd={null}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "autoSize": undefined,
+            "controlRef": [Function],
+            "disabled": undefined,
+            "onInput": [Function],
+            "placeholder": "Leave a comment",
+            "readOnly": undefined,
+            "required": undefined,
+            "resizeable": true,
+            "rows": 8,
+            "size": "large",
+          }
+        }
+        iconEnd={null}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "autoSize": undefined,
-                "controlRef": [Function],
-                "disabled": undefined,
-                "onInput": [Function],
-                "placeholder": "Leave a comment",
-                "readOnly": undefined,
-                "required": undefined,
-                "resizeable": true,
-                "rows": 8,
-                "size": "large",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "placeholder": "Leave a comment",
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
               }
-            }
-            controlRef={[Function]}
-            iconEnd={null}
-            innerRef={[Function]}
-            key="control"
-            onInput={[Function]}
-            placeholder="Leave a comment"
-            resizeable={true}
-            rows={8}
-            size="large"
-          >
-            <textarea
-              className="emotion-0"
-              onInput={[Function]}
-              placeholder="Leave a comment"
-              rows={8}
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
-    </TextInput>
+              iconEnd={null}
+              size="large"
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "placeholder": "Leave a comment",
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
+                    }
+                    controlRef={[Function]}
+                    iconEnd={null}
+                    innerRef={[Function]}
+                    key="control"
+                    onInput={[Function]}
+                    placeholder="Leave a comment"
+                    resizeable={true}
+                    rows={8}
+                    size="large"
+                  >
+                    <textarea
+                      className="emotion-0"
+                      onInput={[Function]}
+                      placeholder="Leave a comment"
+                      rows={8}
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
+    </TextArea>
   </TextArea>
 </TextArea>
 `;
@@ -5131,7 +6147,7 @@ exports[`TextArea demo examples Snapshots: read-only 1`] = `
     readOnly={true}
     size="large"
   >
-    <TextInput
+    <TextArea
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -5154,60 +6170,112 @@ exports[`TextArea demo examples Snapshots: read-only 1`] = `
       readOnly={true}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "autoSize": undefined,
+            "controlRef": [Function],
+            "defaultValue": "Hello World",
+            "disabled": undefined,
+            "onInput": [Function],
+            "readOnly": true,
+            "required": undefined,
+            "resizeable": true,
+            "rows": 8,
+            "size": "large",
+          }
+        }
+        iconEnd={null}
+        readOnly={true}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "autoSize": undefined,
-                "controlRef": [Function],
-                "defaultValue": "Hello World",
-                "disabled": undefined,
-                "onInput": [Function],
-                "readOnly": true,
-                "required": undefined,
-                "resizeable": true,
-                "rows": 8,
-                "size": "large",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Hello World",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": true,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
               }
-            }
-            controlRef={[Function]}
-            defaultValue="Hello World"
-            iconEnd={null}
-            innerRef={[Function]}
-            key="control"
-            onInput={[Function]}
-            readOnly={true}
-            resizeable={true}
-            rows={8}
-            size="large"
-          >
-            <textarea
-              className="emotion-0"
-              defaultValue="Hello World"
-              onInput={[Function]}
+              iconEnd={null}
               readOnly={true}
-              rows={8}
-            />
-          </Control>
-          <Underlay
-            readOnly={true}
-          >
-            <div
-              className="emotion-1"
-              readOnly={true}
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
-    </TextInput>
+              size="large"
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Hello World",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": true,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
+                    }
+                    controlRef={[Function]}
+                    defaultValue="Hello World"
+                    iconEnd={null}
+                    innerRef={[Function]}
+                    key="control"
+                    onInput={[Function]}
+                    readOnly={true}
+                    resizeable={true}
+                    rows={8}
+                    size="large"
+                  >
+                    <textarea
+                      className="emotion-0"
+                      defaultValue="Hello World"
+                      onInput={[Function]}
+                      readOnly={true}
+                      rows={8}
+                    />
+                  </Control>
+                  <Underlay
+                    readOnly={true}
+                  >
+                    <div
+                      className="emotion-1"
+                      readOnly={true}
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
+    </TextArea>
   </TextArea>
 </TextArea>
 `;
@@ -5376,7 +6444,7 @@ exports[`TextArea demo examples Snapshots: required 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextInput
+    <TextArea
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -5397,56 +6465,104 @@ exports[`TextArea demo examples Snapshots: required 1`] = `
       iconEnd={null}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": true,
+            "autoSize": undefined,
+            "controlRef": [Function],
+            "disabled": undefined,
+            "onInput": [Function],
+            "readOnly": undefined,
+            "required": true,
+            "resizeable": true,
+            "rows": 8,
+            "size": "large",
+          }
+        }
+        iconEnd={null}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            aria-required={true}
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": true,
-                "autoSize": undefined,
-                "controlRef": [Function],
-                "disabled": undefined,
-                "onInput": [Function],
-                "readOnly": undefined,
-                "required": true,
-                "resizeable": true,
-                "rows": 8,
-                "size": "large",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": true,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": true,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
               }
-            }
-            controlRef={[Function]}
-            iconEnd={null}
-            innerRef={[Function]}
-            key="control"
-            onInput={[Function]}
-            required={true}
-            resizeable={true}
-            rows={8}
-            size="large"
-          >
-            <textarea
-              aria-required={true}
-              className="emotion-0"
-              onInput={[Function]}
-              required={true}
-              rows={8}
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
-    </TextInput>
+              iconEnd={null}
+              size="large"
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    aria-required={true}
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": true,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": true,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
+                    }
+                    controlRef={[Function]}
+                    iconEnd={null}
+                    innerRef={[Function]}
+                    key="control"
+                    onInput={[Function]}
+                    required={true}
+                    resizeable={true}
+                    rows={8}
+                    size="large"
+                  >
+                    <textarea
+                      aria-required={true}
+                      className="emotion-0"
+                      onInput={[Function]}
+                      required={true}
+                      rows={8}
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
+    </TextArea>
   </TextArea>
 </TextArea>
 `;
@@ -5508,7 +6624,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-10 {
+.emotion-14 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -5533,47 +6649,47 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-10::-webkit-input-placeholder {
+.emotion-14::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-moz-placeholder {
+.emotion-14::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::placeholder {
+.emotion-14::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-input-placeholder {
+.emotion-14::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-clear {
+.emotion-14::-ms-clear {
   display: none;
 }
 
-.emotion-10:focus ~ div:last-child {
+.emotion-14:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -5592,7 +6708,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
   z-index: -1;
 }
 
-.emotion-20[class] > *:not(:last-child) {
+.emotion-28[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -5666,7 +6782,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -5691,52 +6807,52 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-5::-webkit-input-placeholder {
+.emotion-7::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-moz-placeholder {
+.emotion-7::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::placeholder {
+.emotion-7::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-input-placeholder {
+.emotion-7::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-clear {
+.emotion-7::-ms-clear {
   display: none;
 }
 
-.emotion-5:focus ~ div:last-child {
+.emotion-7:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-15 {
+.emotion-21 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -5761,47 +6877,47 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-15::-webkit-input-placeholder {
+.emotion-21::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-moz-placeholder {
+.emotion-21::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15:-ms-input-placeholder {
+.emotion-21:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::placeholder {
+.emotion-21::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-ms-input-placeholder {
+.emotion-21::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15:-ms-input-placeholder {
+.emotion-21:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-ms-clear {
+.emotion-21::-ms-clear {
   display: none;
 }
 
-.emotion-15:focus ~ div:last-child {
+.emotion-21:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -5811,7 +6927,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-20"
+      className="emotion-28"
     >
       <TextArea
         defaultValue="Small"
@@ -5839,7 +6955,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="small"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -5861,55 +6977,105 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
             iconEnd={null}
             size="small"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Small",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 1,
+                  "size": "small",
+                }
+              }
+              iconEnd={null}
+              size="small"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Small",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 1,
-                      "size": "small",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Small",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 1,
+                        "size": "small",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Small"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={1}
-                  size="small"
-                >
-                  <textarea
-                    className="emotion-0"
-                    defaultValue="Small"
-                    onInput={[Function]}
-                    rows={1}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="small"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Small",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 1,
+                              "size": "small",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Small"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={1}
+                          size="small"
+                        >
+                          <textarea
+                            className="emotion-0"
+                            defaultValue="Small"
+                            onInput={[Function]}
+                            rows={1}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -5938,7 +7104,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="medium"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -5960,55 +7126,105 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
             iconEnd={null}
             size="medium"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Medium",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 1,
+                  "size": "medium",
+                }
+              }
+              iconEnd={null}
+              size="medium"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Medium",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 1,
-                      "size": "medium",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Medium",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 1,
+                        "size": "medium",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Medium"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={1}
-                  size="medium"
-                >
-                  <textarea
-                    className="emotion-5"
-                    defaultValue="Medium"
-                    onInput={[Function]}
-                    rows={1}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="medium"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Medium",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 1,
+                              "size": "medium",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Medium"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={1}
+                          size="medium"
+                        >
+                          <textarea
+                            className="emotion-7"
+                            defaultValue="Medium"
+                            onInput={[Function]}
+                            rows={1}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -6036,7 +7252,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="large"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -6058,55 +7274,105 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
             iconEnd={null}
             size="large"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Large",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 1,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Large",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 1,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Large",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 1,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Large"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={1}
-                  size="large"
-                >
-                  <textarea
-                    className="emotion-10"
-                    defaultValue="Large"
-                    onInput={[Function]}
-                    rows={1}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Large",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 1,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Large"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={1}
+                          size="large"
+                        >
+                          <textarea
+                            className="emotion-14"
+                            defaultValue="Large"
+                            onInput={[Function]}
+                            rows={1}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -6135,7 +7401,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="jumbo"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -6157,55 +7423,105 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
             iconEnd={null}
             size="jumbo"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Jumbo",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 1,
+                  "size": "jumbo",
+                }
+              }
+              iconEnd={null}
+              size="jumbo"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Jumbo",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 1,
-                      "size": "jumbo",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Jumbo",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 1,
+                        "size": "jumbo",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Jumbo"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={1}
-                  size="jumbo"
-                >
-                  <textarea
-                    className="emotion-15"
-                    defaultValue="Jumbo"
-                    onInput={[Function]}
-                    rows={1}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="jumbo"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Jumbo",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 1,
+                              "size": "jumbo",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Jumbo"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={1}
+                          size="jumbo"
+                        >
+                          <textarea
+                            className="emotion-21"
+                            defaultValue="Jumbo"
+                            onInput={[Function]}
+                            rows={1}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
     </div>
@@ -6383,7 +7699,7 @@ exports[`TextArea demo examples Snapshots: rtl 1`] = `
           iconEnd={null}
           size="large"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -6405,55 +7721,105 @@ exports[`TextArea demo examples Snapshots: rtl 1`] = `
             iconEnd={null}
             size="large"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "مرحبا بالعالم",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "مرحبا بالعالم",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 8,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "مرحبا بالعالم",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="مرحبا بالعالم"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={8}
-                  size="large"
-                >
-                  <textarea
-                    className="emotion-0"
-                    defaultValue="مرحبا بالعالم"
-                    onInput={[Function]}
-                    rows={8}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "مرحبا بالعالم",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 8,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="مرحبا بالعالم"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={8}
+                          size="large"
+                        >
+                          <textarea
+                            className="emotion-0"
+                            defaultValue="مرحبا بالعالم"
+                            onInput={[Function]}
+                            rows={8}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
     </ThemeProvider>
@@ -6518,7 +7884,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-10 {
+.emotion-14 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -6543,47 +7909,47 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-10::-webkit-input-placeholder {
+.emotion-14::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-moz-placeholder {
+.emotion-14::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::placeholder {
+.emotion-14::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-input-placeholder {
+.emotion-14::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-clear {
+.emotion-14::-ms-clear {
   display: none;
 }
 
-.emotion-10:focus ~ div:last-child {
+.emotion-14:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -6602,7 +7968,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
   z-index: -1;
 }
 
-.emotion-20[class] > *:not(:last-child) {
+.emotion-28[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -6676,7 +8042,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -6701,52 +8067,52 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-5::-webkit-input-placeholder {
+.emotion-7::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-moz-placeholder {
+.emotion-7::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::placeholder {
+.emotion-7::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-input-placeholder {
+.emotion-7::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-clear {
+.emotion-7::-ms-clear {
   display: none;
 }
 
-.emotion-5:focus ~ div:last-child {
+.emotion-7:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-15 {
+.emotion-21 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -6771,47 +8137,47 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-15::-webkit-input-placeholder {
+.emotion-21::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-moz-placeholder {
+.emotion-21::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15:-ms-input-placeholder {
+.emotion-21:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::placeholder {
+.emotion-21::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-ms-input-placeholder {
+.emotion-21::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15:-ms-input-placeholder {
+.emotion-21:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-ms-clear {
+.emotion-21::-ms-clear {
   display: none;
 }
 
-.emotion-15:focus ~ div:last-child {
+.emotion-21:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -6821,7 +8187,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-20"
+      className="emotion-28"
     >
       <TextArea
         defaultValue="Small"
@@ -6848,7 +8214,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="small"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -6870,55 +8236,105 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
             iconEnd={null}
             size="small"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Small",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 2,
+                  "size": "small",
+                }
+              }
+              iconEnd={null}
+              size="small"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Small",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 2,
-                      "size": "small",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Small",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 2,
+                        "size": "small",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Small"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={2}
-                  size="small"
-                >
-                  <textarea
-                    className="emotion-0"
-                    defaultValue="Small"
-                    onInput={[Function]}
-                    rows={2}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="small"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Small",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 2,
+                              "size": "small",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Small"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={2}
+                          size="small"
+                        >
+                          <textarea
+                            className="emotion-0"
+                            defaultValue="Small"
+                            onInput={[Function]}
+                            rows={2}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -6946,7 +8362,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="medium"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -6968,55 +8384,105 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
             iconEnd={null}
             size="medium"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Medium",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 6,
+                  "size": "medium",
+                }
+              }
+              iconEnd={null}
+              size="medium"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Medium",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 6,
-                      "size": "medium",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Medium",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 6,
+                        "size": "medium",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Medium"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={6}
-                  size="medium"
-                >
-                  <textarea
-                    className="emotion-5"
-                    defaultValue="Medium"
-                    onInput={[Function]}
-                    rows={6}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="medium"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Medium",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 6,
+                              "size": "medium",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Medium"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={6}
+                          size="medium"
+                        >
+                          <textarea
+                            className="emotion-7"
+                            defaultValue="Medium"
+                            onInput={[Function]}
+                            rows={6}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -7043,7 +8509,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="large"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7065,55 +8531,105 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
             iconEnd={null}
             size="large"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Large",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Large",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 8,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Large",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Large"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={8}
-                  size="large"
-                >
-                  <textarea
-                    className="emotion-10"
-                    defaultValue="Large"
-                    onInput={[Function]}
-                    rows={8}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Large",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 8,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Large"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={8}
+                          size="large"
+                        >
+                          <textarea
+                            className="emotion-14"
+                            defaultValue="Large"
+                            onInput={[Function]}
+                            rows={8}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -7141,7 +8657,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="jumbo"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7163,55 +8679,105 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
             iconEnd={null}
             size="jumbo"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Jumbo",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 12,
+                  "size": "jumbo",
+                }
+              }
+              iconEnd={null}
+              size="jumbo"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Jumbo",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 12,
-                      "size": "jumbo",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Jumbo",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 12,
+                        "size": "jumbo",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Jumbo"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={12}
-                  size="jumbo"
-                >
-                  <textarea
-                    className="emotion-15"
-                    defaultValue="Jumbo"
-                    onInput={[Function]}
-                    rows={12}
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="jumbo"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Jumbo",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 12,
+                              "size": "jumbo",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Jumbo"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={12}
+                          size="jumbo"
+                        >
+                          <textarea
+                            className="emotion-21"
+                            defaultValue="Jumbo"
+                            onInput={[Function]}
+                            rows={12}
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
     </div>
@@ -7384,7 +8950,7 @@ exports[`TextArea demo examples Snapshots: uncontrolled 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextInput
+    <TextArea
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -7406,55 +8972,105 @@ exports[`TextArea demo examples Snapshots: uncontrolled 1`] = `
       iconEnd={null}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "autoSize": undefined,
+            "controlRef": [Function],
+            "defaultValue": "Hello World",
+            "disabled": undefined,
+            "onInput": [Function],
+            "readOnly": undefined,
+            "required": undefined,
+            "resizeable": true,
+            "rows": 8,
+            "size": "large",
+          }
+        }
+        iconEnd={null}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "autoSize": undefined,
-                "controlRef": [Function],
-                "defaultValue": "Hello World",
-                "disabled": undefined,
-                "onInput": [Function],
-                "readOnly": undefined,
-                "required": undefined,
-                "resizeable": true,
-                "rows": 8,
-                "size": "large",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Hello World",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
               }
-            }
-            controlRef={[Function]}
-            defaultValue="Hello World"
-            iconEnd={null}
-            innerRef={[Function]}
-            key="control"
-            onInput={[Function]}
-            resizeable={true}
-            rows={8}
-            size="large"
-          >
-            <textarea
-              className="emotion-0"
-              defaultValue="Hello World"
-              onInput={[Function]}
-              rows={8}
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
-    </TextInput>
+              iconEnd={null}
+              size="large"
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Hello World",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
+                    }
+                    controlRef={[Function]}
+                    defaultValue="Hello World"
+                    iconEnd={null}
+                    innerRef={[Function]}
+                    key="control"
+                    onInput={[Function]}
+                    resizeable={true}
+                    rows={8}
+                    size="large"
+                  >
+                    <textarea
+                      className="emotion-0"
+                      defaultValue="Hello World"
+                      onInput={[Function]}
+                      rows={8}
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
+    </TextArea>
   </TextArea>
 </TextArea>
 `;
@@ -7473,7 +9089,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-15[class] > *:not(:last-child) {
+.emotion-21[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -7604,7 +9220,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -7627,27 +9243,27 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
-.emotion-7:hover > div:last-child {
+.emotion-9:hover > div:last-child {
   border-color: #cf7911;
 }
 
-.emotion-7:focus > div:last-child {
+.emotion-9:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-7:active > div:last-child {
+.emotion-9:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -7672,52 +9288,52 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-5::-webkit-input-placeholder {
+.emotion-7::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-moz-placeholder {
+.emotion-7::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::placeholder {
+.emotion-7::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-input-placeholder {
+.emotion-7::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-clear {
+.emotion-7::-ms-clear {
   display: none;
 }
 
-.emotion-5:focus ~ div:last-child {
+.emotion-7:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-6 {
+.emotion-8 {
   background-color: #ffffff;
   border-color: #ad5f00;
   border-radius: 0.1875em;
@@ -7731,7 +9347,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-12 {
+.emotion-16 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -7754,27 +9370,27 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
+.emotion-16 *,
+.emotion-16 *::before,
+.emotion-16 *::after {
   box-sizing: inherit;
 }
 
-.emotion-12:hover > div:last-child {
+.emotion-16:hover > div:last-child {
   border-color: #f55353;
 }
 
-.emotion-12:focus > div:last-child {
+.emotion-16:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-12:active > div:last-child {
+.emotion-16:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-10 {
+.emotion-14 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -7799,52 +9415,52 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-10::-webkit-input-placeholder {
+.emotion-14::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-moz-placeholder {
+.emotion-14::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::placeholder {
+.emotion-14::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-input-placeholder {
+.emotion-14::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-clear {
+.emotion-14::-ms-clear {
   display: none;
 }
 
-.emotion-10:focus ~ div:last-child {
+.emotion-14:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-11 {
+.emotion-15 {
   background-color: #ffffff;
   border-color: #de1b1b;
   border-radius: 0.1875em;
@@ -7863,7 +9479,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-15"
+      className="emotion-21"
     >
       <TextArea
         defaultValue="Success"
@@ -7891,7 +9507,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
           size="large"
           variant="success"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7914,59 +9530,111 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
             size="large"
             variant="success"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Success",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
               variant="success"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Success",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 8,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Success",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Success"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={8}
-                  size="large"
-                  variant="success"
-                >
-                  <textarea
-                    className="emotion-0"
-                    defaultValue="Success"
-                    onInput={[Function]}
-                    rows={8}
-                  />
-                </Control>
-                <Underlay
-                  variant="success"
-                >
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                    variant="success"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                      variant="success"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Success",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 8,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Success"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={8}
+                          size="large"
+                          variant="success"
+                        >
+                          <textarea
+                            className="emotion-0"
+                            defaultValue="Success"
+                            onInput={[Function]}
+                            rows={8}
+                          />
+                        </Control>
+                        <Underlay
+                          variant="success"
+                        >
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -7995,7 +9663,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
           size="large"
           variant="warning"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -8018,59 +9686,111 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
             size="large"
             variant="warning"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Warning",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
               variant="warning"
             >
-              <div
-                className="emotion-7"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Warning",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 8,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Warning",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Warning"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={8}
-                  size="large"
-                  variant="warning"
-                >
-                  <textarea
-                    className="emotion-5"
-                    defaultValue="Warning"
-                    onInput={[Function]}
-                    rows={8}
-                  />
-                </Control>
-                <Underlay
-                  variant="warning"
-                >
-                  <div
-                    className="emotion-6"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                    variant="warning"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                      variant="warning"
+                    >
+                      <div
+                        className="emotion-9"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Warning",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 8,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Warning"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={8}
+                          size="large"
+                          variant="warning"
+                        >
+                          <textarea
+                            className="emotion-7"
+                            defaultValue="Warning"
+                            onInput={[Function]}
+                            rows={8}
+                          />
+                        </Control>
+                        <Underlay
+                          variant="warning"
+                        >
+                          <div
+                            className="emotion-8"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
       <TextArea
@@ -8099,7 +9819,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
           size="large"
           variant="danger"
         >
-          <TextInput
+          <TextArea
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -8122,59 +9842,111 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
             size="large"
             variant="danger"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "autoSize": undefined,
+                  "controlRef": [Function],
+                  "defaultValue": "Danger",
+                  "disabled": undefined,
+                  "onInput": [Function],
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "resizeable": true,
+                  "rows": 8,
+                  "size": "large",
+                }
+              }
+              iconEnd={null}
+              size="large"
               variant="danger"
             >
-              <div
-                className="emotion-12"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "autoSize": undefined,
-                      "controlRef": [Function],
-                      "defaultValue": "Danger",
-                      "disabled": undefined,
-                      "onInput": [Function],
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "resizeable": true,
-                      "rows": 8,
-                      "size": "large",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "autoSize": undefined,
+                        "controlRef": [Function],
+                        "defaultValue": "Danger",
+                        "disabled": undefined,
+                        "onInput": [Function],
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "resizeable": true,
+                        "rows": 8,
+                        "size": "large",
+                      }
                     }
-                  }
-                  controlRef={[Function]}
-                  defaultValue="Danger"
-                  iconEnd={null}
-                  innerRef={[Function]}
-                  key="control"
-                  onInput={[Function]}
-                  resizeable={true}
-                  rows={8}
-                  size="large"
-                  variant="danger"
-                >
-                  <textarea
-                    className="emotion-10"
-                    defaultValue="Danger"
-                    onInput={[Function]}
-                    rows={8}
-                  />
-                </Control>
-                <Underlay
-                  variant="danger"
-                >
-                  <div
-                    className="emotion-11"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
-          </TextInput>
+                    iconEnd={null}
+                    size="large"
+                    variant="danger"
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                      variant="danger"
+                    >
+                      <div
+                        className="emotion-16"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "autoSize": undefined,
+                              "controlRef": [Function],
+                              "defaultValue": "Danger",
+                              "disabled": undefined,
+                              "onInput": [Function],
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "resizeable": true,
+                              "rows": 8,
+                              "size": "large",
+                            }
+                          }
+                          controlRef={[Function]}
+                          defaultValue="Danger"
+                          iconEnd={null}
+                          innerRef={[Function]}
+                          key="control"
+                          onInput={[Function]}
+                          resizeable={true}
+                          rows={8}
+                          size="large"
+                          variant="danger"
+                        >
+                          <textarea
+                            className="emotion-14"
+                            defaultValue="Danger"
+                            onInput={[Function]}
+                            rows={8}
+                          />
+                        </Control>
+                        <Underlay
+                          variant="danger"
+                        >
+                          <div
+                            className="emotion-15"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
+          </TextArea>
         </TextArea>
       </TextArea>
     </div>

--- a/src/library/TextInput/TextInput.js
+++ b/src/library/TextInput/TextInput.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React from 'react';
 import { createStyledComponent, getNormalizedValue } from '../styles';
-import { mapComponentThemes } from '../themes';
+import { createThemedComponent, mapComponentThemes } from '../themes';
 import FauxControl, {
   componentTheme as fauxControlComponentTheme
 } from '../FauxControl/FauxControl';
@@ -59,8 +59,8 @@ type Props = {
   variant?: 'success' | 'warning' | 'danger'
 };
 
-export const componentTheme = (baseTheme: Object) => ({
-  ...mapComponentThemes(
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
     {
       name: 'FauxControl',
       theme: fauxControlComponentTheme(baseTheme)
@@ -77,8 +77,23 @@ export const componentTheme = (baseTheme: Object) => ({
       }
     },
     baseTheme
-  )
-});
+  );
+
+const ThemedFauxControl = createThemedComponent(
+  FauxControl,
+  ({ theme: baseTheme }) =>
+    mapComponentThemes(
+      {
+        name: 'TextInput',
+        theme: componentTheme(baseTheme)
+      },
+      {
+        name: 'FauxControl',
+        theme: {}
+      },
+      baseTheme
+    )
+);
 
 const styles = {
   input: ({ size, theme: baseTheme }) => {
@@ -139,7 +154,7 @@ const styles = {
   }
 };
 
-const Root = createStyledComponent(FauxControl, styles.root, {
+const Root = createStyledComponent(ThemedFauxControl, styles.root, {
   displayName: 'TextInput'
 });
 const Input = createStyledComponent('input', styles.input, {

--- a/src/library/TextInput/__tests__/__snapshots__/TextInput.spec.js.snap
+++ b/src/library/TextInput/__tests__/__snapshots__/TextInput.spec.js.snap
@@ -212,48 +212,90 @@ exports[`TextInput demo examples Snapshots: controlled 1`] = `
           }
           size="large"
         >
-          <FauxControl
+          <Themed(FauxControl)
             className="emotion-3"
             control={[Function]}
+            controlProps={
+              Object {
+                "aria-invalid": undefined,
+                "aria-required": undefined,
+                "controlRef": undefined,
+                "disabled": undefined,
+                "onChange": [Function],
+                "readOnly": undefined,
+                "required": undefined,
+                "type": "text",
+                "value": "Hello World",
+              }
+            }
+            size="large"
           >
-            <div
-              className="emotion-2"
-            >
-              <Control
-                controlPropsIn={
-                  Object {
-                    "aria-invalid": undefined,
-                    "aria-required": undefined,
-                    "controlRef": undefined,
-                    "disabled": undefined,
-                    "onChange": [Function],
-                    "readOnly": undefined,
-                    "required": undefined,
-                    "type": "text",
-                    "value": "Hello World",
+            <ThemeProvider>
+              <ThemeProvider>
+                <FauxControl
+                  className="emotion-3"
+                  control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "disabled": undefined,
+                      "onChange": [Function],
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                      "value": "Hello World",
+                    }
                   }
-                }
-                key="control"
-                onChange={[Function]}
-                size="large"
-                type="text"
-                value="Hello World"
-              >
-                <input
-                  className="emotion-0"
-                  onChange={[Function]}
                   size="large"
-                  type="text"
-                  value="Hello World"
-                />
-              </Control>
-              <Underlay>
-                <div
-                  className="emotion-1"
-                />
-              </Underlay>
-            </div>
-          </FauxControl>
+                >
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                  >
+                    <div
+                      className="emotion-2"
+                    >
+                      <Control
+                        controlPropsIn={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "disabled": undefined,
+                            "onChange": [Function],
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                            "value": "Hello World",
+                          }
+                        }
+                        key="control"
+                        onChange={[Function]}
+                        size="large"
+                        type="text"
+                        value="Hello World"
+                      >
+                        <input
+                          className="emotion-0"
+                          onChange={[Function]}
+                          size="large"
+                          type="text"
+                          value="Hello World"
+                        />
+                      </Control>
+                      <Underlay>
+                        <div
+                          className="emotion-1"
+                        />
+                      </Underlay>
+                    </div>
+                  </FauxControl>
+                </FauxControl>
+              </ThemeProvider>
+            </ThemeProvider>
+          </Themed(FauxControl)>
         </TextInput>
       </TextInput>
     </TextInput>
@@ -462,50 +504,92 @@ exports[`TextInput demo examples Snapshots: disabled 1`] = `
       disabled={true}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "controlRef": undefined,
+            "defaultValue": "Hello World",
+            "disabled": true,
+            "readOnly": undefined,
+            "required": undefined,
+            "type": "text",
+          }
+        }
         disabled={true}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "controlRef": undefined,
-                "defaultValue": "Hello World",
-                "disabled": true,
-                "readOnly": undefined,
-                "required": undefined,
-                "type": "text",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Hello World",
+                  "disabled": true,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
               }
-            }
-            defaultValue="Hello World"
-            disabled={true}
-            key="control"
-            size="large"
-            type="text"
-          >
-            <input
-              className="emotion-0"
-              defaultValue="Hello World"
               disabled={true}
               size="large"
-              type="text"
-            />
-          </Control>
-          <Underlay
-            disabled={true}
-          >
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+                disabled={true}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Hello World",
+                        "disabled": true,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    defaultValue="Hello World"
+                    disabled={true}
+                    key="control"
+                    size="large"
+                    type="text"
+                  >
+                    <input
+                      className="emotion-0"
+                      defaultValue="Hello World"
+                      disabled={true}
+                      size="large"
+                      type="text"
+                    />
+                  </Control>
+                  <Underlay
+                    disabled={true}
+                  >
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
     </TextInput>
   </TextInput>
 </TextInput>
@@ -608,7 +692,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
   z-index: -1;
 }
 
-.emotion-10[class] > *:not(:last-child) {
+.emotion-12[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -691,7 +775,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-9 {
+.emotion-11 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -702,9 +786,9 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.emotion-9 *,
-.emotion-9 *::before,
-.emotion-9 *::after {
+.emotion-11 *,
+.emotion-11 *::before,
+.emotion-11 *::after {
   box-sizing: inherit;
 }
 
@@ -736,7 +820,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
   font-weight: 400;
 }
 
-.emotion-8 {
+.emotion-10 {
   color: #58606e;
   font-size: 0.6875em;
   margin-top: 0.18181818181818182em;
@@ -747,7 +831,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-10"
+      className="emotion-12"
     >
       <FormField
         caption="Surname, family name"
@@ -759,7 +843,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
       >
         <FormField>
           <div
-            className="emotion-9"
+            className="emotion-11"
           >
             <label>
               <Styled(div)
@@ -825,82 +909,124 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
                     iconStart={<IconAccountBox />}
                     size="large"
                   >
-                    <FauxControl
+                    <Themed(FauxControl)
                       className="emotion-6"
                       control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-describedby": "formField-21-caption",
+                          "aria-invalid": undefined,
+                          "aria-required": true,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": true,
+                          "type": "text",
+                        }
+                      }
+                      iconStart={<IconAccountBox />}
+                      size="large"
                     >
-                      <div
-                        className="emotion-5"
-                      >
-                        <IconAccountBox
-                          key="iconStart"
-                          size="1.5em"
-                        >
-                          <Icon
-                            rtl={false}
-                            size="1.5em"
-                          >
-                            <Styled(svg)
-                              aria-hidden={true}
-                              focusable="false"
-                              role="img"
-                              rtl={false}
-                              size="1.5em"
-                              viewBox="0 0 24 24"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="emotion-2"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 24 24"
-                              >
-                                <g>
-                                  <path
-                                    d="M3 5v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5a2 2 0 0 0-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
-                                  />
-                                </g>
-                              </svg>
-                            </Styled(svg)>
-                          </Icon>
-                        </IconAccountBox>
-                        <Control
-                          aria-describedby="formField-21-caption"
-                          aria-required={true}
-                          controlPropsIn={
-                            Object {
-                              "aria-describedby": "formField-21-caption",
-                              "aria-invalid": undefined,
-                              "aria-required": true,
-                              "controlRef": undefined,
-                              "disabled": undefined,
-                              "readOnly": undefined,
-                              "required": true,
-                              "type": "text",
+                      <ThemeProvider>
+                        <ThemeProvider>
+                          <FauxControl
+                            className="emotion-6"
+                            control={[Function]}
+                            controlProps={
+                              Object {
+                                "aria-describedby": "formField-21-caption",
+                                "aria-invalid": undefined,
+                                "aria-required": true,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": true,
+                                "type": "text",
+                              }
                             }
-                          }
-                          iconStart={<IconAccountBox />}
-                          key="control"
-                          required={true}
-                          size="large"
-                          type="text"
-                        >
-                          <input
-                            aria-describedby="formField-21-caption"
-                            aria-required={true}
-                            className="emotion-3"
-                            required={true}
+                            iconStart={<IconAccountBox />}
                             size="large"
-                            type="text"
-                          />
-                        </Control>
-                        <Underlay>
-                          <div
-                            className="emotion-4"
-                          />
-                        </Underlay>
-                      </div>
-                    </FauxControl>
+                          >
+                            <FauxControl
+                              className="emotion-6"
+                              control={[Function]}
+                            >
+                              <div
+                                className="emotion-5"
+                              >
+                                <IconAccountBox
+                                  key="iconStart"
+                                  size="1.5em"
+                                >
+                                  <Icon
+                                    rtl={false}
+                                    size="1.5em"
+                                  >
+                                    <Styled(svg)
+                                      aria-hidden={true}
+                                      focusable="false"
+                                      role="img"
+                                      rtl={false}
+                                      size="1.5em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="emotion-2"
+                                        focusable="false"
+                                        role="img"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <g>
+                                          <path
+                                            d="M3 5v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5a2 2 0 0 0-2 2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1H6v-1z"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </Styled(svg)>
+                                  </Icon>
+                                </IconAccountBox>
+                                <Control
+                                  aria-describedby="formField-21-caption"
+                                  aria-required={true}
+                                  controlPropsIn={
+                                    Object {
+                                      "aria-describedby": "formField-21-caption",
+                                      "aria-invalid": undefined,
+                                      "aria-required": true,
+                                      "controlRef": undefined,
+                                      "disabled": undefined,
+                                      "readOnly": undefined,
+                                      "required": true,
+                                      "type": "text",
+                                    }
+                                  }
+                                  iconStart={<IconAccountBox />}
+                                  key="control"
+                                  required={true}
+                                  size="large"
+                                  type="text"
+                                >
+                                  <input
+                                    aria-describedby="formField-21-caption"
+                                    aria-required={true}
+                                    className="emotion-3"
+                                    required={true}
+                                    size="large"
+                                    type="text"
+                                  />
+                                </Control>
+                                <Underlay>
+                                  <div
+                                    className="emotion-4"
+                                  />
+                                </Underlay>
+                              </div>
+                            </FauxControl>
+                          </FauxControl>
+                        </ThemeProvider>
+                      </ThemeProvider>
+                    </Themed(FauxControl)>
                   </TextInput>
                 </TextInput>
               </TextInput>
@@ -910,7 +1036,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
               id="formField-21-caption"
             >
               <div
-                className="emotion-8"
+                className="emotion-10"
                 id="formField-21-caption"
               >
                 Surname, family name
@@ -1021,7 +1147,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
   z-index: -1;
 }
 
-.emotion-19[class] > *:not(:last-child) {
+.emotion-25[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -1104,7 +1230,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-6 {
+.emotion-8 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -1123,60 +1249,60 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
   padding-right: 0;
 }
 
-.emotion-6[type="search"] {
+.emotion-8[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-6[type="search"]::-webkit-search-decoration {
+.emotion-8[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-6::-webkit-input-placeholder {
+.emotion-8::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-moz-placeholder {
+.emotion-8::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::placeholder {
+.emotion-8::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-input-placeholder {
+.emotion-8::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-clear {
+.emotion-8::-ms-clear {
   display: none;
 }
 
-.emotion-6:focus ~ div:last-child {
+.emotion-8:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-13 {
+.emotion-17 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -1195,55 +1321,55 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
   padding-right: 0;
 }
 
-.emotion-13[type="search"] {
+.emotion-17[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-13[type="search"]::-webkit-search-decoration {
+.emotion-17[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-13::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-13::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-13:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-13::placeholder {
+.emotion-17::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-13::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-13:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-13::-ms-clear {
+.emotion-17::-ms-clear {
   display: none;
 }
 
-.emotion-13:focus ~ div:last-child {
+.emotion-17:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -1254,7 +1380,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
       marginBottom="1rem"
     >
       <div
-        className="emotion-19"
+        className="emotion-25"
       >
         <TextInput
           iconStart={<IconCloud />}
@@ -1294,75 +1420,115 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
               iconStart={<IconCloud />}
               size="large"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-4"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "text",
+                  }
+                }
+                iconStart={<IconCloud />}
+                size="large"
               >
-                <div
-                  className="emotion-3"
-                >
-                  <IconCloud
-                    key="iconStart"
-                    size="1.5em"
-                  >
-                    <Icon
-                      rtl={false}
-                      size="1.5em"
-                    >
-                      <Styled(svg)
-                        aria-hidden={true}
-                        focusable="false"
-                        role="img"
-                        rtl={false}
-                        size="1.5em"
-                        viewBox="0 0 24 24"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-0"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 24 24"
-                        >
-                          <g>
-                            <path
-                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                            />
-                          </g>
-                        </svg>
-                      </Styled(svg)>
-                    </Icon>
-                  </IconCloud>
-                  <Control
-                    controlPropsIn={
-                      Object {
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "text",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
                       }
-                    }
-                    iconStart={<IconCloud />}
-                    key="control"
-                    size="large"
-                    type="text"
-                  >
-                    <input
-                      className="emotion-1"
+                      iconStart={<IconCloud />}
                       size="large"
-                      type="text"
-                    />
-                  </Control>
-                  <Underlay>
-                    <div
-                      className="emotion-2"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                    >
+                      <FauxControl
+                        className="emotion-4"
+                        control={[Function]}
+                      >
+                        <div
+                          className="emotion-3"
+                        >
+                          <IconCloud
+                            key="iconStart"
+                            size="1.5em"
+                          >
+                            <Icon
+                              rtl={false}
+                              size="1.5em"
+                            >
+                              <Styled(svg)
+                                aria-hidden={true}
+                                focusable="false"
+                                role="img"
+                                rtl={false}
+                                size="1.5em"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="emotion-0"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <g>
+                                    <path
+                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                    />
+                                  </g>
+                                </svg>
+                              </Styled(svg)>
+                            </Icon>
+                          </IconCloud>
+                          <Control
+                            controlPropsIn={
+                              Object {
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
+                            }
+                            iconStart={<IconCloud />}
+                            key="control"
+                            size="large"
+                            type="text"
+                          >
+                            <input
+                              className="emotion-1"
+                              size="large"
+                              type="text"
+                            />
+                          </Control>
+                          <Underlay>
+                            <div
+                              className="emotion-2"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -1404,75 +1570,115 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
               iconEnd={<IconCloud />}
               size="large"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-4"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "text",
+                  }
+                }
+                iconEnd={<IconCloud />}
+                size="large"
               >
-                <div
-                  className="emotion-3"
-                >
-                  <Control
-                    controlPropsIn={
-                      Object {
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "text",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
                       }
-                    }
-                    iconEnd={<IconCloud />}
-                    key="control"
-                    size="large"
-                    type="text"
-                  >
-                    <input
-                      className="emotion-6"
+                      iconEnd={<IconCloud />}
                       size="large"
-                      type="text"
-                    />
-                  </Control>
-                  <IconCloud
-                    key="iconEnd"
-                    size="1.5em"
-                  >
-                    <Icon
-                      rtl={false}
-                      size="1.5em"
                     >
-                      <Styled(svg)
-                        aria-hidden={true}
-                        focusable="false"
-                        role="img"
-                        rtl={false}
-                        size="1.5em"
-                        viewBox="0 0 24 24"
+                      <FauxControl
+                        className="emotion-4"
+                        control={[Function]}
                       >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-0"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 24 24"
+                        <div
+                          className="emotion-3"
                         >
-                          <g>
-                            <path
-                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                          <Control
+                            controlPropsIn={
+                              Object {
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
+                            }
+                            iconEnd={<IconCloud />}
+                            key="control"
+                            size="large"
+                            type="text"
+                          >
+                            <input
+                              className="emotion-8"
+                              size="large"
+                              type="text"
                             />
-                          </g>
-                        </svg>
-                      </Styled(svg)>
-                    </Icon>
-                  </IconCloud>
-                  <Underlay>
-                    <div
-                      className="emotion-2"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                          </Control>
+                          <IconCloud
+                            key="iconEnd"
+                            size="1.5em"
+                          >
+                            <Icon
+                              rtl={false}
+                              size="1.5em"
+                            >
+                              <Styled(svg)
+                                aria-hidden={true}
+                                focusable="false"
+                                role="img"
+                                rtl={false}
+                                size="1.5em"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="emotion-0"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <g>
+                                    <path
+                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                    />
+                                  </g>
+                                </svg>
+                              </Styled(svg)>
+                            </Icon>
+                          </IconCloud>
+                          <Underlay>
+                            <div
+                              className="emotion-2"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -1517,108 +1723,150 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
               iconStart={<IconCloud />}
               size="large"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-4"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "text",
+                  }
+                }
+                iconEnd={<IconCloud />}
+                iconStart={<IconCloud />}
+                size="large"
               >
-                <div
-                  className="emotion-3"
-                >
-                  <IconCloud
-                    key="iconStart"
-                    size="1.5em"
-                  >
-                    <Icon
-                      rtl={false}
-                      size="1.5em"
-                    >
-                      <Styled(svg)
-                        aria-hidden={true}
-                        focusable="false"
-                        role="img"
-                        rtl={false}
-                        size="1.5em"
-                        viewBox="0 0 24 24"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-0"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 24 24"
-                        >
-                          <g>
-                            <path
-                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                            />
-                          </g>
-                        </svg>
-                      </Styled(svg)>
-                    </Icon>
-                  </IconCloud>
-                  <Control
-                    controlPropsIn={
-                      Object {
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "text",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "text",
+                        }
                       }
-                    }
-                    iconEnd={<IconCloud />}
-                    iconStart={<IconCloud />}
-                    key="control"
-                    size="large"
-                    type="text"
-                  >
-                    <input
-                      className="emotion-13"
+                      iconEnd={<IconCloud />}
+                      iconStart={<IconCloud />}
                       size="large"
-                      type="text"
-                    />
-                  </Control>
-                  <IconCloud
-                    key="iconEnd"
-                    size="1.5em"
-                  >
-                    <Icon
-                      rtl={false}
-                      size="1.5em"
                     >
-                      <Styled(svg)
-                        aria-hidden={true}
-                        focusable="false"
-                        role="img"
-                        rtl={false}
-                        size="1.5em"
-                        viewBox="0 0 24 24"
+                      <FauxControl
+                        className="emotion-4"
+                        control={[Function]}
                       >
-                        <svg
-                          aria-hidden={true}
-                          className="emotion-0"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 24 24"
+                        <div
+                          className="emotion-3"
                         >
-                          <g>
-                            <path
-                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                          <IconCloud
+                            key="iconStart"
+                            size="1.5em"
+                          >
+                            <Icon
+                              rtl={false}
+                              size="1.5em"
+                            >
+                              <Styled(svg)
+                                aria-hidden={true}
+                                focusable="false"
+                                role="img"
+                                rtl={false}
+                                size="1.5em"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="emotion-0"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <g>
+                                    <path
+                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                    />
+                                  </g>
+                                </svg>
+                              </Styled(svg)>
+                            </Icon>
+                          </IconCloud>
+                          <Control
+                            controlPropsIn={
+                              Object {
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "text",
+                              }
+                            }
+                            iconEnd={<IconCloud />}
+                            iconStart={<IconCloud />}
+                            key="control"
+                            size="large"
+                            type="text"
+                          >
+                            <input
+                              className="emotion-17"
+                              size="large"
+                              type="text"
                             />
-                          </g>
-                        </svg>
-                      </Styled(svg)>
-                    </Icon>
-                  </IconCloud>
-                  <Underlay>
-                    <div
-                      className="emotion-2"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                          </Control>
+                          <IconCloud
+                            key="iconEnd"
+                            size="1.5em"
+                          >
+                            <Icon
+                              rtl={false}
+                              size="1.5em"
+                            >
+                              <Styled(svg)
+                                aria-hidden={true}
+                                focusable="false"
+                                role="img"
+                                rtl={false}
+                                size="1.5em"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="emotion-0"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <g>
+                                    <path
+                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                    />
+                                  </g>
+                                </svg>
+                              </Styled(svg)>
+                            </Icon>
+                          </IconCloud>
+                          <Underlay>
+                            <div
+                              className="emotion-2"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -1797,11 +2045,11 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   z-index: -1;
 }
 
-.emotion-8[class] > *:not(:last-child) {
+.emotion-10[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -1827,13 +2075,13 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   vertical-align: middle;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
-.emotion-7:focus {
+.emotion-9:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -1841,41 +2089,41 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   text-decoration: none;
 }
 
-.emotion-7:hover {
+.emotion-9:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-7:active {
+.emotion-9:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-7::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-7 [role="img"] {
+.emotion-9 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-7 [role="img"]:first-child {
+.emotion-9 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-7 [role="img"]:last-child {
+.emotion-9 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-7 [role="img"]:only-child {
+.emotion-9 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-6 {
+.emotion-8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1893,7 +2141,7 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   width: 100%;
 }
 
-.emotion-5 {
+.emotion-7 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -1904,11 +2152,11 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-5:first-child {
+.emotion-7:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-5:last-child {
+.emotion-7:last-child {
   padding-right: 0.5714285714285714em;
 }
 
@@ -1919,7 +2167,7 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
         marginBottom="1rem"
       >
         <div
-          className="emotion-8"
+          className="emotion-10"
         >
           <TextInput
             inputRef={[Function]}
@@ -1957,44 +2205,82 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
                 }
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": [Function],
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": [Function],
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": [Function],
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      controlRef={[Function]}
-                      innerRef={[Function]}
-                      key="control"
-                      size="large"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-0"
                         size="large"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": [Function],
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              controlRef={[Function]}
+                              innerRef={[Function]}
+                              key="control"
+                              size="large"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-0"
+                                size="large"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -2012,19 +2298,19 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
               type="button"
             >
               <button
-                className="emotion-7"
+                className="emotion-9"
                 onClick={[Function]}
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-6"
+                    className="emotion-8"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-5"
+                        className="emotion-7"
                       >
                         Focus the input
                       </span>
@@ -2246,44 +2532,82 @@ exports[`TextInput demo examples Snapshots: invalid 1`] = `
       }
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": true,
+            "aria-required": undefined,
+            "controlRef": undefined,
+            "disabled": undefined,
+            "readOnly": undefined,
+            "required": undefined,
+            "type": "text",
+          }
+        }
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            aria-invalid={true}
-            controlPropsIn={
-              Object {
-                "aria-invalid": true,
-                "aria-required": undefined,
-                "controlRef": undefined,
-                "disabled": undefined,
-                "readOnly": undefined,
-                "required": undefined,
-                "type": "text",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": true,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
               }
-            }
-            key="control"
-            size="large"
-            type="text"
-          >
-            <input
-              aria-invalid={true}
-              className="emotion-0"
               size="large"
-              type="text"
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    aria-invalid={true}
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": true,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    key="control"
+                    size="large"
+                    type="text"
+                  >
+                    <input
+                      aria-invalid={true}
+                      className="emotion-0"
+                      size="large"
+                      type="text"
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
     </TextInput>
   </TextInput>
 </TextInput>
@@ -2458,18 +2782,18 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   z-index: -1;
 }
 
-.emotion-63[class] > *:not(:last-child) {
+.emotion-81[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-24 {
+.emotion-32 {
   fill: currentcolor;
   font-size: 16px;
   height: 1.5em;
   width: 1.5em;
 }
 
-.emotion-52 {
+.emotion-66 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2482,7 +2806,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   width: 100%;
 }
 
-.emotion-52 [role="img"] {
+.emotion-66 [role="img"] {
   color: #de1b1b;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -2491,11 +2815,11 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-52 [role="img"]:last-of-type {
+.emotion-66 [role="img"]:last-of-type {
   color: #de1b1b;
 }
 
-.emotion-51 {
+.emotion-65 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -2518,27 +2842,27 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   width: 100%;
 }
 
-.emotion-51 *,
-.emotion-51 *::before,
-.emotion-51 *::after {
+.emotion-65 *,
+.emotion-65 *::before,
+.emotion-65 *::after {
   box-sizing: inherit;
 }
 
-.emotion-51:hover > div:last-child {
+.emotion-65:hover > div:last-child {
   border-color: #f55353;
 }
 
-.emotion-51:focus > div:last-child {
+.emotion-65:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-51:active > div:last-child {
+.emotion-65:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-51 [role="img"] {
+.emotion-65 [role="img"] {
   color: #de1b1b;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -2547,11 +2871,11 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-51 [role="img"]:last-of-type {
+.emotion-65 [role="img"]:last-of-type {
   color: #de1b1b;
 }
 
-.emotion-47 {
+.emotion-61 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2570,60 +2894,60 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   padding-right: 0;
 }
 
-.emotion-47[type="search"] {
+.emotion-61[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-47[type="search"]::-webkit-search-decoration {
+.emotion-61[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-47::-webkit-input-placeholder {
+.emotion-61::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-47::-moz-placeholder {
+.emotion-61::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-47:-ms-input-placeholder {
+.emotion-61:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-47::placeholder {
+.emotion-61::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-47::-ms-input-placeholder {
+.emotion-61::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-47:-ms-input-placeholder {
+.emotion-61:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-47::-ms-clear {
+.emotion-61::-ms-clear {
   display: none;
 }
 
-.emotion-47:focus ~ div:last-child {
+.emotion-61:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-50 {
+.emotion-64 {
   background-color: #ffffff;
   border-color: #de1b1b;
   border-radius: 0.1875em;
@@ -2637,7 +2961,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   z-index: -1;
 }
 
-.emotion-6 {
+.emotion-8 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2656,60 +2980,60 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-6[type="search"] {
+.emotion-8[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-6[type="search"]::-webkit-search-decoration {
+.emotion-8[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-6::-webkit-input-placeholder {
+.emotion-8::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-moz-placeholder {
+.emotion-8::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::placeholder {
+.emotion-8::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-input-placeholder {
+.emotion-8::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-clear {
+.emotion-8::-ms-clear {
   display: none;
 }
 
-.emotion-6:focus ~ div:last-child {
+.emotion-8:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-11 {
+.emotion-15 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2728,60 +3052,60 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   padding-right: 0;
 }
 
-.emotion-11[type="search"] {
+.emotion-15[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-11[type="search"]::-webkit-search-decoration {
+.emotion-15[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-11::-webkit-input-placeholder {
+.emotion-15::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-11::-moz-placeholder {
+.emotion-15::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-11:-ms-input-placeholder {
+.emotion-15:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-11::placeholder {
+.emotion-15::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-11::-ms-input-placeholder {
+.emotion-15::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-11:-ms-input-placeholder {
+.emotion-15:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-11::-ms-clear {
+.emotion-15::-ms-clear {
   display: none;
 }
 
-.emotion-11:focus ~ div:last-child {
+.emotion-15:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-18 {
+.emotion-24 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2800,60 +3124,60 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   padding-right: 0;
 }
 
-.emotion-18[type="search"] {
+.emotion-24[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-18[type="search"]::-webkit-search-decoration {
+.emotion-24[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-24::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-24::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-24:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::placeholder {
+.emotion-24::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-24::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-24:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-18::-ms-clear {
+.emotion-24::-ms-clear {
   display: none;
 }
 
-.emotion-18:focus ~ div:last-child {
+.emotion-24:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-5 {
+.emotion-7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2868,7 +3192,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   word-wrap: normal;
 }
 
-.emotion-12 {
+.emotion-16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2883,7 +3207,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   word-wrap: normal;
 }
 
-.emotion-97 {
+.emotion-125 {
   fill: currentcolor;
   font-size: 16px;
   height: 1.5em;
@@ -2893,7 +3217,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   width: 1.5em;
 }
 
-.emotion-25 {
+.emotion-33 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2908,7 +3232,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   word-wrap: normal;
 }
 
-.emotion-32 {
+.emotion-42 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2923,14 +3247,14 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   word-wrap: normal;
 }
 
-.emotion-54 {
+.emotion-70 {
   fill: currentcolor;
   font-size: 16px;
   height: 1em;
   width: 1em;
 }
 
-.emotion-55 {
+.emotion-71 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2945,7 +3269,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   word-wrap: normal;
 }
 
-.emotion-56 {
+.emotion-72 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -2964,60 +3288,60 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   padding-right: 0;
 }
 
-.emotion-56[type="search"] {
+.emotion-72[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-56[type="search"]::-webkit-search-decoration {
+.emotion-72[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-56::-webkit-input-placeholder {
+.emotion-72::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-56::-moz-placeholder {
+.emotion-72::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-56:-ms-input-placeholder {
+.emotion-72:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-56::placeholder {
+.emotion-72::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-56::-ms-input-placeholder {
+.emotion-72::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-56:-ms-input-placeholder {
+.emotion-72:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-56::-ms-clear {
+.emotion-72::-ms-clear {
   display: none;
 }
 
-.emotion-56:focus ~ div:last-child {
+.emotion-72:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-57 {
+.emotion-73 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -3032,7 +3356,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   word-wrap: normal;
 }
 
-.emotion-111 {
+.emotion-143 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -3051,60 +3375,60 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-111[type="search"] {
+.emotion-143[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-111[type="search"]::-webkit-search-decoration {
+.emotion-143[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-111::-webkit-input-placeholder {
+.emotion-143::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-111::-moz-placeholder {
+.emotion-143::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-111:-ms-input-placeholder {
+.emotion-143:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-111::placeholder {
+.emotion-143::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-111::-ms-input-placeholder {
+.emotion-143::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-111:-ms-input-placeholder {
+.emotion-143:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-111::-ms-clear {
+.emotion-143::-ms-clear {
   display: none;
 }
 
-.emotion-111:focus ~ div:last-child {
+.emotion-143:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-122 {
+.emotion-156 {
   fill: currentcolor;
   font-size: 16px;
   height: 1em;
@@ -3121,7 +3445,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
         marginBottom="1rem"
       >
         <div
-          className="emotion-63"
+          className="emotion-81"
         >
           <TextInput
             defaultValue="000"
@@ -3161,45 +3485,85 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 }
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      key="control"
-                      size="large"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-0"
-                        defaultValue="000"
                         size="large"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="000"
+                              key="control"
+                              size="large"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-0"
+                                defaultValue="000"
+                                size="large"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3244,57 +3608,99 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 prefix="$"
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  prefix="$"
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Styled(span)
-                      key="prefix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-5"
-                      >
-                        $
-                      </span>
-                    </Styled(span)>
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      key="control"
-                      prefix="$"
-                      size="large"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-6"
-                        defaultValue="000"
                         prefix="$"
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Styled(span)
+                              key="prefix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-7"
+                              >
+                                $
+                              </span>
+                            </Styled(span)>
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              key="control"
+                              prefix="$"
+                              size="large"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-8"
+                                defaultValue="000"
+                                prefix="$"
+                                size="large"
+                                type="number"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3339,56 +3745,98 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 size="large"
                 suffix="cm"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  size="large"
+                  suffix="cm"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      key="control"
-                      size="large"
-                      suffix="cm"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-11"
-                        defaultValue="000"
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Styled(span)
-                      key="suffix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-12"
+                        suffix="cm"
                       >
-                        cm
-                      </span>
-                    </Styled(span)>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              key="control"
+                              size="large"
+                              suffix="cm"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-15"
+                                defaultValue="000"
+                                size="large"
+                                type="number"
+                              />
+                            </Control>
+                            <Styled(span)
+                              key="suffix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-16"
+                              >
+                                cm
+                              </span>
+                            </Styled(span)>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3436,68 +3884,112 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 size="large"
                 suffix="cm"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  prefix="$"
+                  size="large"
+                  suffix="cm"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Styled(span)
-                      key="prefix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-5"
-                      >
-                        $
-                      </span>
-                    </Styled(span)>
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      key="control"
-                      prefix="$"
-                      size="large"
-                      suffix="cm"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-18"
-                        defaultValue="000"
                         prefix="$"
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Styled(span)
-                      key="suffix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-12"
+                        suffix="cm"
                       >
-                        cm
-                      </span>
-                    </Styled(span)>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Styled(span)
+                              key="prefix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-7"
+                              >
+                                $
+                              </span>
+                            </Styled(span)>
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              key="control"
+                              prefix="$"
+                              size="large"
+                              suffix="cm"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-24"
+                                defaultValue="000"
+                                prefix="$"
+                                size="large"
+                                type="number"
+                              />
+                            </Control>
+                            <Styled(span)
+                              key="suffix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-16"
+                              >
+                                cm
+                              </span>
+                            </Styled(span)>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3545,91 +4037,135 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 prefix="$"
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  iconStart={<IconCloud />}
+                  prefix="$"
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <IconCloud
-                      key="iconStart"
-                      size="1.5em"
-                    >
-                      <Icon
-                        rtl={false}
-                        size="1.5em"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={false}
-                          size="1.5em"
-                          viewBox="0 0 24 24"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-24"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                              />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconCloud>
-                    <Styled(span)
-                      iconStart={<IconCloud />}
-                      key="prefix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-25"
-                      >
-                        $
-                      </span>
-                    </Styled(span)>
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      iconStart={<IconCloud />}
-                      key="control"
-                      prefix="$"
-                      size="large"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-6"
-                        defaultValue="000"
+                        iconStart={<IconCloud />}
                         prefix="$"
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <IconCloud
+                              key="iconStart"
+                              size="1.5em"
+                            >
+                              <Icon
+                                rtl={false}
+                                size="1.5em"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={false}
+                                  size="1.5em"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-32"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconCloud>
+                            <Styled(span)
+                              iconStart={<IconCloud />}
+                              key="prefix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-33"
+                              >
+                                $
+                              </span>
+                            </Styled(span)>
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              iconStart={<IconCloud />}
+                              key="control"
+                              prefix="$"
+                              size="large"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-8"
+                                defaultValue="000"
+                                prefix="$"
+                                size="large"
+                                type="number"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3677,90 +4213,134 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 size="large"
                 suffix="cm"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  iconEnd={<IconBackspace />}
+                  size="large"
+                  suffix="cm"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      iconEnd={<IconBackspace />}
-                      key="control"
-                      size="large"
-                      suffix="cm"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-11"
-                        defaultValue="000"
+                        iconEnd={<IconBackspace />}
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Styled(span)
-                      iconEnd={<IconBackspace />}
-                      key="suffix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-32"
+                        suffix="cm"
                       >
-                        cm
-                      </span>
-                    </Styled(span)>
-                    <IconBackspace
-                      key="iconEnd"
-                      size="1.5em"
-                    >
-                      <Icon
-                        rtl={true}
-                        size="1.5em"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={true}
-                          size="1.5em"
-                          viewBox="0 0 24 24"
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
                         >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-24"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
+                          <div
+                            className="emotion-2"
                           >
-                            <g>
-                              <path
-                                d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              iconEnd={<IconBackspace />}
+                              key="control"
+                              size="large"
+                              suffix="cm"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-15"
+                                defaultValue="000"
+                                size="large"
+                                type="number"
                               />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconBackspace>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                            </Control>
+                            <Styled(span)
+                              iconEnd={<IconBackspace />}
+                              key="suffix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-42"
+                              >
+                                cm
+                              </span>
+                            </Styled(span)>
+                            <IconBackspace
+                              key="iconEnd"
+                              size="1.5em"
+                            >
+                              <Icon
+                                rtl={true}
+                                size="1.5em"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={true}
+                                  size="1.5em"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-32"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconBackspace>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3814,138 +4394,186 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 size="large"
                 suffix="cm"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  iconEnd={<IconBackspace />}
+                  iconStart={<IconCloud />}
+                  prefix="$"
+                  size="large"
+                  suffix="cm"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <IconCloud
-                      key="iconStart"
-                      size="1.5em"
-                    >
-                      <Icon
-                        rtl={false}
-                        size="1.5em"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={false}
-                          size="1.5em"
-                          viewBox="0 0 24 24"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-24"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                              />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconCloud>
-                    <Styled(span)
-                      iconEnd={<IconBackspace />}
-                      iconStart={<IconCloud />}
-                      key="prefix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-25"
-                      >
-                        $
-                      </span>
-                    </Styled(span)>
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      iconEnd={<IconBackspace />}
-                      iconStart={<IconCloud />}
-                      key="control"
-                      prefix="$"
-                      size="large"
-                      suffix="cm"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-18"
-                        defaultValue="000"
+                        iconEnd={<IconBackspace />}
+                        iconStart={<IconCloud />}
                         prefix="$"
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Styled(span)
-                      iconEnd={<IconBackspace />}
-                      iconStart={<IconCloud />}
-                      key="suffix"
-                      size="large"
-                    >
-                      <span
-                        className="emotion-32"
+                        suffix="cm"
                       >
-                        cm
-                      </span>
-                    </Styled(span)>
-                    <IconBackspace
-                      key="iconEnd"
-                      size="1.5em"
-                    >
-                      <Icon
-                        rtl={true}
-                        size="1.5em"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={true}
-                          size="1.5em"
-                          viewBox="0 0 24 24"
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
                         >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-24"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
+                          <div
+                            className="emotion-2"
                           >
-                            <g>
-                              <path
-                                d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                            <IconCloud
+                              key="iconStart"
+                              size="1.5em"
+                            >
+                              <Icon
+                                rtl={false}
+                                size="1.5em"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={false}
+                                  size="1.5em"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-32"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconCloud>
+                            <Styled(span)
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
+                              key="prefix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-33"
+                              >
+                                $
+                              </span>
+                            </Styled(span)>
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
+                              key="control"
+                              prefix="$"
+                              size="large"
+                              suffix="cm"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-24"
+                                defaultValue="000"
+                                prefix="$"
+                                size="large"
+                                type="number"
                               />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconBackspace>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                            </Control>
+                            <Styled(span)
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
+                              key="suffix"
+                              size="large"
+                            >
+                              <span
+                                className="emotion-42"
+                              >
+                                cm
+                              </span>
+                            </Styled(span)>
+                            <IconBackspace
+                              key="iconEnd"
+                              size="1.5em"
+                            >
+                              <Icon
+                                rtl={true}
+                                size="1.5em"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={true}
+                                  size="1.5em"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-32"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconBackspace>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -3975,7 +4603,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               variant="danger"
             >
               <TextInput
-                className="emotion-52"
+                className="emotion-66"
                 control={[Function]}
                 controlProps={
                   Object {
@@ -3993,93 +4621,137 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 suffix="cm"
                 variant="danger"
               >
-                <FauxControl
-                  className="emotion-52"
+                <Themed(FauxControl)
+                  className="emotion-66"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  size="large"
+                  suffix="cm"
                   variant="danger"
                 >
-                  <div
-                    className="emotion-51"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-66"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      key="control"
-                      size="large"
-                      suffix="cm"
-                      type="number"
-                      variant="danger"
-                    >
-                      <input
-                        className="emotion-47"
-                        defaultValue="000"
                         size="large"
-                        type="number"
-                      />
-                    </Control>
-                    <Styled(span)
-                      key="suffix"
-                      size="large"
-                      variant="danger"
-                    >
-                      <span
-                        className="emotion-32"
+                        suffix="cm"
+                        variant="danger"
                       >
-                        cm
-                      </span>
-                    </Styled(span)>
-                    <IconDanger
-                      key="iconEnd"
-                      size="1.5em"
-                    >
-                      <Icon
-                        rtl={false}
-                        size="1.5em"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={false}
-                          size="1.5em"
-                          viewBox="0 0 24 24"
+                        <FauxControl
+                          className="emotion-66"
+                          control={[Function]}
+                          variant="danger"
                         >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-24"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
+                          <div
+                            className="emotion-65"
                           >
-                            <g>
-                              <path
-                                d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              key="control"
+                              size="large"
+                              suffix="cm"
+                              type="number"
+                              variant="danger"
+                            >
+                              <input
+                                className="emotion-61"
+                                defaultValue="000"
+                                size="large"
+                                type="number"
                               />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconDanger>
-                    <Underlay
-                      variant="danger"
-                    >
-                      <div
-                        className="emotion-50"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                            </Control>
+                            <Styled(span)
+                              key="suffix"
+                              size="large"
+                              variant="danger"
+                            >
+                              <span
+                                className="emotion-42"
+                              >
+                                cm
+                              </span>
+                            </Styled(span)>
+                            <IconDanger
+                              key="iconEnd"
+                              size="1.5em"
+                            >
+                              <Icon
+                                rtl={false}
+                                size="1.5em"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={false}
+                                  size="1.5em"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-32"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconDanger>
+                            <Underlay
+                              variant="danger"
+                            >
+                              <div
+                                className="emotion-64"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4133,138 +4805,186 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                 size="small"
                 suffix="cm"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "000",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "number",
+                    }
+                  }
+                  iconEnd={<IconBackspace />}
+                  iconStart={<IconCloud />}
+                  prefix="$"
+                  size="small"
+                  suffix="cm"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <IconCloud
-                      key="iconStart"
-                      size="medium"
-                    >
-                      <Icon
-                        rtl={false}
-                        size="medium"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={false}
-                          size="medium"
-                          viewBox="0 0 24 24"
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-54"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
-                          >
-                            <g>
-                              <path
-                                d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                              />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconCloud>
-                    <Styled(span)
-                      iconEnd={<IconBackspace />}
-                      iconStart={<IconCloud />}
-                      key="prefix"
-                      size="small"
-                    >
-                      <span
-                        className="emotion-55"
-                      >
-                        $
-                      </span>
-                    </Styled(span)>
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "000",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "number",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
                         }
-                      }
-                      defaultValue="000"
-                      iconEnd={<IconBackspace />}
-                      iconStart={<IconCloud />}
-                      key="control"
-                      prefix="$"
-                      size="small"
-                      suffix="cm"
-                      type="number"
-                    >
-                      <input
-                        className="emotion-56"
-                        defaultValue="000"
+                        iconEnd={<IconBackspace />}
+                        iconStart={<IconCloud />}
                         prefix="$"
                         size="small"
-                        type="number"
-                      />
-                    </Control>
-                    <Styled(span)
-                      iconEnd={<IconBackspace />}
-                      iconStart={<IconCloud />}
-                      key="suffix"
-                      size="small"
-                    >
-                      <span
-                        className="emotion-57"
+                        suffix="cm"
                       >
-                        cm
-                      </span>
-                    </Styled(span)>
-                    <IconBackspace
-                      key="iconEnd"
-                      size="medium"
-                    >
-                      <Icon
-                        rtl={true}
-                        size="medium"
-                      >
-                        <Styled(svg)
-                          aria-hidden={true}
-                          focusable="false"
-                          role="img"
-                          rtl={true}
-                          size="medium"
-                          viewBox="0 0 24 24"
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
                         >
-                          <svg
-                            aria-hidden={true}
-                            className="emotion-54"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 24 24"
+                          <div
+                            className="emotion-2"
                           >
-                            <g>
-                              <path
-                                d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                            <IconCloud
+                              key="iconStart"
+                              size="medium"
+                            >
+                              <Icon
+                                rtl={false}
+                                size="medium"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={false}
+                                  size="medium"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-70"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconCloud>
+                            <Styled(span)
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
+                              key="prefix"
+                              size="small"
+                            >
+                              <span
+                                className="emotion-71"
+                              >
+                                $
+                              </span>
+                            </Styled(span)>
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
+                              }
+                              defaultValue="000"
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
+                              key="control"
+                              prefix="$"
+                              size="small"
+                              suffix="cm"
+                              type="number"
+                            >
+                              <input
+                                className="emotion-72"
+                                defaultValue="000"
+                                prefix="$"
+                                size="small"
+                                type="number"
                               />
-                            </g>
-                          </svg>
-                        </Styled(svg)>
-                      </Icon>
-                    </IconBackspace>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                            </Control>
+                            <Styled(span)
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
+                              key="suffix"
+                              size="small"
+                            >
+                              <span
+                                className="emotion-73"
+                              >
+                                cm
+                              </span>
+                            </Styled(span)>
+                            <IconBackspace
+                              key="iconEnd"
+                              size="medium"
+                            >
+                              <Icon
+                                rtl={true}
+                                size="medium"
+                              >
+                                <Styled(svg)
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  role="img"
+                                  rtl={true}
+                                  size="medium"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="emotion-70"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </Styled(svg)>
+                              </Icon>
+                            </IconBackspace>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -4284,7 +5004,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               marginBottom="1rem"
             >
               <div
-                className="emotion-63"
+                className="emotion-81"
               >
                 <TextInput
                   defaultValue="000"
@@ -4324,45 +5044,85 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       }
                       size="large"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
+                        }
+                        size="large"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "text",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            key="control"
-                            size="large"
-                            type="text"
-                          >
-                            <input
-                              className="emotion-0"
-                              defaultValue="000"
                               size="large"
-                              type="text"
-                            />
-                          </Control>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                            >
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
+                              >
+                                <div
+                                  className="emotion-2"
+                                >
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "text",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    key="control"
+                                    size="large"
+                                    type="text"
+                                  >
+                                    <input
+                                      className="emotion-0"
+                                      defaultValue="000"
+                                      size="large"
+                                      type="text"
+                                    />
+                                  </Control>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -4407,57 +5167,99 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       prefix="$"
                       size="large"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        prefix="$"
+                        size="large"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <Styled(span)
-                            key="prefix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-12"
-                            >
-                              $
-                            </span>
-                          </Styled(span)>
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            key="control"
-                            prefix="$"
-                            size="large"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-11"
-                              defaultValue="000"
                               prefix="$"
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                            >
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
+                              >
+                                <div
+                                  className="emotion-2"
+                                >
+                                  <Styled(span)
+                                    key="prefix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-16"
+                                    >
+                                      $
+                                    </span>
+                                  </Styled(span)>
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    key="control"
+                                    prefix="$"
+                                    size="large"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-15"
+                                      defaultValue="000"
+                                      prefix="$"
+                                      size="large"
+                                      type="number"
+                                    />
+                                  </Control>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -4502,56 +5304,98 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       size="large"
                       suffix="cm"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        size="large"
+                        suffix="cm"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            key="control"
-                            size="large"
-                            suffix="cm"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-6"
-                              defaultValue="000"
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Styled(span)
-                            key="suffix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-5"
+                              suffix="cm"
                             >
-                              cm
-                            </span>
-                          </Styled(span)>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
+                              >
+                                <div
+                                  className="emotion-2"
+                                >
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    key="control"
+                                    size="large"
+                                    suffix="cm"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-8"
+                                      defaultValue="000"
+                                      size="large"
+                                      type="number"
+                                    />
+                                  </Control>
+                                  <Styled(span)
+                                    key="suffix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-7"
+                                    >
+                                      cm
+                                    </span>
+                                  </Styled(span)>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -4599,68 +5443,112 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       size="large"
                       suffix="cm"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        prefix="$"
+                        size="large"
+                        suffix="cm"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <Styled(span)
-                            key="prefix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-12"
-                            >
-                              $
-                            </span>
-                          </Styled(span)>
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            key="control"
-                            prefix="$"
-                            size="large"
-                            suffix="cm"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-18"
-                              defaultValue="000"
                               prefix="$"
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Styled(span)
-                            key="suffix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-5"
+                              suffix="cm"
                             >
-                              cm
-                            </span>
-                          </Styled(span)>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
+                              >
+                                <div
+                                  className="emotion-2"
+                                >
+                                  <Styled(span)
+                                    key="prefix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-16"
+                                    >
+                                      $
+                                    </span>
+                                  </Styled(span)>
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    key="control"
+                                    prefix="$"
+                                    size="large"
+                                    suffix="cm"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-24"
+                                      defaultValue="000"
+                                      prefix="$"
+                                      size="large"
+                                      type="number"
+                                    />
+                                  </Control>
+                                  <Styled(span)
+                                    key="suffix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-7"
+                                    >
+                                      cm
+                                    </span>
+                                  </Styled(span)>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -4708,91 +5596,135 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       prefix="$"
                       size="large"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        iconStart={<IconCloud />}
+                        prefix="$"
+                        size="large"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <IconCloud
-                            key="iconStart"
-                            size="1.5em"
-                          >
-                            <Icon
-                              rtl={false}
-                              size="1.5em"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={false}
-                                size="1.5em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-24"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <g>
-                                    <path
-                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                                    />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconCloud>
-                          <Styled(span)
-                            iconStart={<IconCloud />}
-                            key="prefix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-32"
-                            >
-                              $
-                            </span>
-                          </Styled(span)>
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            iconStart={<IconCloud />}
-                            key="control"
-                            prefix="$"
-                            size="large"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-11"
-                              defaultValue="000"
+                              iconStart={<IconCloud />}
                               prefix="$"
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                            >
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
+                              >
+                                <div
+                                  className="emotion-2"
+                                >
+                                  <IconCloud
+                                    key="iconStart"
+                                    size="1.5em"
+                                  >
+                                    <Icon
+                                      rtl={false}
+                                      size="1.5em"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={false}
+                                        size="1.5em"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-32"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconCloud>
+                                  <Styled(span)
+                                    iconStart={<IconCloud />}
+                                    key="prefix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-42"
+                                    >
+                                      $
+                                    </span>
+                                  </Styled(span)>
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    iconStart={<IconCloud />}
+                                    key="control"
+                                    prefix="$"
+                                    size="large"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-15"
+                                      defaultValue="000"
+                                      prefix="$"
+                                      size="large"
+                                      type="number"
+                                    />
+                                  </Control>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -4840,90 +5772,134 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       size="large"
                       suffix="cm"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        iconEnd={<IconBackspace />}
+                        size="large"
+                        suffix="cm"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            iconEnd={<IconBackspace />}
-                            key="control"
-                            size="large"
-                            suffix="cm"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-6"
-                              defaultValue="000"
+                              iconEnd={<IconBackspace />}
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Styled(span)
-                            iconEnd={<IconBackspace />}
-                            key="suffix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-25"
+                              suffix="cm"
                             >
-                              cm
-                            </span>
-                          </Styled(span)>
-                          <IconBackspace
-                            key="iconEnd"
-                            size="1.5em"
-                          >
-                            <Icon
-                              rtl={true}
-                              size="1.5em"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={true}
-                                size="1.5em"
-                                viewBox="0 0 24 24"
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-97"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
+                                <div
+                                  className="emotion-2"
                                 >
-                                  <g>
-                                    <path
-                                      d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    iconEnd={<IconBackspace />}
+                                    key="control"
+                                    size="large"
+                                    suffix="cm"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-8"
+                                      defaultValue="000"
+                                      size="large"
+                                      type="number"
                                     />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconBackspace>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                                  </Control>
+                                  <Styled(span)
+                                    iconEnd={<IconBackspace />}
+                                    key="suffix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-33"
+                                    >
+                                      cm
+                                    </span>
+                                  </Styled(span)>
+                                  <IconBackspace
+                                    key="iconEnd"
+                                    size="1.5em"
+                                  >
+                                    <Icon
+                                      rtl={true}
+                                      size="1.5em"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={true}
+                                        size="1.5em"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-125"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconBackspace>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -4977,138 +5953,186 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       size="large"
                       suffix="cm"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        iconEnd={<IconBackspace />}
+                        iconStart={<IconCloud />}
+                        prefix="$"
+                        size="large"
+                        suffix="cm"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <IconCloud
-                            key="iconStart"
-                            size="1.5em"
-                          >
-                            <Icon
-                              rtl={false}
-                              size="1.5em"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={false}
-                                size="1.5em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-24"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <g>
-                                    <path
-                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                                    />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconCloud>
-                          <Styled(span)
-                            iconEnd={<IconBackspace />}
-                            iconStart={<IconCloud />}
-                            key="prefix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-32"
-                            >
-                              $
-                            </span>
-                          </Styled(span)>
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            iconEnd={<IconBackspace />}
-                            iconStart={<IconCloud />}
-                            key="control"
-                            prefix="$"
-                            size="large"
-                            suffix="cm"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-18"
-                              defaultValue="000"
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
                               prefix="$"
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Styled(span)
-                            iconEnd={<IconBackspace />}
-                            iconStart={<IconCloud />}
-                            key="suffix"
-                            size="large"
-                          >
-                            <span
-                              className="emotion-25"
+                              suffix="cm"
                             >
-                              cm
-                            </span>
-                          </Styled(span)>
-                          <IconBackspace
-                            key="iconEnd"
-                            size="1.5em"
-                          >
-                            <Icon
-                              rtl={true}
-                              size="1.5em"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={true}
-                                size="1.5em"
-                                viewBox="0 0 24 24"
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-97"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
+                                <div
+                                  className="emotion-2"
                                 >
-                                  <g>
-                                    <path
-                                      d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                  <IconCloud
+                                    key="iconStart"
+                                    size="1.5em"
+                                  >
+                                    <Icon
+                                      rtl={false}
+                                      size="1.5em"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={false}
+                                        size="1.5em"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-32"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconCloud>
+                                  <Styled(span)
+                                    iconEnd={<IconBackspace />}
+                                    iconStart={<IconCloud />}
+                                    key="prefix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-42"
+                                    >
+                                      $
+                                    </span>
+                                  </Styled(span)>
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    iconEnd={<IconBackspace />}
+                                    iconStart={<IconCloud />}
+                                    key="control"
+                                    prefix="$"
+                                    size="large"
+                                    suffix="cm"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-24"
+                                      defaultValue="000"
+                                      prefix="$"
+                                      size="large"
+                                      type="number"
                                     />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconBackspace>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                                  </Control>
+                                  <Styled(span)
+                                    iconEnd={<IconBackspace />}
+                                    iconStart={<IconCloud />}
+                                    key="suffix"
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-33"
+                                    >
+                                      cm
+                                    </span>
+                                  </Styled(span)>
+                                  <IconBackspace
+                                    key="iconEnd"
+                                    size="1.5em"
+                                  >
+                                    <Icon
+                                      rtl={true}
+                                      size="1.5em"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={true}
+                                        size="1.5em"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-125"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconBackspace>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -5138,7 +6162,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     variant="danger"
                   >
                     <TextInput
-                      className="emotion-52"
+                      className="emotion-66"
                       control={[Function]}
                       controlProps={
                         Object {
@@ -5156,93 +6180,137 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       suffix="cm"
                       variant="danger"
                     >
-                      <FauxControl
-                        className="emotion-52"
+                      <Themed(FauxControl)
+                        className="emotion-66"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        size="large"
+                        suffix="cm"
                         variant="danger"
                       >
-                        <div
-                          className="emotion-51"
-                        >
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-66"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            key="control"
-                            size="large"
-                            suffix="cm"
-                            type="number"
-                            variant="danger"
-                          >
-                            <input
-                              className="emotion-111"
-                              defaultValue="000"
                               size="large"
-                              type="number"
-                            />
-                          </Control>
-                          <Styled(span)
-                            key="suffix"
-                            size="large"
-                            variant="danger"
-                          >
-                            <span
-                              className="emotion-25"
+                              suffix="cm"
+                              variant="danger"
                             >
-                              cm
-                            </span>
-                          </Styled(span)>
-                          <IconDanger
-                            key="iconEnd"
-                            size="1.5em"
-                          >
-                            <Icon
-                              rtl={false}
-                              size="1.5em"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={false}
-                                size="1.5em"
-                                viewBox="0 0 24 24"
+                              <FauxControl
+                                className="emotion-66"
+                                control={[Function]}
+                                variant="danger"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-24"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
+                                <div
+                                  className="emotion-65"
                                 >
-                                  <g>
-                                    <path
-                                      d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    key="control"
+                                    size="large"
+                                    suffix="cm"
+                                    type="number"
+                                    variant="danger"
+                                  >
+                                    <input
+                                      className="emotion-143"
+                                      defaultValue="000"
+                                      size="large"
+                                      type="number"
                                     />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconDanger>
-                          <Underlay
-                            variant="danger"
-                          >
-                            <div
-                              className="emotion-50"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                                  </Control>
+                                  <Styled(span)
+                                    key="suffix"
+                                    size="large"
+                                    variant="danger"
+                                  >
+                                    <span
+                                      className="emotion-33"
+                                    >
+                                      cm
+                                    </span>
+                                  </Styled(span)>
+                                  <IconDanger
+                                    key="iconEnd"
+                                    size="1.5em"
+                                  >
+                                    <Icon
+                                      rtl={false}
+                                      size="1.5em"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={false}
+                                        size="1.5em"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-32"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconDanger>
+                                  <Underlay
+                                    variant="danger"
+                                  >
+                                    <div
+                                      className="emotion-64"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -5296,138 +6364,186 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                       size="small"
                       suffix="cm"
                     >
-                      <FauxControl
+                      <Themed(FauxControl)
                         className="emotion-3"
                         control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "000",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "number",
+                          }
+                        }
+                        iconEnd={<IconBackspace />}
+                        iconStart={<IconCloud />}
+                        prefix="$"
+                        size="small"
+                        suffix="cm"
                       >
-                        <div
-                          className="emotion-2"
-                        >
-                          <IconCloud
-                            key="iconStart"
-                            size="medium"
-                          >
-                            <Icon
-                              rtl={false}
-                              size="medium"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={false}
-                                size="medium"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-54"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <g>
-                                    <path
-                                      d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
-                                    />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconCloud>
-                          <Styled(span)
-                            iconEnd={<IconBackspace />}
-                            iconStart={<IconCloud />}
-                            key="prefix"
-                            size="small"
-                          >
-                            <span
-                              className="emotion-57"
-                            >
-                              $
-                            </span>
-                          </Styled(span)>
-                          <Control
-                            controlPropsIn={
-                              Object {
-                                "aria-invalid": undefined,
-                                "aria-required": undefined,
-                                "controlRef": undefined,
-                                "defaultValue": "000",
-                                "disabled": undefined,
-                                "readOnly": undefined,
-                                "required": undefined,
-                                "type": "number",
+                        <ThemeProvider>
+                          <ThemeProvider>
+                            <FauxControl
+                              className="emotion-3"
+                              control={[Function]}
+                              controlProps={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "000",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "number",
+                                }
                               }
-                            }
-                            defaultValue="000"
-                            iconEnd={<IconBackspace />}
-                            iconStart={<IconCloud />}
-                            key="control"
-                            prefix="$"
-                            size="small"
-                            suffix="cm"
-                            type="number"
-                          >
-                            <input
-                              className="emotion-56"
-                              defaultValue="000"
+                              iconEnd={<IconBackspace />}
+                              iconStart={<IconCloud />}
                               prefix="$"
                               size="small"
-                              type="number"
-                            />
-                          </Control>
-                          <Styled(span)
-                            iconEnd={<IconBackspace />}
-                            iconStart={<IconCloud />}
-                            key="suffix"
-                            size="small"
-                          >
-                            <span
-                              className="emotion-55"
+                              suffix="cm"
                             >
-                              cm
-                            </span>
-                          </Styled(span)>
-                          <IconBackspace
-                            key="iconEnd"
-                            size="medium"
-                          >
-                            <Icon
-                              rtl={true}
-                              size="medium"
-                            >
-                              <Styled(svg)
-                                aria-hidden={true}
-                                focusable="false"
-                                role="img"
-                                rtl={true}
-                                size="medium"
-                                viewBox="0 0 24 24"
+                              <FauxControl
+                                className="emotion-3"
+                                control={[Function]}
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  className="emotion-122"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 24 24"
+                                <div
+                                  className="emotion-2"
                                 >
-                                  <g>
-                                    <path
-                                      d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                  <IconCloud
+                                    key="iconStart"
+                                    size="medium"
+                                  >
+                                    <Icon
+                                      rtl={false}
+                                      size="medium"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={false}
+                                        size="medium"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-70"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconCloud>
+                                  <Styled(span)
+                                    iconEnd={<IconBackspace />}
+                                    iconStart={<IconCloud />}
+                                    key="prefix"
+                                    size="small"
+                                  >
+                                    <span
+                                      className="emotion-73"
+                                    >
+                                      $
+                                    </span>
+                                  </Styled(span)>
+                                  <Control
+                                    controlPropsIn={
+                                      Object {
+                                        "aria-invalid": undefined,
+                                        "aria-required": undefined,
+                                        "controlRef": undefined,
+                                        "defaultValue": "000",
+                                        "disabled": undefined,
+                                        "readOnly": undefined,
+                                        "required": undefined,
+                                        "type": "number",
+                                      }
+                                    }
+                                    defaultValue="000"
+                                    iconEnd={<IconBackspace />}
+                                    iconStart={<IconCloud />}
+                                    key="control"
+                                    prefix="$"
+                                    size="small"
+                                    suffix="cm"
+                                    type="number"
+                                  >
+                                    <input
+                                      className="emotion-72"
+                                      defaultValue="000"
+                                      prefix="$"
+                                      size="small"
+                                      type="number"
                                     />
-                                  </g>
-                                </svg>
-                              </Styled(svg)>
-                            </Icon>
-                          </IconBackspace>
-                          <Underlay>
-                            <div
-                              className="emotion-1"
-                            />
-                          </Underlay>
-                        </div>
-                      </FauxControl>
+                                  </Control>
+                                  <Styled(span)
+                                    iconEnd={<IconBackspace />}
+                                    iconStart={<IconCloud />}
+                                    key="suffix"
+                                    size="small"
+                                  >
+                                    <span
+                                      className="emotion-71"
+                                    >
+                                      cm
+                                    </span>
+                                  </Styled(span)>
+                                  <IconBackspace
+                                    key="iconEnd"
+                                    size="medium"
+                                  >
+                                    <Icon
+                                      rtl={true}
+                                      size="medium"
+                                    >
+                                      <Styled(svg)
+                                        aria-hidden={true}
+                                        focusable="false"
+                                        role="img"
+                                        rtl={true}
+                                        size="medium"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="emotion-156"
+                                          focusable="false"
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <g>
+                                            <path
+                                              d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </Styled(svg)>
+                                    </Icon>
+                                  </IconBackspace>
+                                  <Underlay>
+                                    <div
+                                      className="emotion-1"
+                                    />
+                                  </Underlay>
+                                </div>
+                              </FauxControl>
+                            </FauxControl>
+                          </ThemeProvider>
+                        </ThemeProvider>
+                      </Themed(FauxControl)>
                     </TextInput>
                   </TextInput>
                 </TextInput>
@@ -5524,7 +6640,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   color: #c8d1e0;
 }
 
-.emotion-16 {
+.emotion-20 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -5543,55 +6659,55 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-16[type="search"] {
+.emotion-20[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-16[type="search"]::-webkit-search-decoration {
+.emotion-20[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-16::-webkit-input-placeholder {
+.emotion-20::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-16::-moz-placeholder {
+.emotion-20::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-16:-ms-input-placeholder {
+.emotion-20:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-16::placeholder {
+.emotion-20::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-16::-ms-input-placeholder {
+.emotion-20::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-16:-ms-input-placeholder {
+.emotion-20:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-16::-ms-clear {
+.emotion-20::-ms-clear {
   display: none;
 }
 
-.emotion-16:focus ~ div:last-child {
+.emotion-20:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -5682,7 +6798,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-8 {
+.emotion-10 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -5701,60 +6817,60 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-8[type="search"] {
+.emotion-10[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-8[type="search"]::-webkit-search-decoration {
+.emotion-10[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-8::-webkit-input-placeholder {
+.emotion-10::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::-moz-placeholder {
+.emotion-10::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8:-ms-input-placeholder {
+.emotion-10:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::placeholder {
+.emotion-10::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::-ms-input-placeholder {
+.emotion-10::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8:-ms-input-placeholder {
+.emotion-10:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-8::-ms-clear {
+.emotion-10::-ms-clear {
   display: none;
 }
 
-.emotion-8:focus ~ div:last-child {
+.emotion-10:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-24 {
+.emotion-30 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -5773,60 +6889,60 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-24[type="search"] {
+.emotion-30[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-24[type="search"]::-webkit-search-decoration {
+.emotion-30[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-24::-webkit-input-placeholder {
+.emotion-30::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-24::-moz-placeholder {
+.emotion-30::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-24:-ms-input-placeholder {
+.emotion-30:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-24::placeholder {
+.emotion-30::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-24::-ms-input-placeholder {
+.emotion-30::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-24:-ms-input-placeholder {
+.emotion-30:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-24::-ms-clear {
+.emotion-30::-ms-clear {
   display: none;
 }
 
-.emotion-24:focus ~ div:last-child {
+.emotion-30:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-23 {
+.emotion-29 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -5852,13 +6968,13 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   vertical-align: middle;
 }
 
-.emotion-23 *,
-.emotion-23 *::before,
-.emotion-23 *::after {
+.emotion-29 *,
+.emotion-29 *::before,
+.emotion-29 *::after {
   box-sizing: inherit;
 }
 
-.emotion-23:focus {
+.emotion-29:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -5866,41 +6982,41 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   text-decoration: none;
 }
 
-.emotion-23:hover {
+.emotion-29:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-23:active {
+.emotion-29:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-23::-moz-focus-inner {
+.emotion-29::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-23 [role="img"] {
+.emotion-29 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-23 [role="img"]:first-child {
+.emotion-29 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-23 [role="img"]:last-child {
+.emotion-29 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-23 [role="img"]:only-child {
+.emotion-29 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-6 {
+.emotion-8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5918,7 +7034,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   width: 100%;
 }
 
-.emotion-21 {
+.emotion-27 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -5929,15 +7045,15 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   line-height: 2.857142857142857em;
 }
 
-.emotion-21:first-child {
+.emotion-27:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-21:last-child {
+.emotion-27:last-child {
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-33 > * {
+.emotion-41 > * {
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -5948,18 +7064,18 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   display: flex;
 }
 
-.emotion-33 > * > div {
+.emotion-41 > * > div {
   -webkit-flex: 0 0 8rem;
   -ms-flex: 0 0 8rem;
   flex: 0 0 8rem;
   margin-right: 0.5rem;
 }
 
-.emotion-32[class] > *:not(:last-child) {
+.emotion-40[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-32 > * {
+.emotion-40 > * {
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -5970,14 +7086,14 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   display: flex;
 }
 
-.emotion-32 > * > div {
+.emotion-40 > * > div {
   -webkit-flex: 0 0 8rem;
   -ms-flex: 0 0 8rem;
   flex: 0 0 8rem;
   margin-right: 0.5rem;
 }
 
-.emotion-7 {
+.emotion-9 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -6003,13 +7119,13 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   vertical-align: middle;
 }
 
-.emotion-7 *,
-.emotion-7 *::before,
-.emotion-7 *::after {
+.emotion-9 *,
+.emotion-9 *::before,
+.emotion-9 *::after {
   box-sizing: inherit;
 }
 
-.emotion-7:focus {
+.emotion-9:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -6017,41 +7133,41 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   text-decoration: none;
 }
 
-.emotion-7:hover {
+.emotion-9:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-7:active {
+.emotion-9:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-7::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-7 [role="img"] {
+.emotion-9 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-7 [role="img"]:first-child {
+.emotion-9 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-7 [role="img"]:last-child {
+.emotion-9 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-7 [role="img"]:only-child {
+.emotion-9 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-5 {
+.emotion-7 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -6062,7 +7178,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   line-height: 2em;
 }
 
-.emotion-15 {
+.emotion-19 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -6088,13 +7204,13 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   vertical-align: middle;
 }
 
-.emotion-15 *,
-.emotion-15 *::before,
-.emotion-15 *::after {
+.emotion-19 *,
+.emotion-19 *::before,
+.emotion-19 *::after {
   box-sizing: inherit;
 }
 
-.emotion-15:focus {
+.emotion-19:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -6102,41 +7218,41 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   text-decoration: none;
 }
 
-.emotion-15:hover {
+.emotion-19:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-15:active {
+.emotion-19:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-15::-moz-focus-inner {
+.emotion-19::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-15 [role="img"] {
+.emotion-19 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-15 [role="img"]:first-child {
+.emotion-19 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-15 [role="img"]:last-child {
+.emotion-19 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-15 [role="img"]:only-child {
+.emotion-19 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-13 {
+.emotion-17 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -6147,7 +7263,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   line-height: 2.2857142857142856em;
 }
 
-.emotion-31 {
+.emotion-39 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -6173,13 +7289,13 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   vertical-align: middle;
 }
 
-.emotion-31 *,
-.emotion-31 *::before,
-.emotion-31 *::after {
+.emotion-39 *,
+.emotion-39 *::before,
+.emotion-39 *::after {
   box-sizing: inherit;
 }
 
-.emotion-31:focus {
+.emotion-39:focus {
   background-color: #ebeff5;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
   color: #333840;
@@ -6187,41 +7303,41 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   text-decoration: none;
 }
 
-.emotion-31:hover {
+.emotion-39:hover {
   background-color: #f5f7fa;
   color: #333840;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-31:active {
+.emotion-39:active {
   background-color: #dde3ed;
   color: #333840;
 }
 
-.emotion-31::-moz-focus-inner {
+.emotion-39::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-31 [role="img"] {
+.emotion-39 [role="img"] {
   box-sizing: content-box;
   color: #3272d9;
   display: block;
 }
 
-.emotion-31 [role="img"]:first-child {
+.emotion-39 [role="img"]:first-child {
   margin-right: 0.5em;
 }
 
-.emotion-31 [role="img"]:last-child {
+.emotion-39 [role="img"]:last-child {
   margin-left: 0.5em;
 }
 
-.emotion-31 [role="img"]:only-child {
+.emotion-39 [role="img"]:only-child {
   margin: 0;
 }
 
-.emotion-29 {
+.emotion-37 {
   display: block;
   max-width: 100%;
   overflow: hidden;
@@ -6232,24 +7348,24 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
   line-height: 3.7142857142857144em;
 }
 
-.emotion-29:first-child {
+.emotion-37:first-child {
   padding-left: 0.5714285714285714em;
 }
 
-.emotion-29:last-child {
+.emotion-37:last-child {
   padding-right: 0.5714285714285714em;
 }
 
 <Styled(DemoLayout)>
   <DemoLayout
-    className="emotion-33"
+    className="emotion-41"
   >
     <Styled(div)
-      className="emotion-33"
+      className="emotion-41"
       marginBottom="1rem"
     >
       <div
-        className="emotion-32"
+        className="emotion-40"
       >
         <div>
           <TextInput
@@ -6290,45 +7406,85 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                 }
                 size="small"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Small",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="small"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Small",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Small",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Small"
-                      key="control"
-                      size="small"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-0"
-                        defaultValue="Small"
                         size="small"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Small",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Small"
+                              key="control"
+                              size="small"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-0"
+                                defaultValue="Small"
+                                size="small"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -6344,18 +7500,18 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               type="button"
             >
               <button
-                className="emotion-7"
+                className="emotion-9"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-6"
+                    className="emotion-8"
                   >
                     <Styled(span)
                       size="small"
                     >
                       <span
-                        className="emotion-5"
+                        className="emotion-7"
                       >
                         Small
                       </span>
@@ -6405,45 +7561,85 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                 }
                 size="medium"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Medium",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="medium"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Medium",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Medium",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Medium"
-                      key="control"
-                      size="medium"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-8"
-                        defaultValue="Medium"
                         size="medium"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Medium",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Medium"
+                              key="control"
+                              size="medium"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-10"
+                                defaultValue="Medium"
+                                size="medium"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -6459,18 +7655,18 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               type="button"
             >
               <button
-                className="emotion-15"
+                className="emotion-19"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-6"
+                    className="emotion-8"
                   >
                     <Styled(span)
                       size="medium"
                     >
                       <span
-                        className="emotion-13"
+                        className="emotion-17"
                       >
                         Medium
                       </span>
@@ -6520,45 +7716,85 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                 }
                 size="large"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Large",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="large"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Large",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Large",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Large"
-                      key="control"
-                      size="large"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-16"
-                        defaultValue="Large"
                         size="large"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Large",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Large"
+                              key="control"
+                              size="large"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-20"
+                                defaultValue="Large"
+                                size="large"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -6574,18 +7810,18 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               type="button"
             >
               <button
-                className="emotion-23"
+                className="emotion-29"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-6"
+                    className="emotion-8"
                   >
                     <Styled(span)
                       size="large"
                     >
                       <span
-                        className="emotion-21"
+                        className="emotion-27"
                       >
                         Large
                       </span>
@@ -6635,45 +7871,85 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                 }
                 size="jumbo"
               >
-                <FauxControl
+                <Themed(FauxControl)
                   className="emotion-3"
                   control={[Function]}
+                  controlProps={
+                    Object {
+                      "aria-invalid": undefined,
+                      "aria-required": undefined,
+                      "controlRef": undefined,
+                      "defaultValue": "Jumbo",
+                      "disabled": undefined,
+                      "readOnly": undefined,
+                      "required": undefined,
+                      "type": "text",
+                    }
+                  }
+                  size="jumbo"
                 >
-                  <div
-                    className="emotion-2"
-                  >
-                    <Control
-                      controlPropsIn={
-                        Object {
-                          "aria-invalid": undefined,
-                          "aria-required": undefined,
-                          "controlRef": undefined,
-                          "defaultValue": "Jumbo",
-                          "disabled": undefined,
-                          "readOnly": undefined,
-                          "required": undefined,
-                          "type": "text",
+                  <ThemeProvider>
+                    <ThemeProvider>
+                      <FauxControl
+                        className="emotion-3"
+                        control={[Function]}
+                        controlProps={
+                          Object {
+                            "aria-invalid": undefined,
+                            "aria-required": undefined,
+                            "controlRef": undefined,
+                            "defaultValue": "Jumbo",
+                            "disabled": undefined,
+                            "readOnly": undefined,
+                            "required": undefined,
+                            "type": "text",
+                          }
                         }
-                      }
-                      defaultValue="Jumbo"
-                      key="control"
-                      size="jumbo"
-                      type="text"
-                    >
-                      <input
-                        className="emotion-24"
-                        defaultValue="Jumbo"
                         size="jumbo"
-                        type="text"
-                      />
-                    </Control>
-                    <Underlay>
-                      <div
-                        className="emotion-1"
-                      />
-                    </Underlay>
-                  </div>
-                </FauxControl>
+                      >
+                        <FauxControl
+                          className="emotion-3"
+                          control={[Function]}
+                        >
+                          <div
+                            className="emotion-2"
+                          >
+                            <Control
+                              controlPropsIn={
+                                Object {
+                                  "aria-invalid": undefined,
+                                  "aria-required": undefined,
+                                  "controlRef": undefined,
+                                  "defaultValue": "Jumbo",
+                                  "disabled": undefined,
+                                  "readOnly": undefined,
+                                  "required": undefined,
+                                  "type": "text",
+                                }
+                              }
+                              defaultValue="Jumbo"
+                              key="control"
+                              size="jumbo"
+                              type="text"
+                            >
+                              <input
+                                className="emotion-30"
+                                defaultValue="Jumbo"
+                                size="jumbo"
+                                type="text"
+                              />
+                            </Control>
+                            <Underlay>
+                              <div
+                                className="emotion-1"
+                              />
+                            </Underlay>
+                          </div>
+                        </FauxControl>
+                      </FauxControl>
+                    </ThemeProvider>
+                  </ThemeProvider>
+                </Themed(FauxControl)>
               </TextInput>
             </TextInput>
           </TextInput>
@@ -6689,18 +7965,18 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               type="button"
             >
               <button
-                className="emotion-31"
+                className="emotion-39"
                 type="button"
               >
                 <Styled(span)>
                   <span
-                    className="emotion-6"
+                    className="emotion-8"
                   >
                     <Styled(span)
                       size="jumbo"
                     >
                       <span
-                        className="emotion-29"
+                        className="emotion-37"
                       >
                         Jumbo
                       </span>
@@ -6924,45 +8200,85 @@ exports[`TextInput demo examples Snapshots: placeholder 1`] = `
       }
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "controlRef": undefined,
+            "disabled": undefined,
+            "placeholder": "12345-123",
+            "readOnly": undefined,
+            "required": undefined,
+            "type": "text",
+          }
+        }
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "controlRef": undefined,
-                "disabled": undefined,
-                "placeholder": "12345-123",
-                "readOnly": undefined,
-                "required": undefined,
-                "type": "text",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "disabled": undefined,
+                  "placeholder": "12345-123",
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
               }
-            }
-            key="control"
-            placeholder="12345-123"
-            size="large"
-            type="text"
-          >
-            <input
-              className="emotion-0"
-              placeholder="12345-123"
               size="large"
-              type="text"
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "disabled": undefined,
+                        "placeholder": "12345-123",
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    key="control"
+                    placeholder="12345-123"
+                    size="large"
+                    type="text"
+                  >
+                    <input
+                      className="emotion-0"
+                      placeholder="12345-123"
+                      size="large"
+                      type="text"
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
     </TextInput>
   </TextInput>
 </TextInput>
@@ -7065,7 +8381,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
   z-index: -1;
 }
 
-.emotion-12[class] > *:not(:last-child) {
+.emotion-16[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -7141,7 +8457,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-6 {
+.emotion-8 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -7160,55 +8476,55 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
   padding-right: 0;
 }
 
-.emotion-6[type="search"] {
+.emotion-8[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-6[type="search"]::-webkit-search-decoration {
+.emotion-8[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-6::-webkit-input-placeholder {
+.emotion-8::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-moz-placeholder {
+.emotion-8::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::placeholder {
+.emotion-8::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-input-placeholder {
+.emotion-8::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-clear {
+.emotion-8::-ms-clear {
   display: none;
 }
 
-.emotion-6:focus ~ div:last-child {
+.emotion-8:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -7228,7 +8544,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
   word-wrap: normal;
 }
 
-.emotion-7 {
+.emotion-9 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -7249,7 +8565,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
       marginBottom="1rem"
     >
       <div
-        className="emotion-12"
+        className="emotion-16"
       >
         <TextInput
           prefix="$"
@@ -7289,54 +8605,94 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
               prefix="$"
               size="large"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-4"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "number",
+                  }
+                }
+                prefix="$"
+                size="large"
               >
-                <div
-                  className="emotion-3"
-                >
-                  <Styled(span)
-                    key="prefix"
-                    size="large"
-                  >
-                    <span
-                      className="emotion-0"
-                    >
-                      $
-                    </span>
-                  </Styled(span)>
-                  <Control
-                    controlPropsIn={
-                      Object {
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "number",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "number",
+                        }
                       }
-                    }
-                    key="control"
-                    prefix="$"
-                    size="large"
-                    type="number"
-                  >
-                    <input
-                      className="emotion-1"
                       prefix="$"
                       size="large"
-                      type="number"
-                    />
-                  </Control>
-                  <Underlay>
-                    <div
-                      className="emotion-2"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                    >
+                      <FauxControl
+                        className="emotion-4"
+                        control={[Function]}
+                      >
+                        <div
+                          className="emotion-3"
+                        >
+                          <Styled(span)
+                            key="prefix"
+                            size="large"
+                          >
+                            <span
+                              className="emotion-0"
+                            >
+                              $
+                            </span>
+                          </Styled(span)>
+                          <Control
+                            controlPropsIn={
+                              Object {
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "number",
+                              }
+                            }
+                            key="control"
+                            prefix="$"
+                            size="large"
+                            type="number"
+                          >
+                            <input
+                              className="emotion-1"
+                              prefix="$"
+                              size="large"
+                              type="number"
+                            />
+                          </Control>
+                          <Underlay>
+                            <div
+                              className="emotion-2"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -7378,53 +8734,93 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
               size="large"
               suffix="cm"
             >
-              <FauxControl
+              <Themed(FauxControl)
                 className="emotion-4"
                 control={[Function]}
+                controlProps={
+                  Object {
+                    "aria-invalid": undefined,
+                    "aria-required": undefined,
+                    "controlRef": undefined,
+                    "disabled": undefined,
+                    "readOnly": undefined,
+                    "required": undefined,
+                    "type": "number",
+                  }
+                }
+                size="large"
+                suffix="cm"
               >
-                <div
-                  className="emotion-3"
-                >
-                  <Control
-                    controlPropsIn={
-                      Object {
-                        "aria-invalid": undefined,
-                        "aria-required": undefined,
-                        "controlRef": undefined,
-                        "disabled": undefined,
-                        "readOnly": undefined,
-                        "required": undefined,
-                        "type": "number",
+                <ThemeProvider>
+                  <ThemeProvider>
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      controlProps={
+                        Object {
+                          "aria-invalid": undefined,
+                          "aria-required": undefined,
+                          "controlRef": undefined,
+                          "disabled": undefined,
+                          "readOnly": undefined,
+                          "required": undefined,
+                          "type": "number",
+                        }
                       }
-                    }
-                    key="control"
-                    size="large"
-                    suffix="cm"
-                    type="number"
-                  >
-                    <input
-                      className="emotion-6"
                       size="large"
-                      type="number"
-                    />
-                  </Control>
-                  <Styled(span)
-                    key="suffix"
-                    size="large"
-                  >
-                    <span
-                      className="emotion-7"
+                      suffix="cm"
                     >
-                      cm
-                    </span>
-                  </Styled(span)>
-                  <Underlay>
-                    <div
-                      className="emotion-2"
-                    />
-                  </Underlay>
-                </div>
-              </FauxControl>
+                      <FauxControl
+                        className="emotion-4"
+                        control={[Function]}
+                      >
+                        <div
+                          className="emotion-3"
+                        >
+                          <Control
+                            controlPropsIn={
+                              Object {
+                                "aria-invalid": undefined,
+                                "aria-required": undefined,
+                                "controlRef": undefined,
+                                "disabled": undefined,
+                                "readOnly": undefined,
+                                "required": undefined,
+                                "type": "number",
+                              }
+                            }
+                            key="control"
+                            size="large"
+                            suffix="cm"
+                            type="number"
+                          >
+                            <input
+                              className="emotion-8"
+                              size="large"
+                              type="number"
+                            />
+                          </Control>
+                          <Styled(span)
+                            key="suffix"
+                            size="large"
+                          >
+                            <span
+                              className="emotion-9"
+                            >
+                              cm
+                            </span>
+                          </Styled(span)>
+                          <Underlay>
+                            <div
+                              className="emotion-2"
+                            />
+                          </Underlay>
+                        </div>
+                      </FauxControl>
+                    </FauxControl>
+                  </ThemeProvider>
+                </ThemeProvider>
+              </Themed(FauxControl)>
             </TextInput>
           </TextInput>
         </TextInput>
@@ -7644,50 +9040,92 @@ exports[`TextInput demo examples Snapshots: read-only 1`] = `
       readOnly={true}
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "controlRef": undefined,
+            "defaultValue": "Hello World",
+            "disabled": undefined,
+            "readOnly": true,
+            "required": undefined,
+            "type": "text",
+          }
+        }
+        readOnly={true}
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "controlRef": undefined,
-                "defaultValue": "Hello World",
-                "disabled": undefined,
-                "readOnly": true,
-                "required": undefined,
-                "type": "text",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Hello World",
+                  "disabled": undefined,
+                  "readOnly": true,
+                  "required": undefined,
+                  "type": "text",
+                }
               }
-            }
-            defaultValue="Hello World"
-            key="control"
-            readOnly={true}
-            size="large"
-            type="text"
-          >
-            <input
-              className="emotion-0"
-              defaultValue="Hello World"
               readOnly={true}
               size="large"
-              type="text"
-            />
-          </Control>
-          <Underlay
-            readOnly={true}
-          >
-            <div
-              className="emotion-1"
-              readOnly={true}
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Hello World",
+                        "disabled": undefined,
+                        "readOnly": true,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    defaultValue="Hello World"
+                    key="control"
+                    readOnly={true}
+                    size="large"
+                    type="text"
+                  >
+                    <input
+                      className="emotion-0"
+                      defaultValue="Hello World"
+                      readOnly={true}
+                      size="large"
+                      type="text"
+                    />
+                  </Control>
+                  <Underlay
+                    readOnly={true}
+                  >
+                    <div
+                      className="emotion-1"
+                      readOnly={true}
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
     </TextInput>
   </TextInput>
 </TextInput>
@@ -7898,46 +9336,84 @@ exports[`TextInput demo examples Snapshots: required 1`] = `
       }
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": true,
+            "controlRef": undefined,
+            "disabled": undefined,
+            "readOnly": undefined,
+            "required": true,
+            "type": "text",
+          }
+        }
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            aria-required={true}
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": true,
-                "controlRef": undefined,
-                "disabled": undefined,
-                "readOnly": undefined,
-                "required": true,
-                "type": "text",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": true,
+                  "controlRef": undefined,
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": true,
+                  "type": "text",
+                }
               }
-            }
-            key="control"
-            required={true}
-            size="large"
-            type="text"
-          >
-            <input
-              aria-required={true}
-              className="emotion-0"
-              required={true}
               size="large"
-              type="text"
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    aria-required={true}
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": true,
+                        "controlRef": undefined,
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": true,
+                        "type": "text",
+                      }
+                    }
+                    key="control"
+                    required={true}
+                    size="large"
+                    type="text"
+                  >
+                    <input
+                      aria-required={true}
+                      className="emotion-0"
+                      required={true}
+                      size="large"
+                      type="text"
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
     </TextInput>
   </TextInput>
 </TextInput>
@@ -8040,11 +9516,11 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   z-index: -1;
 }
 
-.emotion-18[class] > *:not(:last-child) {
+.emotion-24[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
-.emotion-16 {
+.emotion-20 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8057,7 +9533,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
-.emotion-16 [role="img"] {
+.emotion-20 [role="img"] {
   color: #2a854e;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -8066,11 +9542,11 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-16 [role="img"]:last-of-type {
+.emotion-20 [role="img"]:last-of-type {
   color: #2a854e;
 }
 
-.emotion-15 {
+.emotion-19 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -8093,27 +9569,27 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
-.emotion-15 *,
-.emotion-15 *::before,
-.emotion-15 *::after {
+.emotion-19 *,
+.emotion-19 *::before,
+.emotion-19 *::after {
   box-sizing: inherit;
 }
 
-.emotion-15:hover > div:last-child {
+.emotion-19:hover > div:last-child {
   border-color: #3ba164;
 }
 
-.emotion-15:focus > div:last-child {
+.emotion-19:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-15:active > div:last-child {
+.emotion-19:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
 
-.emotion-15 [role="img"] {
+.emotion-19 [role="img"] {
   color: #2a854e;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -8122,18 +9598,18 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-15 [role="img"]:last-of-type {
+.emotion-19 [role="img"]:last-of-type {
   color: #2a854e;
 }
 
-.emotion-13 {
+.emotion-17 {
   fill: currentcolor;
   font-size: 16px;
   height: 1.5em;
   width: 1.5em;
 }
 
-.emotion-14 {
+.emotion-18 {
   background-color: #ffffff;
   border-color: #2a854e;
   border-radius: 0.1875em;
@@ -8147,7 +9623,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   z-index: -1;
 }
 
-.emotion-6 {
+.emotion-8 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -8166,55 +9642,55 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-6[type="search"] {
+.emotion-8[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-6[type="search"]::-webkit-search-decoration {
+.emotion-8[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-6::-webkit-input-placeholder {
+.emotion-8::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-moz-placeholder {
+.emotion-8::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::placeholder {
+.emotion-8::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-input-placeholder {
+.emotion-8::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-clear {
+.emotion-8::-ms-clear {
   display: none;
 }
 
-.emotion-6:focus ~ div:last-child {
+.emotion-8:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -8301,7 +9777,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   width: 1.5em;
 }
 
-.emotion-12 {
+.emotion-16 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -8320,55 +9796,55 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-12[type="search"] {
+.emotion-16[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-12[type="search"]::-webkit-search-decoration {
+.emotion-16[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-12::-webkit-input-placeholder {
+.emotion-16::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::-moz-placeholder {
+.emotion-16::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12:-ms-input-placeholder {
+.emotion-16:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::placeholder {
+.emotion-16::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::-ms-input-placeholder {
+.emotion-16::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12:-ms-input-placeholder {
+.emotion-16:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::-ms-clear {
+.emotion-16::-ms-clear {
   display: none;
 }
 
-.emotion-12:focus ~ div:last-child {
+.emotion-16:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #20693d;
 }
@@ -8383,7 +9859,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
           marginBottom="1rem"
         >
           <div
-            className="emotion-18"
+            className="emotion-24"
           >
             <TextInput
               defaultValue="مرحبا بالعالم"
@@ -8426,78 +9902,120 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                   iconStart={<IconBackspace />}
                   size="large"
                 >
-                  <FauxControl
+                  <Themed(FauxControl)
                     className="emotion-4"
                     control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "مرحبا بالعالم",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    iconStart={<IconBackspace />}
+                    size="large"
                   >
-                    <div
-                      className="emotion-3"
-                    >
-                      <IconBackspace
-                        key="iconStart"
-                        size="1.5em"
-                      >
-                        <Icon
-                          rtl={true}
-                          size="1.5em"
-                        >
-                          <Styled(svg)
-                            aria-hidden={true}
-                            focusable="false"
-                            role="img"
-                            rtl={true}
-                            size="1.5em"
-                            viewBox="0 0 24 24"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="emotion-0"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 24 24"
-                            >
-                              <g>
-                                <path
-                                  d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
-                                />
-                              </g>
-                            </svg>
-                          </Styled(svg)>
-                        </Icon>
-                      </IconBackspace>
-                      <Control
-                        controlPropsIn={
-                          Object {
-                            "aria-invalid": undefined,
-                            "aria-required": undefined,
-                            "controlRef": undefined,
-                            "defaultValue": "مرحبا بالعالم",
-                            "disabled": undefined,
-                            "readOnly": undefined,
-                            "required": undefined,
-                            "type": "text",
+                    <ThemeProvider>
+                      <ThemeProvider>
+                        <FauxControl
+                          className="emotion-4"
+                          control={[Function]}
+                          controlProps={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "مرحبا بالعالم",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
                           }
-                        }
-                        defaultValue="مرحبا بالعالم"
-                        iconStart={<IconBackspace />}
-                        key="control"
-                        size="large"
-                        type="text"
-                      >
-                        <input
-                          className="emotion-1"
-                          defaultValue="مرحبا بالعالم"
+                          iconStart={<IconBackspace />}
                           size="large"
-                          type="text"
-                        />
-                      </Control>
-                      <Underlay>
-                        <div
-                          className="emotion-2"
-                        />
-                      </Underlay>
-                    </div>
-                  </FauxControl>
+                        >
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
+                          >
+                            <div
+                              className="emotion-3"
+                            >
+                              <IconBackspace
+                                key="iconStart"
+                                size="1.5em"
+                              >
+                                <Icon
+                                  rtl={true}
+                                  size="1.5em"
+                                >
+                                  <Styled(svg)
+                                    aria-hidden={true}
+                                    focusable="false"
+                                    role="img"
+                                    rtl={true}
+                                    size="1.5em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="emotion-0"
+                                      focusable="false"
+                                      role="img"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <g>
+                                        <path
+                                          d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </Styled(svg)>
+                                </Icon>
+                              </IconBackspace>
+                              <Control
+                                controlPropsIn={
+                                  Object {
+                                    "aria-invalid": undefined,
+                                    "aria-required": undefined,
+                                    "controlRef": undefined,
+                                    "defaultValue": "مرحبا بالعالم",
+                                    "disabled": undefined,
+                                    "readOnly": undefined,
+                                    "required": undefined,
+                                    "type": "text",
+                                  }
+                                }
+                                defaultValue="مرحبا بالعالم"
+                                iconStart={<IconBackspace />}
+                                key="control"
+                                size="large"
+                                type="text"
+                              >
+                                <input
+                                  className="emotion-1"
+                                  defaultValue="مرحبا بالعالم"
+                                  size="large"
+                                  type="text"
+                                />
+                              </Control>
+                              <Underlay>
+                                <div
+                                  className="emotion-2"
+                                />
+                              </Underlay>
+                            </div>
+                          </FauxControl>
+                        </FauxControl>
+                      </ThemeProvider>
+                    </ThemeProvider>
+                  </Themed(FauxControl)>
                 </TextInput>
               </TextInput>
             </TextInput>
@@ -8542,78 +10060,120 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                   iconEnd={<IconBackspace />}
                   size="large"
                 >
-                  <FauxControl
+                  <Themed(FauxControl)
                     className="emotion-4"
                     control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "مرحبا بالعالم",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    iconEnd={<IconBackspace />}
+                    size="large"
                   >
-                    <div
-                      className="emotion-3"
-                    >
-                      <Control
-                        controlPropsIn={
-                          Object {
-                            "aria-invalid": undefined,
-                            "aria-required": undefined,
-                            "controlRef": undefined,
-                            "defaultValue": "مرحبا بالعالم",
-                            "disabled": undefined,
-                            "readOnly": undefined,
-                            "required": undefined,
-                            "type": "text",
+                    <ThemeProvider>
+                      <ThemeProvider>
+                        <FauxControl
+                          className="emotion-4"
+                          control={[Function]}
+                          controlProps={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "مرحبا بالعالم",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
                           }
-                        }
-                        defaultValue="مرحبا بالعالم"
-                        iconEnd={<IconBackspace />}
-                        key="control"
-                        size="large"
-                        type="text"
-                      >
-                        <input
-                          className="emotion-6"
-                          defaultValue="مرحبا بالعالم"
+                          iconEnd={<IconBackspace />}
                           size="large"
-                          type="text"
-                        />
-                      </Control>
-                      <IconBackspace
-                        key="iconEnd"
-                        size="1.5em"
-                      >
-                        <Icon
-                          rtl={true}
-                          size="1.5em"
                         >
-                          <Styled(svg)
-                            aria-hidden={true}
-                            focusable="false"
-                            role="img"
-                            rtl={true}
-                            size="1.5em"
-                            viewBox="0 0 24 24"
+                          <FauxControl
+                            className="emotion-4"
+                            control={[Function]}
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="emotion-0"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 24 24"
+                            <div
+                              className="emotion-3"
                             >
-                              <g>
-                                <path
-                                  d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                              <Control
+                                controlPropsIn={
+                                  Object {
+                                    "aria-invalid": undefined,
+                                    "aria-required": undefined,
+                                    "controlRef": undefined,
+                                    "defaultValue": "مرحبا بالعالم",
+                                    "disabled": undefined,
+                                    "readOnly": undefined,
+                                    "required": undefined,
+                                    "type": "text",
+                                  }
+                                }
+                                defaultValue="مرحبا بالعالم"
+                                iconEnd={<IconBackspace />}
+                                key="control"
+                                size="large"
+                                type="text"
+                              >
+                                <input
+                                  className="emotion-8"
+                                  defaultValue="مرحبا بالعالم"
+                                  size="large"
+                                  type="text"
                                 />
-                              </g>
-                            </svg>
-                          </Styled(svg)>
-                        </Icon>
-                      </IconBackspace>
-                      <Underlay>
-                        <div
-                          className="emotion-2"
-                        />
-                      </Underlay>
-                    </div>
-                  </FauxControl>
+                              </Control>
+                              <IconBackspace
+                                key="iconEnd"
+                                size="1.5em"
+                              >
+                                <Icon
+                                  rtl={true}
+                                  size="1.5em"
+                                >
+                                  <Styled(svg)
+                                    aria-hidden={true}
+                                    focusable="false"
+                                    role="img"
+                                    rtl={true}
+                                    size="1.5em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="emotion-0"
+                                      focusable="false"
+                                      role="img"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <g>
+                                        <path
+                                          d="M22 3H7c-.69 0-1.23.35-1.59.88L0 12l5.41 8.11c.36.53.9.89 1.59.89h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-3 12.59L17.59 17 14 13.41 10.41 17 9 15.59 12.59 12 9 8.41 10.41 7 14 10.59 17.59 7 19 8.41 15.41 12 19 15.59z"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </Styled(svg)>
+                                </Icon>
+                              </IconBackspace>
+                              <Underlay>
+                                <div
+                                  className="emotion-2"
+                                />
+                              </Underlay>
+                            </div>
+                          </FauxControl>
+                        </FauxControl>
+                      </ThemeProvider>
+                    </ThemeProvider>
+                  </Themed(FauxControl)>
                 </TextInput>
               </TextInput>
             </TextInput>
@@ -8641,7 +10201,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                 variant="success"
               >
                 <TextInput
-                  className="emotion-16"
+                  className="emotion-20"
                   control={[Function]}
                   controlProps={
                     Object {
@@ -8658,81 +10218,123 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                   size="large"
                   variant="success"
                 >
-                  <FauxControl
-                    className="emotion-16"
+                  <Themed(FauxControl)
+                    className="emotion-20"
                     control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "مرحبا بالعالم",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    size="large"
                     variant="success"
                   >
-                    <div
-                      className="emotion-15"
-                    >
-                      <Control
-                        controlPropsIn={
-                          Object {
-                            "aria-invalid": undefined,
-                            "aria-required": undefined,
-                            "controlRef": undefined,
-                            "defaultValue": "مرحبا بالعالم",
-                            "disabled": undefined,
-                            "readOnly": undefined,
-                            "required": undefined,
-                            "type": "text",
+                    <ThemeProvider>
+                      <ThemeProvider>
+                        <FauxControl
+                          className="emotion-20"
+                          control={[Function]}
+                          controlProps={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "مرحبا بالعالم",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
                           }
-                        }
-                        defaultValue="مرحبا بالعالم"
-                        key="control"
-                        size="large"
-                        type="text"
-                        variant="success"
-                      >
-                        <input
-                          className="emotion-12"
-                          defaultValue="مرحبا بالعالم"
                           size="large"
-                          type="text"
-                        />
-                      </Control>
-                      <IconSuccess
-                        key="iconEnd"
-                        size="1.5em"
-                      >
-                        <Icon
-                          rtl={false}
-                          size="1.5em"
+                          variant="success"
                         >
-                          <Styled(svg)
-                            aria-hidden={true}
-                            focusable="false"
-                            role="img"
-                            rtl={false}
-                            size="1.5em"
-                            viewBox="0 0 24 24"
+                          <FauxControl
+                            className="emotion-20"
+                            control={[Function]}
+                            variant="success"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="emotion-13"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 24 24"
+                            <div
+                              className="emotion-19"
                             >
-                              <g>
-                                <path
-                                  d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                              <Control
+                                controlPropsIn={
+                                  Object {
+                                    "aria-invalid": undefined,
+                                    "aria-required": undefined,
+                                    "controlRef": undefined,
+                                    "defaultValue": "مرحبا بالعالم",
+                                    "disabled": undefined,
+                                    "readOnly": undefined,
+                                    "required": undefined,
+                                    "type": "text",
+                                  }
+                                }
+                                defaultValue="مرحبا بالعالم"
+                                key="control"
+                                size="large"
+                                type="text"
+                                variant="success"
+                              >
+                                <input
+                                  className="emotion-16"
+                                  defaultValue="مرحبا بالعالم"
+                                  size="large"
+                                  type="text"
                                 />
-                              </g>
-                            </svg>
-                          </Styled(svg)>
-                        </Icon>
-                      </IconSuccess>
-                      <Underlay
-                        variant="success"
-                      >
-                        <div
-                          className="emotion-14"
-                        />
-                      </Underlay>
-                    </div>
-                  </FauxControl>
+                              </Control>
+                              <IconSuccess
+                                key="iconEnd"
+                                size="1.5em"
+                              >
+                                <Icon
+                                  rtl={false}
+                                  size="1.5em"
+                                >
+                                  <Styled(svg)
+                                    aria-hidden={true}
+                                    focusable="false"
+                                    role="img"
+                                    rtl={false}
+                                    size="1.5em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="emotion-17"
+                                      focusable="false"
+                                      role="img"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <g>
+                                        <path
+                                          d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </Styled(svg)>
+                                </Icon>
+                              </IconSuccess>
+                              <Underlay
+                                variant="success"
+                              >
+                                <div
+                                  className="emotion-18"
+                                />
+                              </Underlay>
+                            </div>
+                          </FauxControl>
+                        </FauxControl>
+                      </ThemeProvider>
+                    </ThemeProvider>
+                  </Themed(FauxControl)>
                 </TextInput>
               </TextInput>
             </TextInput>
@@ -8827,7 +10429,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
   color: #c8d1e0;
 }
 
-.emotion-10 {
+.emotion-14 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -8846,55 +10448,55 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-10[type="search"] {
+.emotion-14[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-10[type="search"]::-webkit-search-decoration {
+.emotion-14[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-10::-webkit-input-placeholder {
+.emotion-14::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-moz-placeholder {
+.emotion-14::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::placeholder {
+.emotion-14::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-input-placeholder {
+.emotion-14::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10:-ms-input-placeholder {
+.emotion-14:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-10::-ms-clear {
+.emotion-14::-ms-clear {
   display: none;
 }
 
-.emotion-10:focus ~ div:last-child {
+.emotion-14:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -8913,7 +10515,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
   z-index: -1;
 }
 
-.emotion-20[class] > *:not(:last-child) {
+.emotion-28[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -8989,7 +10591,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-5 {
+.emotion-7 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -9008,60 +10610,60 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
   padding-right: 0.5714285714285714em;
 }
 
-.emotion-5[type="search"] {
+.emotion-7[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-5[type="search"]::-webkit-search-decoration {
+.emotion-7[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-5::-webkit-input-placeholder {
+.emotion-7::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-moz-placeholder {
+.emotion-7::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::placeholder {
+.emotion-7::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-input-placeholder {
+.emotion-7::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5:-ms-input-placeholder {
+.emotion-7:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-5::-ms-clear {
+.emotion-7::-ms-clear {
   display: none;
 }
 
-.emotion-5:focus ~ div:last-child {
+.emotion-7:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
 
-.emotion-15 {
+.emotion-21 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -9080,55 +10682,55 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
   padding-right: 1.1428571428571428em;
 }
 
-.emotion-15[type="search"] {
+.emotion-21[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-15[type="search"]::-webkit-search-decoration {
+.emotion-21[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-15::-webkit-input-placeholder {
+.emotion-21::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-moz-placeholder {
+.emotion-21::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15:-ms-input-placeholder {
+.emotion-21:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::placeholder {
+.emotion-21::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-ms-input-placeholder {
+.emotion-21::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15:-ms-input-placeholder {
+.emotion-21:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-15::-ms-clear {
+.emotion-21::-ms-clear {
   display: none;
 }
 
-.emotion-15:focus ~ div:last-child {
+.emotion-21:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
 }
@@ -9138,7 +10740,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-20"
+      className="emotion-28"
     >
       <TextInput
         defaultValue="Small"
@@ -9178,45 +10780,85 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
             }
             size="small"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Small",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="small"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Small",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Small",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Small"
-                  key="control"
-                  size="small"
-                  type="text"
-                >
-                  <input
-                    className="emotion-0"
-                    defaultValue="Small"
                     size="small"
-                    type="text"
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Small",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Small"
+                          key="control"
+                          size="small"
+                          type="text"
+                        >
+                          <input
+                            className="emotion-0"
+                            defaultValue="Small"
+                            size="small"
+                            type="text"
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>
@@ -9258,45 +10900,85 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
             }
             size="medium"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Medium",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="medium"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Medium",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Medium",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Medium"
-                  key="control"
-                  size="medium"
-                  type="text"
-                >
-                  <input
-                    className="emotion-5"
-                    defaultValue="Medium"
                     size="medium"
-                    type="text"
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Medium",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Medium"
+                          key="control"
+                          size="medium"
+                          type="text"
+                        >
+                          <input
+                            className="emotion-7"
+                            defaultValue="Medium"
+                            size="medium"
+                            type="text"
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>
@@ -9338,45 +11020,85 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
             }
             size="large"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Large",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="large"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Large",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Large",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Large"
-                  key="control"
-                  size="large"
-                  type="text"
-                >
-                  <input
-                    className="emotion-10"
-                    defaultValue="Large"
                     size="large"
-                    type="text"
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Large",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Large"
+                          key="control"
+                          size="large"
+                          type="text"
+                        >
+                          <input
+                            className="emotion-14"
+                            defaultValue="Large"
+                            size="large"
+                            type="text"
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>
@@ -9418,45 +11140,85 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
             }
             size="jumbo"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-3"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Jumbo",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="jumbo"
             >
-              <div
-                className="emotion-2"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Jumbo",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-3"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Jumbo",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Jumbo"
-                  key="control"
-                  size="jumbo"
-                  type="text"
-                >
-                  <input
-                    className="emotion-15"
-                    defaultValue="Jumbo"
                     size="jumbo"
-                    type="text"
-                  />
-                </Control>
-                <Underlay>
-                  <div
-                    className="emotion-1"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                  >
+                    <FauxControl
+                      className="emotion-3"
+                      control={[Function]}
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Jumbo",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Jumbo"
+                          key="control"
+                          size="jumbo"
+                          type="text"
+                        >
+                          <input
+                            className="emotion-21"
+                            defaultValue="Jumbo"
+                            size="jumbo"
+                            type="text"
+                          />
+                        </Control>
+                        <Underlay>
+                          <div
+                            className="emotion-1"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>
@@ -9672,52 +11434,92 @@ exports[`TextInput demo examples Snapshots: uncontrolled 1`] = `
       }
       size="large"
     >
-      <FauxControl
+      <Themed(FauxControl)
         className="emotion-3"
         control={[Function]}
+        controlProps={
+          Object {
+            "aria-invalid": undefined,
+            "aria-required": undefined,
+            "controlRef": undefined,
+            "defaultValue": "Hello World",
+            "disabled": undefined,
+            "readOnly": undefined,
+            "required": undefined,
+            "type": "text",
+          }
+        }
+        size="large"
       >
-        <div
-          className="emotion-2"
-        >
-          <Control
-            controlPropsIn={
-              Object {
-                "aria-invalid": undefined,
-                "aria-required": undefined,
-                "controlRef": undefined,
-                "defaultValue": "Hello World",
-                "disabled": undefined,
-                "readOnly": undefined,
-                "required": undefined,
-                "type": "text",
+        <ThemeProvider>
+          <ThemeProvider>
+            <FauxControl
+              className="emotion-3"
+              control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Hello World",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
               }
-            }
-            defaultValue="Hello World"
-            key="control"
-            size="large"
-            type="text"
-          >
-            <input
-              className="emotion-0"
-              defaultValue="Hello World"
               size="large"
-              type="text"
-            />
-          </Control>
-          <Underlay>
-            <div
-              className="emotion-1"
-            />
-          </Underlay>
-        </div>
-      </FauxControl>
+            >
+              <FauxControl
+                className="emotion-3"
+                control={[Function]}
+              >
+                <div
+                  className="emotion-2"
+                >
+                  <Control
+                    controlPropsIn={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Hello World",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
+                    }
+                    defaultValue="Hello World"
+                    key="control"
+                    size="large"
+                    type="text"
+                  >
+                    <input
+                      className="emotion-0"
+                      defaultValue="Hello World"
+                      size="large"
+                      type="text"
+                    />
+                  </Control>
+                  <Underlay>
+                    <div
+                      className="emotion-1"
+                    />
+                  </Underlay>
+                </div>
+              </FauxControl>
+            </FauxControl>
+          </ThemeProvider>
+        </ThemeProvider>
+      </Themed(FauxControl)>
     </TextInput>
   </TextInput>
 </TextInput>
 `;
 
 exports[`TextInput demo examples Snapshots: variants 1`] = `
-.emotion-18[class] > *:not(:last-child) {
+.emotion-24[class] > *:not(:last-child) {
   margin-bottom: 1rem;
 }
 
@@ -9896,7 +11698,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-10 {
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9909,7 +11711,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-10 [role="img"] {
+.emotion-12 [role="img"] {
   color: #ad5f00;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -9918,11 +11720,11 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-10 [role="img"]:last-of-type {
+.emotion-12 [role="img"]:last-of-type {
   color: #ad5f00;
 }
 
-.emotion-9 {
+.emotion-11 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -9945,27 +11747,27 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-9 *,
-.emotion-9 *::before,
-.emotion-9 *::after {
+.emotion-11 *,
+.emotion-11 *::before,
+.emotion-11 *::after {
   box-sizing: inherit;
 }
 
-.emotion-9:hover > div:last-child {
+.emotion-11:hover > div:last-child {
   border-color: #cf7911;
 }
 
-.emotion-9:focus > div:last-child {
+.emotion-11:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-9:active > div:last-child {
+.emotion-11:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-9 [role="img"] {
+.emotion-11 [role="img"] {
   color: #ad5f00;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -9974,11 +11776,11 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-9 [role="img"]:last-of-type {
+.emotion-11 [role="img"]:last-of-type {
   color: #ad5f00;
 }
 
-.emotion-6 {
+.emotion-8 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -9997,60 +11799,60 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-6[type="search"] {
+.emotion-8[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-6[type="search"]::-webkit-search-decoration {
+.emotion-8[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-6::-webkit-input-placeholder {
+.emotion-8::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-moz-placeholder {
+.emotion-8::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::placeholder {
+.emotion-8::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-input-placeholder {
+.emotion-8::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6:-ms-input-placeholder {
+.emotion-8:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-6::-ms-clear {
+.emotion-8::-ms-clear {
   display: none;
 }
 
-.emotion-6:focus ~ div:last-child {
+.emotion-8:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #8a4d03;
 }
 
-.emotion-8 {
+.emotion-10 {
   background-color: #ffffff;
   border-color: #ad5f00;
   border-radius: 0.1875em;
@@ -10064,7 +11866,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   z-index: -1;
 }
 
-.emotion-16 {
+.emotion-20 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10077,7 +11879,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-16 [role="img"] {
+.emotion-20 [role="img"] {
   color: #de1b1b;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -10086,11 +11888,11 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-16 [role="img"]:last-of-type {
+.emotion-20 [role="img"]:last-of-type {
   color: #de1b1b;
 }
 
-.emotion-15 {
+.emotion-19 {
   box-sizing: border-box;
   color: #333840;
   font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -10113,27 +11915,27 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   width: 100%;
 }
 
-.emotion-15 *,
-.emotion-15 *::before,
-.emotion-15 *::after {
+.emotion-19 *,
+.emotion-19 *::before,
+.emotion-19 *::after {
   box-sizing: inherit;
 }
 
-.emotion-15:hover > div:last-child {
+.emotion-19:hover > div:last-child {
   border-color: #f55353;
 }
 
-.emotion-15:focus > div:last-child {
+.emotion-19:focus > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-15:active > div:last-child {
+.emotion-19:active > div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-15 [role="img"] {
+.emotion-19 [role="img"] {
   color: #de1b1b;
   display: block;
   -webkit-flex: 0 0 auto;
@@ -10142,11 +11944,11 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   margin: 0 0.5em;
 }
 
-.emotion-15 [role="img"]:last-of-type {
+.emotion-19 [role="img"]:last-of-type {
   color: #de1b1b;
 }
 
-.emotion-12 {
+.emotion-16 {
   background-color: transparent;
   border: 0;
   box-shadow: none;
@@ -10165,60 +11967,60 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
   padding-right: 0;
 }
 
-.emotion-12[type="search"] {
+.emotion-16[type="search"] {
   -webkit-appearance: none;
 }
 
-.emotion-12[type="search"]::-webkit-search-decoration {
+.emotion-16[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.emotion-12::-webkit-input-placeholder {
+.emotion-16::-webkit-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::-moz-placeholder {
+.emotion-16::-moz-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12:-ms-input-placeholder {
+.emotion-16:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::placeholder {
+.emotion-16::placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::-ms-input-placeholder {
+.emotion-16::-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12:-ms-input-placeholder {
+.emotion-16:-ms-input-placeholder {
   color: #8e99ab;
   -webkit-text-fill-color: #8e99ab;
   font-style: italic;
 }
 
-.emotion-12::-ms-clear {
+.emotion-16::-ms-clear {
   display: none;
 }
 
-.emotion-12:focus ~ div:last-child {
+.emotion-16:focus ~ div:last-child {
   border-color: #c8d1e0;
   box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #b80d0d;
 }
 
-.emotion-14 {
+.emotion-18 {
   background-color: #ffffff;
   border-color: #de1b1b;
   border-radius: 0.1875em;
@@ -10237,7 +12039,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
     marginBottom="1rem"
   >
     <div
-      className="emotion-18"
+      className="emotion-24"
     >
       <TextInput
         defaultValue="Success"
@@ -10280,81 +12082,123 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
             size="large"
             variant="success"
           >
-            <FauxControl
+            <Themed(FauxControl)
               className="emotion-4"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Success",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="large"
               variant="success"
             >
-              <div
-                className="emotion-3"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Success",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-4"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Success",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Success"
-                  key="control"
-                  size="large"
-                  type="text"
-                  variant="success"
-                >
-                  <input
-                    className="emotion-0"
-                    defaultValue="Success"
                     size="large"
-                    type="text"
-                  />
-                </Control>
-                <IconSuccess
-                  key="iconEnd"
-                  size="1.5em"
-                >
-                  <Icon
-                    rtl={false}
-                    size="1.5em"
+                    variant="success"
                   >
-                    <Styled(svg)
-                      aria-hidden={true}
-                      focusable="false"
-                      role="img"
-                      rtl={false}
-                      size="1.5em"
-                      viewBox="0 0 24 24"
+                    <FauxControl
+                      className="emotion-4"
+                      control={[Function]}
+                      variant="success"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-1"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
+                      <div
+                        className="emotion-3"
                       >
-                        <g>
-                          <path
-                            d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Success",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Success"
+                          key="control"
+                          size="large"
+                          type="text"
+                          variant="success"
+                        >
+                          <input
+                            className="emotion-0"
+                            defaultValue="Success"
+                            size="large"
+                            type="text"
                           />
-                        </g>
-                      </svg>
-                    </Styled(svg)>
-                  </Icon>
-                </IconSuccess>
-                <Underlay
-                  variant="success"
-                >
-                  <div
-                    className="emotion-2"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                        </Control>
+                        <IconSuccess
+                          key="iconEnd"
+                          size="1.5em"
+                        >
+                          <Icon
+                            rtl={false}
+                            size="1.5em"
+                          >
+                            <Styled(svg)
+                              aria-hidden={true}
+                              focusable="false"
+                              role="img"
+                              rtl={false}
+                              size="1.5em"
+                              viewBox="0 0 24 24"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="emotion-1"
+                                focusable="false"
+                                role="img"
+                                viewBox="0 0 24 24"
+                              >
+                                <g>
+                                  <path
+                                    d="M12 3c4.968 0 9 4.032 9 9s-4.032 9-9 9-9-4.032-9-9 4.032-9 9-9zm-4.247 8.445L6.5 12.698l3.838 3.838 7.198-7.198-1.253-1.254-5.945 5.945-2.585-2.585z"
+                                  />
+                                </g>
+                              </svg>
+                            </Styled(svg)>
+                          </Icon>
+                        </IconSuccess>
+                        <Underlay
+                          variant="success"
+                        >
+                          <div
+                            className="emotion-2"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>
@@ -10382,7 +12226,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
           variant="warning"
         >
           <TextInput
-            className="emotion-10"
+            className="emotion-12"
             control={[Function]}
             controlProps={
               Object {
@@ -10399,81 +12243,123 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
             size="large"
             variant="warning"
           >
-            <FauxControl
-              className="emotion-10"
+            <Themed(FauxControl)
+              className="emotion-12"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Warning",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="large"
               variant="warning"
             >
-              <div
-                className="emotion-9"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Warning",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-12"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Warning",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Warning"
-                  key="control"
-                  size="large"
-                  type="text"
-                  variant="warning"
-                >
-                  <input
-                    className="emotion-6"
-                    defaultValue="Warning"
                     size="large"
-                    type="text"
-                  />
-                </Control>
-                <IconWarning
-                  key="iconEnd"
-                  size="1.5em"
-                >
-                  <Icon
-                    rtl={false}
-                    size="1.5em"
+                    variant="warning"
                   >
-                    <Styled(svg)
-                      aria-hidden={true}
-                      focusable="false"
-                      role="img"
-                      rtl={false}
-                      size="1.5em"
-                      viewBox="0 0 24 24"
+                    <FauxControl
+                      className="emotion-12"
+                      control={[Function]}
+                      variant="warning"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-1"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
+                      <div
+                        className="emotion-11"
                       >
-                        <g>
-                          <path
-                            d="M13.414 2.718l7.868 7.868c.78.78.78 2.047 0 2.828l-7.868 7.868c-.78.78-2.047.78-2.828 0l-7.868-7.868a2.001 2.001 0 0 1 0-2.828l7.868-7.868c.78-.78 2.047-.78 2.828 0zM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm1-3.958V8h-2v5.042h2z"
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Warning",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Warning"
+                          key="control"
+                          size="large"
+                          type="text"
+                          variant="warning"
+                        >
+                          <input
+                            className="emotion-8"
+                            defaultValue="Warning"
+                            size="large"
+                            type="text"
                           />
-                        </g>
-                      </svg>
-                    </Styled(svg)>
-                  </Icon>
-                </IconWarning>
-                <Underlay
-                  variant="warning"
-                >
-                  <div
-                    className="emotion-8"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                        </Control>
+                        <IconWarning
+                          key="iconEnd"
+                          size="1.5em"
+                        >
+                          <Icon
+                            rtl={false}
+                            size="1.5em"
+                          >
+                            <Styled(svg)
+                              aria-hidden={true}
+                              focusable="false"
+                              role="img"
+                              rtl={false}
+                              size="1.5em"
+                              viewBox="0 0 24 24"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="emotion-1"
+                                focusable="false"
+                                role="img"
+                                viewBox="0 0 24 24"
+                              >
+                                <g>
+                                  <path
+                                    d="M13.414 2.718l7.868 7.868c.78.78.78 2.047 0 2.828l-7.868 7.868c-.78.78-2.047.78-2.828 0l-7.868-7.868a2.001 2.001 0 0 1 0-2.828l7.868-7.868c.78-.78 2.047-.78 2.828 0zM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm1-3.958V8h-2v5.042h2z"
+                                  />
+                                </g>
+                              </svg>
+                            </Styled(svg)>
+                          </Icon>
+                        </IconWarning>
+                        <Underlay
+                          variant="warning"
+                        >
+                          <div
+                            className="emotion-10"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>
@@ -10501,7 +12387,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
           variant="danger"
         >
           <TextInput
-            className="emotion-16"
+            className="emotion-20"
             control={[Function]}
             controlProps={
               Object {
@@ -10518,81 +12404,123 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
             size="large"
             variant="danger"
           >
-            <FauxControl
-              className="emotion-16"
+            <Themed(FauxControl)
+              className="emotion-20"
               control={[Function]}
+              controlProps={
+                Object {
+                  "aria-invalid": undefined,
+                  "aria-required": undefined,
+                  "controlRef": undefined,
+                  "defaultValue": "Danger",
+                  "disabled": undefined,
+                  "readOnly": undefined,
+                  "required": undefined,
+                  "type": "text",
+                }
+              }
+              size="large"
               variant="danger"
             >
-              <div
-                className="emotion-15"
-              >
-                <Control
-                  controlPropsIn={
-                    Object {
-                      "aria-invalid": undefined,
-                      "aria-required": undefined,
-                      "controlRef": undefined,
-                      "defaultValue": "Danger",
-                      "disabled": undefined,
-                      "readOnly": undefined,
-                      "required": undefined,
-                      "type": "text",
+              <ThemeProvider>
+                <ThemeProvider>
+                  <FauxControl
+                    className="emotion-20"
+                    control={[Function]}
+                    controlProps={
+                      Object {
+                        "aria-invalid": undefined,
+                        "aria-required": undefined,
+                        "controlRef": undefined,
+                        "defaultValue": "Danger",
+                        "disabled": undefined,
+                        "readOnly": undefined,
+                        "required": undefined,
+                        "type": "text",
+                      }
                     }
-                  }
-                  defaultValue="Danger"
-                  key="control"
-                  size="large"
-                  type="text"
-                  variant="danger"
-                >
-                  <input
-                    className="emotion-12"
-                    defaultValue="Danger"
                     size="large"
-                    type="text"
-                  />
-                </Control>
-                <IconDanger
-                  key="iconEnd"
-                  size="1.5em"
-                >
-                  <Icon
-                    rtl={false}
-                    size="1.5em"
+                    variant="danger"
                   >
-                    <Styled(svg)
-                      aria-hidden={true}
-                      focusable="false"
-                      role="img"
-                      rtl={false}
-                      size="1.5em"
-                      viewBox="0 0 24 24"
+                    <FauxControl
+                      className="emotion-20"
+                      control={[Function]}
+                      variant="danger"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="emotion-1"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
+                      <div
+                        className="emotion-19"
                       >
-                        <g>
-                          <path
-                            d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                        <Control
+                          controlPropsIn={
+                            Object {
+                              "aria-invalid": undefined,
+                              "aria-required": undefined,
+                              "controlRef": undefined,
+                              "defaultValue": "Danger",
+                              "disabled": undefined,
+                              "readOnly": undefined,
+                              "required": undefined,
+                              "type": "text",
+                            }
+                          }
+                          defaultValue="Danger"
+                          key="control"
+                          size="large"
+                          type="text"
+                          variant="danger"
+                        >
+                          <input
+                            className="emotion-16"
+                            defaultValue="Danger"
+                            size="large"
+                            type="text"
                           />
-                        </g>
-                      </svg>
-                    </Styled(svg)>
-                  </Icon>
-                </IconDanger>
-                <Underlay
-                  variant="danger"
-                >
-                  <div
-                    className="emotion-14"
-                  />
-                </Underlay>
-              </div>
-            </FauxControl>
+                        </Control>
+                        <IconDanger
+                          key="iconEnd"
+                          size="1.5em"
+                        >
+                          <Icon
+                            rtl={false}
+                            size="1.5em"
+                          >
+                            <Styled(svg)
+                              aria-hidden={true}
+                              focusable="false"
+                              role="img"
+                              rtl={false}
+                              size="1.5em"
+                              viewBox="0 0 24 24"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="emotion-1"
+                                focusable="false"
+                                role="img"
+                                viewBox="0 0 24 24"
+                              >
+                                <g>
+                                  <path
+                                    d="M3.94 19.49h16.118a1 1 0 0 0 .866-1.498l-8.06-13.99a.996.996 0 0 0-1.732-.001L3.074 17.993a.998.998 0 0 0 .867 1.499zM12 17a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm1-3.503h-2v-5h2v5z"
+                                  />
+                                </g>
+                              </svg>
+                            </Styled(svg)>
+                          </Icon>
+                        </IconDanger>
+                        <Underlay
+                          variant="danger"
+                        >
+                          <div
+                            className="emotion-18"
+                          />
+                        </Underlay>
+                      </div>
+                    </FauxControl>
+                  </FauxControl>
+                </ThemeProvider>
+              </ThemeProvider>
+            </Themed(FauxControl)>
           </TextInput>
         </TextInput>
       </TextInput>

--- a/src/library/Tooltip/Tooltip.js
+++ b/src/library/Tooltip/Tooltip.js
@@ -78,54 +78,48 @@ type RenderProps = {
 
 const DELAY_OPEN = 250; // ms
 
-// prettier-ignore
-export const componentTheme = (baseTheme: Object) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'Popover',
-        theme: popoverComponentTheme(baseTheme)
-      },
-      {
-        name: 'Tooltip',
-        theme: {
-          TooltipArrow_backgroundColor: baseTheme.panel_backgroundColor_inverted,
-          TooltipArrow_borderColor: baseTheme.panel_borderColor_inverted,
+export const componentTheme = (baseTheme: Object) =>
+  mapComponentThemes(
+    {
+      name: 'Popover',
+      theme: popoverComponentTheme(baseTheme)
+    },
+    {
+      name: 'Tooltip',
+      theme: {
+        TooltipArrow_backgroundColor: baseTheme.panel_backgroundColor_inverted,
+        TooltipArrow_borderColor: baseTheme.panel_borderColor_inverted,
 
-          TooltipContent_backgroundColor:
-            baseTheme.panel_backgroundColor_inverted,
-          TooltipContent_borderColor: baseTheme.panel_borderColor_inverted,
-          TooltipContent_color: baseTheme.color_inverted,
-          TooltipContent_maxWidth: '18em',
+        TooltipContent_backgroundColor:
+          baseTheme.panel_backgroundColor_inverted,
+        TooltipContent_borderColor: baseTheme.panel_borderColor_inverted,
+        TooltipContent_color: baseTheme.color_inverted,
+        TooltipContent_maxWidth: '18em',
 
-          TooltipContentBlock_marginVertical: '0',
-          TooltipContentBlock_paddingHorizontal: baseTheme.space_inset_md,
+        TooltipContentBlock_marginVertical: '0',
+        TooltipContentBlock_paddingHorizontal: baseTheme.space_inset_md,
 
-          TooltipTriggerText_borderStyle: 'dashed',
-          TooltipTriggerText_borderColor: 'currentcolor',
-          TooltipTriggerText_borderWidth: '1px'
-        }
-      },
-      baseTheme
-    )
-  };
-};
+        TooltipTriggerText_borderStyle: 'dashed',
+        TooltipTriggerText_borderColor: 'currentcolor',
+        TooltipTriggerText_borderWidth: '1px'
+      }
+    },
+    baseTheme
+  );
 
-const Root = createThemedComponent(Popover, ({ theme: baseTheme }) => {
-  return {
-    ...mapComponentThemes(
-      {
-        name: 'Tooltip',
-        theme: componentTheme(baseTheme)
-      },
-      {
-        name: 'Popover',
-        theme: {}
-      },
-      baseTheme
-    )
-  };
-});
+const Root = createThemedComponent(Popover, ({ theme: baseTheme }) =>
+  mapComponentThemes(
+    {
+      name: 'Tooltip',
+      theme: componentTheme(baseTheme)
+    },
+    {
+      name: 'Popover',
+      theme: {}
+    },
+    baseTheme
+  )
+);
 
 const TriggerText = createStyledComponent('span', ({ theme: baseTheme }) => {
   const theme = componentTheme(baseTheme);


### PR DESCRIPTION
<!--
Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: "[ComponentName] Clear, brief title using imperative tense" ~or~ "type-of-change(what-is-changed): Clear, brief title using imperative tense" (the latter should follow type convention from Commitizen: https://github.com/commitizen/cz-cli)
Examples:
* [Button] Add support for type=submit
* test(happo): Update to happo v1.0

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
- Update Select, TextArea, and TextInput to style a properly themed base component
- Update all other files using `mapComponentThemes` to use a consistent code style
- Update snapshots

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Closes #742 

Specifically, by styling a non-themed base component (FauxControl, in the case of TextInput), we were not supporting any of the theme variables defined on that base component.

### Screenshots, videos, or demo, if appropriate
<!-- Please share either a reproduction of your work on CodeSandbox (our Mineral UI Starter https://codesandbox.io/s/v410y75m0 may be useful for setup) or a deploy preview. To record and share a video: http://recordit.co/ -->

https://742-component-themes--mineral-ui.netlify.com/
(_Unfortunately, that link won't help much this time._)

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Update Select/TextArea/TextInput examples to render a themed version, where the theme sets variables defined by the base component ([TextInput](https://github.com/mineral-ui/mineral-ui/blob/master/src/library/TextInput/TextInput.js#L62-L81) for Select; [FauxControl](https://github.com/mineral-ui/mineral-ui/blob/master/src/library/FauxControl/FauxControl.js#L41-L62), for TextArea & TextInput). Something like:

    ```jsx
    // /website/app/demos/TextInput/examples/uncontrolled.js

    import _TextInput from '../../../../../library/TextInput/';
    import { createThemedComponent } from '../../../../../library/themes';

    const TextInput = createThemedComponent(_TextInput, {
      TextInput_borderColor: 'rebeccapurple'
    });

    export default {
      // unchanged
    };
    ```

3. Check that your theme overrides took hold.

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Bug fix (non-breaking change which fixes an issue)
- Other (provide details below)

Simple refactor for code style.

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) — **[n/a]**
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered — **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered — **[n/a]**
* [x] Documentation created or updated — **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change — **[n/a]**

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Oopsie](https://media.giphy.com/media/xT9IghUVWeHfJTP5Li/giphy.gif)
