### PR TITLE
build(release): Use annotated tag so that follow-tags pushes tag properly

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -89,9 +89,10 @@ exec('mv -f _package.json package.json');
 // Update version in package.json, commit and tag
 exec(`npm version ${nextVersion} --no-git-tag-version`);
 if (!skipGit) {
+  const message = `chore(release): ${nextVersion}`;
   exec(`git add package.json`);
-  exec(`git commit -m "chore(release): ${nextVersion}"`);
-  exec(`git tag -f v${nextVersion}`);
+  exec(`git commit -m "${message}"`);
+  exec(`git tag -a -f v${nextVersion} -m "${message}"`);
 }
 
 // Copy additional files to dist to be included in the npm package

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -84,7 +84,7 @@ inquirer
         console.log('Skipped push to GitHub...');
       } else {
         console.log('Pushing to GitHub...');
-        exec('git push -f --follow-tags');
+        exec('git push --follow-tags');
       }
     } else {
       console.log('Release aborted.');


### PR DESCRIPTION
### Description

* Fix release process by using annotated tag so that follow-tags pushes tag properly.
* This needs tested during the next release

### Motivation and context

Closes #756 

### Screenshots, videos, or demo, if appropriate

Not really applicable...

https://756-release-tags--mineral-ui.netlify.com/

### How to test

During the next release, try it with these changes, and see if this pushed the latest tag automatically.

### Types of changes

- Other (provide details below)

Fix build/release

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
