### PR TITLE
[Card] Make ToggleButton better respect variant

### DIFF
--- a/src/library/Card/CardFooter.js
+++ b/src/library/Card/CardFooter.js
@@ -115,13 +115,21 @@ const styles = {
    * context. These styles allow the Button to shrink, but the Icon remains the
    * same size.
    */
-  toggleButton: ({ theme }) => ({
+  toggleButton: ({ theme, variant }) => ({
     flex: '0 0 auto',
     height: 'auto',
     minWidth: 0,
     overflow: 'hidden',
     padding: 0,
     transform: `translateY(-${pxToEm(1)})`, // Optical alignment
+
+    ...(variant
+      ? {
+          '&:hover': {
+            backgroundColor: theme[`backgroundColor_${variant}_hover`]
+          }
+        }
+      : undefined),
 
     // Inner
     '& > span': {
@@ -172,23 +180,30 @@ export default class CardFooter extends Component<Props, State> {
       expandable,
       title,
       triggerTitle = CardFooter.defaultProps.triggerTitle,
+      variant,
       ...restProps
     } = this.props;
+
+    const rootProps = {
+      variant,
+      ...restProps
+    };
 
     const isOpen = Boolean(this.getControllableValue('isOpen'));
 
     const ExpandCollapseIcon = isOpen ? IconExpandLess : IconExpandMore;
 
     return (
-      <Root {...restProps}>
+      <Root {...rootProps}>
         {title && (
           <Title>
             <TitleContent>{title}</TitleContent>
             {expandable && (
               <ToggleButton
-                onClick={this.toggleOpen}
-                minimal
                 iconStart={<ExpandCollapseIcon title={triggerTitle(isOpen)} />}
+                minimal
+                onClick={this.toggleOpen}
+                variant={variant}
               />
             )}
           </Title>


### PR DESCRIPTION
<!--
Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: "[ComponentName] Clear, brief title using imperative tense" ~or~ "type-of-change(what-is-changed): Clear, brief title using imperative tense" (the latter should follow type convention from Commitizen: https://github.com/commitizen/cz-cli)
Examples:
* [Button] Add support for type=submit
* test(happo): Update to happo v1.0

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
- Style CardFooter's expand/collapse toggle Button to use variant-appropriate background colors

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Closes #740 

### Screenshots, videos, or demo, if appropriate
<!-- Please share either a reproduction of your work on CodeSandbox (our Mineral UI Starter https://codesandbox.io/s/v410y75m0 may be useful for setup) or a deploy preview. To record and share a video: http://recordit.co/ -->

https://740-card-footer-variant--mineral-ui.netlify.com/components/card-footer/variants

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Navigate to CardFooter > Variants
3. Add `expandable` to at least one of the CardFooters rendered
4. Confirm that the hover color is a very light tint of the appropriate variant color

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered — **[n/a]**
* [x] Documentation created or updated — **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change — **[n/a]**

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Matching](https://media.giphy.com/media/vwj744t832rcANhm2T/giphy.gif)
