### PR TITLE
[themes][Table] Fix theme overrides

### DIFF
--- a/src/library/Table/TableCell.js
+++ b/src/library/Table/TableCell.js
@@ -39,6 +39,10 @@ const styles = ({
   const theme = componentTheme(baseTheme);
   const fontSize = theme.TableCell_fontSize;
   const rtl = theme.direction === 'rtl';
+  const borderProperty = rtl ? 'borderRight' : 'borderLeft';
+  const borderVertical = highContrast
+    ? theme.TableCell_borderVertical_highContrast
+    : theme.TableCell_borderVertical;
   const paddingHorizontal = getNormalizedValue(
     theme.TableCell_paddingHorizontal,
     fontSize
@@ -49,9 +53,6 @@ const styles = ({
       : theme.TableCell_paddingVertical,
     fontSize
   );
-  const borderVertical = highContrast
-    ? theme.TableCell_borderVertical_highContrast
-    : theme.TableCell_borderVertical;
 
   return {
     fontSize,
@@ -61,8 +62,7 @@ const styles = ({
     verticalAlign: theme.TableCell_verticalAlign,
 
     '&:not(:first-child)': {
-      borderLeft: rtl ? null : borderVertical,
-      borderRight: !rtl ? null : borderVertical
+      [borderProperty]: borderVertical
     }
   };
 };

--- a/src/library/Table/TableHeaderCell.js
+++ b/src/library/Table/TableHeaderCell.js
@@ -46,29 +46,27 @@ export const componentTheme = (baseTheme: Object) =>
     baseTheme
   );
 
-export const ThemedTD = createThemedComponent(
+export const ThemedTableCell = createThemedComponent(
   TableCell,
-  ({ theme: baseTheme }) => {
-    // Prevent these theme variables from clobbering the placeholder variables
-    // in TableCell
-    const {
-      TableHeaderCell_borderVertical: ignoreTableHeaderCell_borderVertical,
-      TableHeaderCell_borderVertical_highContrast: ignoreTableHeaderCell_borderVertical_highContrast,
-      ...theme
-    } = componentTheme(baseTheme);
-
-    return mapComponentThemes(
+  ({ theme: baseTheme }) =>
+    mapComponentThemes(
       {
         name: 'TableHeaderCell',
-        theme
+        theme: componentTheme(baseTheme)
       },
       {
         name: 'TableCell',
         theme: {}
       },
-      baseTheme
-    );
-  }
+      baseTheme,
+      [
+        'TableHeaderCell_borderVertical',
+        'TableHeaderCell_fontSize',
+        'TableHeaderCell_paddingHorizontal',
+        'TableHeaderCell_paddingVertical',
+        'TableHeaderCell_verticalAlign'
+      ]
+    )
 );
 
 const REGEX_IS_EM_VALUE = /\d+em$/;
@@ -85,9 +83,11 @@ const styles = ({
   const theme = componentTheme(baseTheme);
   const fontSize = theme.TableHeaderCell_fontSize;
   const rtl = theme.direction === 'rtl';
+  const borderProperty = rtl ? 'borderRight' : 'borderLeft';
   const borderVertical = highContrast
     ? theme.TableHeaderCell_borderVertical_highContrast
     : theme.TableHeaderCell_borderVertical;
+  const positionProperty = rtl ? 'right' : 'left';
 
   return {
     fontWeight: theme.TableHeaderCell_fontWeight,
@@ -99,15 +99,16 @@ const styles = ({
     // Using this "border" to appease Firefox, which extends TableHeaderCell's
     // real border down the entire column after clicking a TableSortableHeaderCell.
     '&:not(:first-child)': {
+      [borderProperty]: 0,
+
       '&::before': {
         bottom: 0,
         content: '""',
-        left: rtl ? null : 0,
+        [positionProperty]: 0,
         position: 'absolute',
-        right: rtl ? 0 : null,
         top: 0,
         width: 0,
-        borderLeft: borderVertical
+        [borderProperty]: borderVertical
       }
     }
   };
@@ -119,7 +120,7 @@ const styles = ({
 function createRootNode(props: Props) {
   const { element = TableHeaderCell.defaultProps.element } = props;
 
-  return createStyledComponent(ThemedTD, styles, {
+  return createStyledComponent(ThemedTableCell, styles, {
     displayName: 'TableHeaderCell',
     filterProps: ['width'],
     forwardProps: ['element', 'noPadding', 'textAlign'],

--- a/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
+++ b/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
@@ -111,6 +111,10 @@ exports[`Table demo examples Snapshots: alignment 1`] = `
   overflow: hidden;
 }
 
+.emotion-14:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-14:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -140,6 +144,14 @@ exports[`Table demo examples Snapshots: alignment 1`] = `
   font-weight: 700;
   position: relative;
   overflow: hidden;
+}
+
+.emotion-13:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-13:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-13:not(:first-child)::before {
@@ -211,6 +223,10 @@ exports[`Table demo examples Snapshots: alignment 1`] = `
   width: 100%;
 }
 
+.emotion-6:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-6:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -261,6 +277,14 @@ exports[`Table demo examples Snapshots: alignment 1`] = `
   position: relative;
   white-space: nowrap;
   width: 100%;
+}
+
+.emotion-5:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-5:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-5:not(:first-child)::before {
@@ -382,6 +406,14 @@ button:focus > .emotion-4 {
   overflow: hidden;
 }
 
+.emotion-32:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-32:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-32:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -419,6 +451,14 @@ button:focus > .emotion-4 {
   position: relative;
   white-space: nowrap;
   width: 100%;
+}
+
+.emotion-24:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-24:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-24:not(:first-child)::before {
@@ -465,6 +505,14 @@ button:focus > .emotion-4 {
   overflow: hidden;
 }
 
+.emotion-51:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-51:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-51:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -502,6 +550,14 @@ button:focus > .emotion-4 {
   position: relative;
   white-space: nowrap;
   width: 100%;
+}
+
+.emotion-43:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-43:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-43:not(:first-child)::before {
@@ -548,6 +604,14 @@ button:focus > .emotion-4 {
   overflow: hidden;
 }
 
+.emotion-70:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-70:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-70:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -585,6 +649,14 @@ button:focus > .emotion-4 {
   position: relative;
   white-space: nowrap;
   width: 100%;
+}
+
+.emotion-62:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-62:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-62:not(:first-child)::before {
@@ -3129,6 +3201,10 @@ exports[`Table demo examples Snapshots: basic 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -3147,6 +3223,14 @@ exports[`Table demo examples Snapshots: basic 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -4764,6 +4848,10 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -4782,6 +4870,14 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -4812,6 +4908,14 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
   position: relative;
 }
 
+.emotion-7:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-7:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-7:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -4832,6 +4936,14 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
   position: relative;
 }
 
+.emotion-12:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-12:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-12:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -4850,6 +4962,14 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-17:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-17:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-17:not(:first-child)::before {
@@ -6550,6 +6670,10 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -6568,6 +6692,14 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -8209,6 +8341,10 @@ exports[`Table demo examples Snapshots: density 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -8227,6 +8363,14 @@ exports[`Table demo examples Snapshots: density 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -9850,6 +9994,10 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -9868,6 +10016,14 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #58606e;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -11524,6 +11680,10 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -11542,6 +11702,14 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -13161,14 +13329,6 @@ exports[`Table demo examples Snapshots: rtl 1`] = `
   background-color: #ebeff5;
 }
 
-.emotion-60 {
-  font-size: 0.875em;
-  font-weight: inherit;
-  padding: 0.5714285714285714em 1.1428571428571428em;
-  text-align: left;
-  vertical-align: top;
-}
-
 .emotion-18 {
   overflow: hidden;
 }
@@ -13234,22 +13394,6 @@ exports[`Table demo examples Snapshots: rtl 1`] = `
   margin-bottom: 0.5em;
 }
 
-.emotion-57 {
-  font-size: 0.875em;
-  font-weight: inherit;
-  padding: 0.5714285714285714em 1.1428571428571428em;
-  text-align: right;
-  vertical-align: top;
-}
-
-.emotion-58 {
-  font-size: 0.875em;
-  font-weight: inherit;
-  padding: 0.5714285714285714em 1.1428571428571428em;
-  text-align: center;
-  vertical-align: top;
-}
-
 .emotion-0 {
   box-sizing: border-box;
   color: #58606e;
@@ -13277,14 +13421,18 @@ exports[`Table demo examples Snapshots: rtl 1`] = `
   overflow: hidden;
 }
 
+.emotion-14:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-14:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-14:hover {
@@ -13308,14 +13456,22 @@ exports[`Table demo examples Snapshots: rtl 1`] = `
   overflow: hidden;
 }
 
+.emotion-13:not(:first-child) {
+  border-right: 1px dotted #c8d1e0;
+}
+
+.emotion-13:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-13:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-13:hover {
@@ -13342,14 +13498,18 @@ exports[`Table demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
+.emotion-6:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-6:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-6:focus {
@@ -13394,14 +13554,22 @@ exports[`Table demo examples Snapshots: rtl 1`] = `
   width: 100%;
 }
 
+.emotion-5:not(:first-child) {
+  border-right: 1px dotted #c8d1e0;
+}
+
+.emotion-5:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-5:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-5:focus {
@@ -13452,14 +13620,18 @@ button:focus > .emotion-4 {
   position: relative;
 }
 
+.emotion-22:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-22:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-21 {
@@ -13472,14 +13644,22 @@ button:focus > .emotion-4 {
   position: relative;
 }
 
+.emotion-21:not(:first-child) {
+  border-right: 1px dotted #c8d1e0;
+}
+
+.emotion-21:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-21:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-26 {
@@ -13492,14 +13672,22 @@ button:focus > .emotion-4 {
   position: relative;
 }
 
+.emotion-26:not(:first-child) {
+  border-right: 1px dotted #c8d1e0;
+}
+
+.emotion-26:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-26:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-42 {
@@ -13513,14 +13701,22 @@ button:focus > .emotion-4 {
   overflow: hidden;
 }
 
+.emotion-42:not(:first-child) {
+  border-right: 1px dotted #c8d1e0;
+}
+
+.emotion-42:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-42:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-42:hover {
@@ -13552,14 +13748,22 @@ button:focus > .emotion-4 {
   width: 100%;
 }
 
+.emotion-34:not(:first-child) {
+  border-right: 1px dotted #c8d1e0;
+}
+
+.emotion-34:not(:first-child) {
+  border-right: 0;
+}
+
 .emotion-34:not(:first-child)::before {
   bottom: 0;
   content: "";
-  position: absolute;
   right: 0;
+  position: absolute;
   top: 0;
   width: 0;
-  border-left: 1px dotted #c8d1e0;
+  border-right: 1px dotted #c8d1e0;
 }
 
 .emotion-34:focus {
@@ -13583,6 +13787,30 @@ button:focus > .emotion-4 {
   left: 0;
   position: absolute;
   right: 0;
+}
+
+.emotion-57 {
+  font-size: 0.875em;
+  font-weight: inherit;
+  padding: 0.5714285714285714em 1.1428571428571428em;
+  text-align: right;
+  vertical-align: top;
+}
+
+.emotion-58 {
+  font-size: 0.875em;
+  font-weight: inherit;
+  padding: 0.5714285714285714em 1.1428571428571428em;
+  text-align: center;
+  vertical-align: top;
+}
+
+.emotion-60 {
+  font-size: 0.875em;
+  font-weight: inherit;
+  padding: 0.5714285714285714em 1.1428571428571428em;
+  text-align: left;
+  vertical-align: top;
 }
 
 <Component>
@@ -15674,6 +15902,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -15692,6 +15924,14 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -17679,6 +17919,10 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
   position: relative;
 }
 
+.emotion-15:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-15:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -17697,6 +17941,14 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-14:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-14:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-14:not(:first-child)::before {
@@ -17723,6 +17975,10 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
   width: 1px;
 }
 
+.emotion-10:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-10:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -17742,6 +17998,14 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
   font-weight: 700;
   position: relative;
   width: 1px;
+}
+
+.emotion-9:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-9:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-9:not(:first-child)::before {
@@ -20648,6 +20912,10 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
   position: relative;
 }
 
+.emotion-36:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-36:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -20666,6 +20934,14 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-35:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-35:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-35:not(:first-child)::before {
@@ -20931,6 +21207,10 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
   width: 1px;
 }
 
+.emotion-31:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-31:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -20950,6 +21230,14 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
   font-weight: 700;
   position: relative;
   width: 1px;
+}
+
+.emotion-30:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-30:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-30:not(:first-child)::before {
@@ -24587,6 +24875,10 @@ exports[`Table demo examples Snapshots: sortable 1`] = `
   position: relative;
 }
 
+.emotion-79:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-79:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -24605,6 +24897,14 @@ exports[`Table demo examples Snapshots: sortable 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-78:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-78:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-78:not(:first-child)::before {
@@ -24645,6 +24945,10 @@ exports[`Table demo examples Snapshots: sortable 1`] = `
   overflow: hidden;
 }
 
+.emotion-14:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-14:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -24674,6 +24978,14 @@ exports[`Table demo examples Snapshots: sortable 1`] = `
   font-weight: 700;
   position: relative;
   overflow: hidden;
+}
+
+.emotion-13:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-13:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-13:not(:first-child)::before {
@@ -24745,6 +25057,10 @@ exports[`Table demo examples Snapshots: sortable 1`] = `
   width: 100%;
 }
 
+.emotion-6:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-6:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -24795,6 +25111,14 @@ exports[`Table demo examples Snapshots: sortable 1`] = `
   position: relative;
   white-space: nowrap;
   width: 100%;
+}
+
+.emotion-5:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-5:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-5:not(:first-child)::before {
@@ -27619,6 +27943,10 @@ exports[`Table demo examples Snapshots: sortable-controlled 1`] = `
   overflow: hidden;
 }
 
+.emotion-35:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-35:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -27648,6 +27976,14 @@ exports[`Table demo examples Snapshots: sortable-controlled 1`] = `
   font-weight: 700;
   position: relative;
   overflow: hidden;
+}
+
+.emotion-34:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-34:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-34:not(:first-child)::before {
@@ -27719,6 +28055,10 @@ exports[`Table demo examples Snapshots: sortable-controlled 1`] = `
   width: 100%;
 }
 
+.emotion-27:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-27:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -27769,6 +28109,14 @@ exports[`Table demo examples Snapshots: sortable-controlled 1`] = `
   position: relative;
   white-space: nowrap;
   width: 100%;
+}
+
+.emotion-26:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-26:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-26:not(:first-child)::before {
@@ -31336,6 +31684,10 @@ exports[`Table demo examples Snapshots: striped 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -31354,6 +31706,14 @@ exports[`Table demo examples Snapshots: striped 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -32977,6 +33337,10 @@ exports[`Table demo examples Snapshots: title 1`] = `
   position: relative;
 }
 
+.emotion-3:not(:first-child) {
+  border-left: 0;
+}
+
 .emotion-3:not(:first-child)::before {
   bottom: 0;
   content: "";
@@ -32995,6 +33359,14 @@ exports[`Table demo examples Snapshots: title 1`] = `
   vertical-align: bottom;
   font-weight: 700;
   position: relative;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 1px dotted #c8d1e0;
+}
+
+.emotion-2:not(:first-child) {
+  border-left: 0;
 }
 
 .emotion-2:not(:first-child)::before {
@@ -37179,7 +37551,7 @@ Array [
 ]
 `;
 
-exports[`Table sortable on click sorts ascending on first click 2`] = `"<th aria-label=\\"aa\\" aria-sort=\\"ascending\\" role=\\"columnheader\\" class=\\"css-1tzxjtv-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in descending order\\" class=\\"css-5irr73-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">aa</span>&nbsp;<span class=\\"css-1i897sk\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 7.5l8 8H4z\\"></path></g></svg></span></button></th>"`;
+exports[`Table sortable on click sorts ascending on first click 2`] = `"<th aria-label=\\"aa\\" aria-sort=\\"ascending\\" role=\\"columnheader\\" class=\\"css-p16prq-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in descending order\\" class=\\"css-1em9f1b-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">aa</span>&nbsp;<span class=\\"css-1i897sk\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 7.5l8 8H4z\\"></path></g></svg></span></button></th>"`;
 
 exports[`Table sortable on click sorts ascending when sorted column changes 1`] = `
 Array [
@@ -37211,9 +37583,9 @@ Array [
 ]
 `;
 
-exports[`Table sortable on click sorts ascending when sorted column changes: Active 1`] = `"<th aria-label=\\"ab\\" aria-sort=\\"ascending\\" role=\\"columnheader\\" class=\\"css-1tzxjtv-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in descending order\\" class=\\"css-5irr73-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">ab</span>&nbsp;<span class=\\"css-1i897sk\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 7.5l8 8H4z\\"></path></g></svg></span></button></th>"`;
+exports[`Table sortable on click sorts ascending when sorted column changes: Active 1`] = `"<th aria-label=\\"ab\\" aria-sort=\\"ascending\\" role=\\"columnheader\\" class=\\"css-p16prq-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in descending order\\" class=\\"css-1em9f1b-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">ab</span>&nbsp;<span class=\\"css-1i897sk\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 7.5l8 8H4z\\"></path></g></svg></span></button></th>"`;
 
-exports[`Table sortable on click sorts ascending when sorted column changes: Idle 1`] = `"<th aria-label=\\"aa\\" aria-sort=\\"none\\" role=\\"columnheader\\" class=\\"css-1tzxjtv-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in ascending order\\" class=\\"css-5irr73-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">aa</span>&nbsp;<span class=\\"css-17gbkvt\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 7.5l8 8H4z\\"></path></g></svg></span></button></th>"`;
+exports[`Table sortable on click sorts ascending when sorted column changes: Idle 1`] = `"<th aria-label=\\"aa\\" aria-sort=\\"none\\" role=\\"columnheader\\" class=\\"css-p16prq-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in ascending order\\" class=\\"css-1em9f1b-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">aa</span>&nbsp;<span class=\\"css-17gbkvt\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 7.5l8 8H4z\\"></path></g></svg></span></button></th>"`;
 
 exports[`Table sortable on click toggles sort direction on second click 1`] = `
 Array [
@@ -37245,4 +37617,4 @@ Array [
 ]
 `;
 
-exports[`Table sortable on click toggles sort direction on second click 2`] = `"<th aria-label=\\"aa\\" aria-sort=\\"descending\\" role=\\"columnheader\\" class=\\"css-1tzxjtv-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in ascending order\\" class=\\"css-5irr73-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">aa</span>&nbsp;<span class=\\"css-t7dm0k\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 17.5l-8-8h16z\\"></path></g></svg></span></button></th>"`;
+exports[`Table sortable on click toggles sort direction on second click 2`] = `"<th aria-label=\\"aa\\" aria-sort=\\"descending\\" role=\\"columnheader\\" class=\\"css-p16prq-TableCell-TableHeaderCell-TableSortableHeaderCell\\"><button aria-label=\\"Sort column in ascending order\\" class=\\"css-1em9f1b-TableCell-TableHeaderCell\\"><span class=\\"css-156zkco\\">aa</span>&nbsp;<span class=\\"css-t7dm0k\\"><svg aria-hidden=\\"true\\" focusable=\\"false\\" role=\\"img\\" viewBox=\\"0 0 24 24\\" class=\\"css-q8tnb2\\"><g><path d=\\"M12 17.5l-8-8h16z\\"></path></g></svg></span></button></th>"`;

--- a/src/library/themes/mapComponentThemes.js
+++ b/src/library/themes/mapComponentThemes.js
@@ -1,11 +1,28 @@
 /* @flow */
 /**
  * Generates a new component theme based on the theme of another component.
+ *
+ * preserveKeys
+ *
+ *   What does it do:
+ *
+ *     Ensures source theme variables are used in override styles when the
+ *     source does not apply those styles and the override component is
+ *     independently themeable
+ *
+ *     e.g. Necessary in TableHeaderCell (which is a themed TableCell) because
+ *     TableCells and TableHeaderCells are both independently themeable
+ *
+ *   How to use:
+ *
+ *     Provide array of theme variable keys used in style properties applied by
+ *     source component and not by override component
  */
 export default function mapComponentThemes(
   source: { name: string, theme: Object },
   override: { name: string, theme: Object },
-  baseTheme: Object
+  baseTheme: Object,
+  preserveKeys?: Array<string>
 ) {
   const REGEXP_SOURCE_NAME = new RegExp(`^${source.name}`);
   const sourceThemeWithRenamedKeys = Object.keys(source.theme).reduce(
@@ -21,10 +38,18 @@ export default function mapComponentThemes(
     },
     {}
   );
+  const preserved =
+    preserveKeys &&
+    preserveKeys.reduce((acc, sourceKey) => {
+      const keyProperty = sourceKey.split('_')[1];
+      acc[`${override.name}_${keyProperty}`] = source.theme[sourceKey];
+      return acc;
+    }, {});
 
   return {
     ...sourceThemeWithRenamedKeys,
     ...override.theme,
-    ...baseTheme
+    ...baseTheme,
+    ...preserved
   };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: "[ComponentName] Clear, brief title using imperative tense" ~or~ "type-of-change(what-is-changed): Clear, brief title using imperative tense" (the latter should follow type convention from Commitizen: https://github.com/commitizen/cz-cli)
Examples:
* [Button] Add support for type=submit
* test(happo): Update to happo v1.0

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
- Add a `preserveKeys` parameter to `mapComponentTheme` for reason described below
- Refactor rtl-dependent border styles in TableCell & TableHeaderCell
- Update snapshots

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
We had an issue reported to us (not on GitHub) where defining both TableCell and TableHeaderCell theme variables would not work correctly; the TableCell theme variables were being applied to TableHeaderCells. After investigation, we determined the details of the root cause and devised a fix.

The fix is needed when both of these are true:

1. Both the themed (TableHeaderCell) and base (TableCell) components need to be independently themeable (e.g. Table exposes theme variables for both)
    - At the time of this PR, only Table meets this qualification
2. The base component applies styles using theme variables and the themed component does not apply those styles

### Screenshots, videos, or demo, if appropriate
<!-- Please share either a reproduction of your work on CodeSandbox (our Mineral UI Starter https://codesandbox.io/s/v410y75m0 may be useful for setup) or a deploy preview. To record and share a video: http://recordit.co/ -->

https://table-theme-overrides--mineral-ui.netlify.com/
(_Unfortunately, that link won't help you much this time._)

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Modify one of Table's examples to use a themed Table, where the overrides meet the criteria above. Something like:

    ```jsx
    // /src/website/app/demos/Table/examples/basic.js

    import _Table from '../../../../../library/Table';
    import { createThemedComponent } from '../../../../../library/themes';

    const Table = createThemedComponent(_Table, {
      TableCell_fontSize: '1em',
      TableHeaderCell_fontSize: '2em',
      TableCell_paddingVertical: '1em',
      TableHeaderCell_paddingVertical: '2em'
    });

    export default {
      // unchanged...
    };

    ```

3. Confirm that the overrides apply correctly

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) — **[n/a]**
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered — **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered — **[n/a]**
* [x] Documentation created or updated — **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change — **[n/a]**

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Dizzy Kirby](https://media.giphy.com/media/OU9QLvInu0fSM/giphy.gif)

> [Better gif that won't embed](https://media.giphy.com/media/LgR0AnXJBrO4E/giphy.gif)
