### PR TITLE
[Pagination]: Render in all supported React versions

### DIFF
--- a/src/library/Pagination/Pages.js
+++ b/src/library/Pagination/Pages.js
@@ -52,7 +52,7 @@ const EllipsisButton = createThemedComponent(Button, ({ theme }) => ({
   color_disabled: theme.color_theme
 }));
 
-const Buttons = ({
+const getPageButtons = ({
   currentPage,
   handleClick,
   messages,
@@ -164,11 +164,13 @@ const IncrementButton = ({
     size,
     ...restProps
   };
+
   return <Button {...buttonProps} />;
 };
 
 export default class Pages extends PureComponent<Props> {
   previousButton: ?HTMLButtonElement;
+
   nextButton: ?HTMLButtonElement;
 
   render() {
@@ -182,7 +184,7 @@ export default class Pages extends PureComponent<Props> {
           innerRef={this.setPreviousButtonRef}
           {...restProps}
         />
-        {showPageNumbers && <Buttons {...restProps} />}
+        {showPageNumbers && getPageButtons(this.props)}
         <IncrementButton
           direction="next"
           focusedNodeWhenDisabled={this.previousButton}
@@ -192,9 +194,11 @@ export default class Pages extends PureComponent<Props> {
       </Container>
     );
   }
+
   setPreviousButtonRef = (node: ?HTMLButtonElement) => {
     this.previousButton = node;
   };
+
   setNextButtonRef = (node: ?HTMLButtonElement) => {
     this.nextButton = node;
   };

--- a/src/library/Pagination/__tests__/Pagination.spec.js
+++ b/src/library/Pagination/__tests__/Pagination.spec.js
@@ -89,7 +89,9 @@ const findPageSizer = (pagination) => {
 };
 
 describe('Pagination', () => {
-  testDemoExamples(examples);
+  testDemoExamples(examples, {
+    contextPolyfill: true
+  });
 
   it('renders', () => {
     const [, pagination] = mountPagination();

--- a/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
+++ b/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
@@ -1361,415 +1361,398 @@ exports[`Pagination demo examples Snapshots: basic 1`] = `
                                                       </Button>
                                                     </Button>
                                                   </IncrementButton>
-                                                  <Buttons
-                                                    currentPage={1}
-                                                    handleClick={[Function]}
-                                                    handleIncrement={[Function]}
-                                                    messages={
-                                                      Object {
-                                                        "next": "Next",
-                                                        "pageLabel": [Function],
-                                                        "previous": "Previous",
-                                                      }
-                                                    }
-                                                    onPageChange={[Function]}
+                                                  <Button
+                                                    aria-current={true}
+                                                    aria-label="Current page, 1"
+                                                    element="button"
+                                                    key="1"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={true}
                                                     size="medium"
-                                                    totalPages={10}
-                                                    visibleRange={5}
+                                                    type="button"
                                                   >
                                                     <Button
                                                       aria-current={true}
                                                       aria-label="Current page, 1"
                                                       element="button"
-                                                      key="1"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={true}
                                                       size="medium"
+                                                      text={1}
                                                       type="button"
                                                     >
-                                                      <Button
+                                                      <button
                                                         aria-current={true}
                                                         aria-label="Current page, 1"
-                                                        element="button"
-                                                        minimal={true}
+                                                        className="emotion-6"
                                                         onClick={[Function]}
-                                                        primary={true}
-                                                        size="medium"
-                                                        text={1}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          aria-current={true}
-                                                          aria-label="Current page, 1"
-                                                          className="emotion-6"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  1
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                1
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="2"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="2"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={2}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={2}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  2
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                2
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="3"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="3"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={3}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={3}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  3
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                3
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="4"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="4"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={4}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={4}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  4
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                4
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="5"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="5"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={5}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={5}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  5
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                5
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="6"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="6"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={6}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={6}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  6
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                6
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="7"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="7"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={7}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={7}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  7
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                7
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                    <WithTheme(Themed(Button))
+                                                  </Button>
+                                                  <WithTheme(Themed(Button))
+                                                    disabled={true}
+                                                    element="span"
+                                                    key="8"
+                                                    minimal={true}
+                                                    size="medium"
+                                                  >
+                                                    <Themed(Button)
                                                       disabled={true}
                                                       element="span"
-                                                      key="8"
                                                       minimal={true}
                                                       size="medium"
                                                     >
-                                                      <Themed(Button)
-                                                        disabled={true}
-                                                        element="span"
-                                                        minimal={true}
-                                                        size="medium"
-                                                      >
+                                                      <ThemeProvider>
                                                         <ThemeProvider>
-                                                          <ThemeProvider>
+                                                          <Button
+                                                            disabled={true}
+                                                            element="span"
+                                                            minimal={true}
+                                                            size="medium"
+                                                            type="button"
+                                                          >
                                                             <Button
                                                               disabled={true}
                                                               element="span"
                                                               minimal={true}
                                                               size="medium"
+                                                              text="…"
                                                               type="button"
                                                             >
-                                                              <Button
-                                                                disabled={true}
-                                                                element="span"
-                                                                minimal={true}
-                                                                size="medium"
-                                                                text="…"
-                                                                type="button"
+                                                              <span
+                                                                className="emotion-27"
                                                               >
-                                                                <span
-                                                                  className="emotion-27"
-                                                                >
-                                                                  <Styled(span)>
-                                                                    <span
-                                                                      className="emotion-2"
+                                                                <Styled(span)>
+                                                                  <span
+                                                                    className="emotion-2"
+                                                                  >
+                                                                    <Styled(span)
+                                                                      size="medium"
                                                                     >
-                                                                      <Styled(span)
-                                                                        size="medium"
+                                                                      <span
+                                                                        className="emotion-1"
                                                                       >
-                                                                        <span
-                                                                          className="emotion-1"
-                                                                        >
-                                                                          …
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </span>
-                                                                  </Styled(span)>
-                                                                </span>
-                                                              </Button>
+                                                                        …
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </span>
+                                                                </Styled(span)>
+                                                              </span>
                                                             </Button>
-                                                          </ThemeProvider>
+                                                          </Button>
                                                         </ThemeProvider>
-                                                      </Themed(Button)>
-                                                    </WithTheme(Themed(Button))>
+                                                      </ThemeProvider>
+                                                    </Themed(Button)>
+                                                  </WithTheme(Themed(Button))>
+                                                  <Button
+                                                    aria-label="Last page, 10"
+                                                    element="button"
+                                                    key="10"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       aria-label="Last page, 10"
                                                       element="button"
-                                                      key="10"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={10}
                                                       type="button"
                                                     >
-                                                      <Button
+                                                      <button
                                                         aria-label="Last page, 10"
-                                                        element="button"
-                                                        minimal={true}
+                                                        className="emotion-9"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={10}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          aria-label="Last page, 10"
-                                                          className="emotion-9"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  10
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                10
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                  </Buttons>
+                                                  </Button>
                                                   <IncrementButton
                                                     currentPage={1}
                                                     direction="next"
@@ -6391,320 +6374,302 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
-                                                          onPageSizeChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="small"
-                                                          totalPages={7}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="small"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-63"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="small"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-63"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-66"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-66"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-66"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-66"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-66"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-66"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-66"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-66"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-66"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-66"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 7"
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 7"
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 7"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-66"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 7"
-                                                                className="emotion-66"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-58"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-58"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -9022,320 +8987,302 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
-                                                          onPageSizeChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="medium"
-                                                          totalPages={7}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="medium"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-164"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="medium"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-164"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-167"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-167"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-167"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-167"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-167"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-167"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-167"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-167"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-167"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-167"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 7"
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 7"
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 7"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-167"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 7"
-                                                                className="emotion-167"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-159"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-159"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -11653,320 +11600,302 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
-                                                          onPageSizeChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="large"
-                                                          totalPages={7}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="large"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-265"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="large"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-265"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-268"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-268"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-268"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-268"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-268"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-268"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-268"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-268"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-268"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-268"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 7"
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 7"
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 7"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-268"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 7"
-                                                                className="emotion-268"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-260"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-260"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -14284,320 +14213,302 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
-                                                          onPageSizeChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="jumbo"
-                                                          totalPages={7}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="jumbo"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-366"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="jumbo"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-366"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-369"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-369"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-369"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-369"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-369"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-369"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-369"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-369"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-369"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-369"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 7"
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 7"
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 7"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-369"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 7"
-                                                                className="emotion-369"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-59"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-59"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-361"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-361"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -17061,415 +16972,398 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                       </Button>
                                                     </Button>
                                                   </IncrementButton>
-                                                  <Buttons
-                                                    currentPage={1}
-                                                    handleClick={[Function]}
-                                                    handleIncrement={[Function]}
-                                                    messages={
-                                                      Object {
-                                                        "next": "Next",
-                                                        "pageLabel": [Function],
-                                                        "previous": "Previous",
-                                                      }
-                                                    }
-                                                    onPageChange={[Function]}
+                                                  <Button
+                                                    aria-current={true}
+                                                    aria-label="Current page, 1"
+                                                    element="button"
+                                                    key="1"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={true}
                                                     size="medium"
-                                                    totalPages={10}
-                                                    visibleRange={5}
+                                                    type="button"
                                                   >
                                                     <Button
                                                       aria-current={true}
                                                       aria-label="Current page, 1"
                                                       element="button"
-                                                      key="1"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={true}
                                                       size="medium"
+                                                      text={1}
                                                       type="button"
                                                     >
-                                                      <Button
+                                                      <button
                                                         aria-current={true}
                                                         aria-label="Current page, 1"
-                                                        element="button"
-                                                        minimal={true}
+                                                        className="emotion-33"
                                                         onClick={[Function]}
-                                                        primary={true}
-                                                        size="medium"
-                                                        text={1}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          aria-current={true}
-                                                          aria-label="Current page, 1"
-                                                          className="emotion-33"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  1
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                1
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="2"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="2"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={2}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={2}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  2
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                2
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="3"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="3"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={3}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={3}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  3
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                3
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="4"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="4"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={4}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={4}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  4
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                4
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="5"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="5"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={5}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={5}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  5
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                5
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="6"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="6"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={6}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={6}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  6
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                6
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="7"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="7"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={7}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={7}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  7
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                7
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                    <WithTheme(Themed(Button))
+                                                  </Button>
+                                                  <WithTheme(Themed(Button))
+                                                    disabled={true}
+                                                    element="span"
+                                                    key="8"
+                                                    minimal={true}
+                                                    size="medium"
+                                                  >
+                                                    <Themed(Button)
                                                       disabled={true}
                                                       element="span"
-                                                      key="8"
                                                       minimal={true}
                                                       size="medium"
                                                     >
-                                                      <Themed(Button)
-                                                        disabled={true}
-                                                        element="span"
-                                                        minimal={true}
-                                                        size="medium"
-                                                      >
+                                                      <ThemeProvider>
                                                         <ThemeProvider>
-                                                          <ThemeProvider>
+                                                          <Button
+                                                            disabled={true}
+                                                            element="span"
+                                                            minimal={true}
+                                                            size="medium"
+                                                            type="button"
+                                                          >
                                                             <Button
                                                               disabled={true}
                                                               element="span"
                                                               minimal={true}
                                                               size="medium"
+                                                              text="…"
                                                               type="button"
                                                             >
-                                                              <Button
-                                                                disabled={true}
-                                                                element="span"
-                                                                minimal={true}
-                                                                size="medium"
-                                                                text="…"
-                                                                type="button"
+                                                              <span
+                                                                className="emotion-54"
                                                               >
-                                                                <span
-                                                                  className="emotion-54"
-                                                                >
-                                                                  <Styled(span)>
-                                                                    <span
-                                                                      className="emotion-29"
+                                                                <Styled(span)>
+                                                                  <span
+                                                                    className="emotion-29"
+                                                                  >
+                                                                    <Styled(span)
+                                                                      size="medium"
                                                                     >
-                                                                      <Styled(span)
-                                                                        size="medium"
+                                                                      <span
+                                                                        className="emotion-28"
                                                                       >
-                                                                        <span
-                                                                          className="emotion-28"
-                                                                        >
-                                                                          …
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </span>
-                                                                  </Styled(span)>
-                                                                </span>
-                                                              </Button>
+                                                                        …
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </span>
+                                                                </Styled(span)>
+                                                              </span>
                                                             </Button>
-                                                          </ThemeProvider>
+                                                          </Button>
                                                         </ThemeProvider>
-                                                      </Themed(Button)>
-                                                    </WithTheme(Themed(Button))>
+                                                      </ThemeProvider>
+                                                    </Themed(Button)>
+                                                  </WithTheme(Themed(Button))>
+                                                  <Button
+                                                    aria-label="Last page, 10"
+                                                    element="button"
+                                                    key="10"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       aria-label="Last page, 10"
                                                       element="button"
-                                                      key="10"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={10}
                                                       type="button"
                                                     >
-                                                      <Button
+                                                      <button
                                                         aria-label="Last page, 10"
-                                                        element="button"
-                                                        minimal={true}
+                                                        className="emotion-36"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={10}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          aria-label="Last page, 10"
-                                                          className="emotion-36"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-29"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-29"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-28"
                                                               >
-                                                                <span
-                                                                  className="emotion-28"
-                                                                >
-                                                                  10
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                10
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                  </Buttons>
+                                                  </Button>
                                                   <IncrementButton
                                                     currentPage={1}
                                                     direction="next"
@@ -21800,320 +21694,302 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
-                                                          onPageSizeChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="medium"
-                                                          totalPages={7}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="medium"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-87"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="medium"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-87"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-90"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-90"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-90"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-90"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-90"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-90"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-90"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-90"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-90"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-90"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 7"
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 7"
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 7"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-90"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 7"
-                                                                className="emotion-90"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-83"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-83"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-82"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-82"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -28531,239 +28407,220 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                   </Button>
                                                                 </Button>
                                                               </IncrementButton>
-                                                              <Buttons
-                                                                currentPage={1}
-                                                                handleClick={[Function]}
-                                                                handleIncrement={[Function]}
-                                                                messages={
-                                                                  Object {
-                                                                    "next": "التالى",
-                                                                    "pageLabel": [Function],
-                                                                    "previous": "سابق",
-                                                                  }
-                                                                }
-                                                                onPageChange={[Function]}
-                                                                onPageSizeChange={[Function]}
-                                                                rtl={true}
+                                                              <Button
+                                                                aria-current={true}
+                                                                aria-label="1, الصفحه الحاليه"
+                                                                element="button"
+                                                                key="1"
+                                                                minimal={true}
+                                                                onClick={[Function]}
+                                                                primary={true}
                                                                 size="medium"
-                                                                totalPages={5}
-                                                                visibleRange={5}
+                                                                type="button"
                                                               >
                                                                 <Button
                                                                   aria-current={true}
                                                                   aria-label="1, الصفحه الحاليه"
                                                                   element="button"
-                                                                  key="1"
                                                                   minimal={true}
                                                                   onClick={[Function]}
                                                                   primary={true}
                                                                   size="medium"
+                                                                  text={1}
                                                                   type="button"
                                                                 >
-                                                                  <Button
+                                                                  <button
                                                                     aria-current={true}
                                                                     aria-label="1, الصفحه الحاليه"
-                                                                    element="button"
-                                                                    minimal={true}
+                                                                    className="emotion-113"
                                                                     onClick={[Function]}
-                                                                    primary={true}
-                                                                    size="medium"
-                                                                    text={1}
                                                                     type="button"
                                                                   >
-                                                                    <button
-                                                                      aria-current={true}
-                                                                      aria-label="1, الصفحه الحاليه"
-                                                                      className="emotion-113"
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      <Styled(span)>
-                                                                        <span
-                                                                          className="emotion-109"
+                                                                    <Styled(span)>
+                                                                      <span
+                                                                        className="emotion-109"
+                                                                      >
+                                                                        <Styled(span)
+                                                                          size="medium"
                                                                         >
-                                                                          <Styled(span)
-                                                                            size="medium"
+                                                                          <span
+                                                                            className="emotion-108"
                                                                           >
-                                                                            <span
-                                                                              className="emotion-108"
-                                                                            >
-                                                                              1
-                                                                            </span>
-                                                                          </Styled(span)>
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </button>
-                                                                  </Button>
+                                                                            1
+                                                                          </span>
+                                                                        </Styled(span)>
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </button>
                                                                 </Button>
+                                                              </Button>
+                                                              <Button
+                                                                element="button"
+                                                                key="2"
+                                                                minimal={true}
+                                                                onClick={[Function]}
+                                                                primary={false}
+                                                                size="medium"
+                                                                type="button"
+                                                              >
                                                                 <Button
                                                                   element="button"
-                                                                  key="2"
                                                                   minimal={true}
                                                                   onClick={[Function]}
                                                                   primary={false}
                                                                   size="medium"
+                                                                  text={2}
                                                                   type="button"
                                                                 >
-                                                                  <Button
-                                                                    element="button"
-                                                                    minimal={true}
+                                                                  <button
+                                                                    className="emotion-116"
                                                                     onClick={[Function]}
-                                                                    primary={false}
-                                                                    size="medium"
-                                                                    text={2}
                                                                     type="button"
                                                                   >
-                                                                    <button
-                                                                      className="emotion-116"
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      <Styled(span)>
-                                                                        <span
-                                                                          className="emotion-109"
+                                                                    <Styled(span)>
+                                                                      <span
+                                                                        className="emotion-109"
+                                                                      >
+                                                                        <Styled(span)
+                                                                          size="medium"
                                                                         >
-                                                                          <Styled(span)
-                                                                            size="medium"
+                                                                          <span
+                                                                            className="emotion-108"
                                                                           >
-                                                                            <span
-                                                                              className="emotion-108"
-                                                                            >
-                                                                              2
-                                                                            </span>
-                                                                          </Styled(span)>
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </button>
-                                                                  </Button>
+                                                                            2
+                                                                          </span>
+                                                                        </Styled(span)>
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </button>
                                                                 </Button>
+                                                              </Button>
+                                                              <Button
+                                                                element="button"
+                                                                key="3"
+                                                                minimal={true}
+                                                                onClick={[Function]}
+                                                                primary={false}
+                                                                size="medium"
+                                                                type="button"
+                                                              >
                                                                 <Button
                                                                   element="button"
-                                                                  key="3"
                                                                   minimal={true}
                                                                   onClick={[Function]}
                                                                   primary={false}
                                                                   size="medium"
+                                                                  text={3}
                                                                   type="button"
                                                                 >
-                                                                  <Button
-                                                                    element="button"
-                                                                    minimal={true}
+                                                                  <button
+                                                                    className="emotion-116"
                                                                     onClick={[Function]}
-                                                                    primary={false}
-                                                                    size="medium"
-                                                                    text={3}
                                                                     type="button"
                                                                   >
-                                                                    <button
-                                                                      className="emotion-116"
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      <Styled(span)>
-                                                                        <span
-                                                                          className="emotion-109"
+                                                                    <Styled(span)>
+                                                                      <span
+                                                                        className="emotion-109"
+                                                                      >
+                                                                        <Styled(span)
+                                                                          size="medium"
                                                                         >
-                                                                          <Styled(span)
-                                                                            size="medium"
+                                                                          <span
+                                                                            className="emotion-108"
                                                                           >
-                                                                            <span
-                                                                              className="emotion-108"
-                                                                            >
-                                                                              3
-                                                                            </span>
-                                                                          </Styled(span)>
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </button>
-                                                                  </Button>
+                                                                            3
+                                                                          </span>
+                                                                        </Styled(span)>
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </button>
                                                                 </Button>
+                                                              </Button>
+                                                              <Button
+                                                                element="button"
+                                                                key="4"
+                                                                minimal={true}
+                                                                onClick={[Function]}
+                                                                primary={false}
+                                                                size="medium"
+                                                                type="button"
+                                                              >
                                                                 <Button
                                                                   element="button"
-                                                                  key="4"
                                                                   minimal={true}
                                                                   onClick={[Function]}
                                                                   primary={false}
                                                                   size="medium"
+                                                                  text={4}
                                                                   type="button"
                                                                 >
-                                                                  <Button
-                                                                    element="button"
-                                                                    minimal={true}
+                                                                  <button
+                                                                    className="emotion-116"
                                                                     onClick={[Function]}
-                                                                    primary={false}
-                                                                    size="medium"
-                                                                    text={4}
                                                                     type="button"
                                                                   >
-                                                                    <button
-                                                                      className="emotion-116"
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      <Styled(span)>
-                                                                        <span
-                                                                          className="emotion-109"
+                                                                    <Styled(span)>
+                                                                      <span
+                                                                        className="emotion-109"
+                                                                      >
+                                                                        <Styled(span)
+                                                                          size="medium"
                                                                         >
-                                                                          <Styled(span)
-                                                                            size="medium"
+                                                                          <span
+                                                                            className="emotion-108"
                                                                           >
-                                                                            <span
-                                                                              className="emotion-108"
-                                                                            >
-                                                                              4
-                                                                            </span>
-                                                                          </Styled(span)>
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </button>
-                                                                  </Button>
+                                                                            4
+                                                                          </span>
+                                                                        </Styled(span)>
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </button>
                                                                 </Button>
+                                                              </Button>
+                                                              <Button
+                                                                aria-label="5, آخر صفحة"
+                                                                element="button"
+                                                                key="5"
+                                                                minimal={true}
+                                                                onClick={[Function]}
+                                                                primary={false}
+                                                                size="medium"
+                                                                type="button"
+                                                              >
                                                                 <Button
                                                                   aria-label="5, آخر صفحة"
                                                                   element="button"
-                                                                  key="5"
                                                                   minimal={true}
                                                                   onClick={[Function]}
                                                                   primary={false}
                                                                   size="medium"
+                                                                  text={5}
                                                                   type="button"
                                                                 >
-                                                                  <Button
+                                                                  <button
                                                                     aria-label="5, آخر صفحة"
-                                                                    element="button"
-                                                                    minimal={true}
+                                                                    className="emotion-116"
                                                                     onClick={[Function]}
-                                                                    primary={false}
-                                                                    size="medium"
-                                                                    text={5}
                                                                     type="button"
                                                                   >
-                                                                    <button
-                                                                      aria-label="5, آخر صفحة"
-                                                                      className="emotion-116"
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      <Styled(span)>
-                                                                        <span
-                                                                          className="emotion-109"
+                                                                    <Styled(span)>
+                                                                      <span
+                                                                        className="emotion-109"
+                                                                      >
+                                                                        <Styled(span)
+                                                                          size="medium"
                                                                         >
-                                                                          <Styled(span)
-                                                                            size="medium"
+                                                                          <span
+                                                                            className="emotion-108"
                                                                           >
-                                                                            <span
-                                                                              className="emotion-108"
-                                                                            >
-                                                                              5
-                                                                            </span>
-                                                                          </Styled(span)>
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </button>
-                                                                  </Button>
+                                                                            5
+                                                                          </span>
+                                                                        </Styled(span)>
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </button>
                                                                 </Button>
-                                                              </Buttons>
+                                                              </Button>
                                                               <IncrementButton
                                                                 currentPage={1}
                                                                 direction="next"
@@ -30924,415 +30781,398 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="small"
-                                                          totalPages={10}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="small"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-6"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="small"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-6"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                          <WithTheme(Themed(Button))
+                                                        </Button>
+                                                        <WithTheme(Themed(Button))
+                                                          disabled={true}
+                                                          element="span"
+                                                          key="8"
+                                                          minimal={true}
+                                                          size="medium"
+                                                        >
+                                                          <Themed(Button)
                                                             disabled={true}
                                                             element="span"
-                                                            key="8"
                                                             minimal={true}
                                                             size="medium"
                                                           >
-                                                            <Themed(Button)
-                                                              disabled={true}
-                                                              element="span"
-                                                              minimal={true}
-                                                              size="medium"
-                                                            >
+                                                            <ThemeProvider>
                                                               <ThemeProvider>
-                                                                <ThemeProvider>
+                                                                <Button
+                                                                  disabled={true}
+                                                                  element="span"
+                                                                  minimal={true}
+                                                                  size="medium"
+                                                                  type="button"
+                                                                >
                                                                   <Button
                                                                     disabled={true}
                                                                     element="span"
                                                                     minimal={true}
                                                                     size="medium"
+                                                                    text="…"
                                                                     type="button"
                                                                   >
-                                                                    <Button
-                                                                      disabled={true}
-                                                                      element="span"
-                                                                      minimal={true}
-                                                                      size="medium"
-                                                                      text="…"
-                                                                      type="button"
+                                                                    <span
+                                                                      className="emotion-27"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-27"
-                                                                      >
-                                                                        <Styled(span)>
-                                                                          <span
-                                                                            className="emotion-2"
+                                                                      <Styled(span)>
+                                                                        <span
+                                                                          className="emotion-2"
+                                                                        >
+                                                                          <Styled(span)
+                                                                            size="medium"
                                                                           >
-                                                                            <Styled(span)
-                                                                              size="medium"
+                                                                            <span
+                                                                              className="emotion-25"
                                                                             >
-                                                                              <span
-                                                                                className="emotion-25"
-                                                                              >
-                                                                                …
-                                                                              </span>
-                                                                            </Styled(span)>
-                                                                          </span>
-                                                                        </Styled(span)>
-                                                                      </span>
-                                                                    </Button>
+                                                                              …
+                                                                            </span>
+                                                                          </Styled(span)>
+                                                                        </span>
+                                                                      </Styled(span)>
+                                                                    </span>
                                                                   </Button>
-                                                                </ThemeProvider>
+                                                                </Button>
                                                               </ThemeProvider>
-                                                            </Themed(Button)>
-                                                          </WithTheme(Themed(Button))>
+                                                            </ThemeProvider>
+                                                          </Themed(Button)>
+                                                        </WithTheme(Themed(Button))>
+                                                        <Button
+                                                          aria-label="Last page, 10"
+                                                          element="button"
+                                                          key="10"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="small"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 10"
                                                             element="button"
-                                                            key="10"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="small"
+                                                            text={10}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 10"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-9"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="small"
-                                                              text={10}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 10"
-                                                                className="emotion-9"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="small"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="small"
+                                                                    <span
+                                                                      className="emotion-1"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-1"
-                                                                      >
-                                                                        10
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      10
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -32222,415 +32062,398 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="medium"
-                                                          totalPages={10}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="medium"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-56"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="medium"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-56"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                          <WithTheme(Themed(Button))
+                                                        </Button>
+                                                        <WithTheme(Themed(Button))
+                                                          disabled={true}
+                                                          element="span"
+                                                          key="8"
+                                                          minimal={true}
+                                                          size="medium"
+                                                        >
+                                                          <Themed(Button)
                                                             disabled={true}
                                                             element="span"
-                                                            key="8"
                                                             minimal={true}
                                                             size="medium"
                                                           >
-                                                            <Themed(Button)
-                                                              disabled={true}
-                                                              element="span"
-                                                              minimal={true}
-                                                              size="medium"
-                                                            >
+                                                            <ThemeProvider>
                                                               <ThemeProvider>
-                                                                <ThemeProvider>
+                                                                <Button
+                                                                  disabled={true}
+                                                                  element="span"
+                                                                  minimal={true}
+                                                                  size="medium"
+                                                                  type="button"
+                                                                >
                                                                   <Button
                                                                     disabled={true}
                                                                     element="span"
                                                                     minimal={true}
                                                                     size="medium"
+                                                                    text="…"
                                                                     type="button"
                                                                   >
-                                                                    <Button
-                                                                      disabled={true}
-                                                                      element="span"
-                                                                      minimal={true}
-                                                                      size="medium"
-                                                                      text="…"
-                                                                      type="button"
+                                                                    <span
+                                                                      className="emotion-27"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-27"
-                                                                      >
-                                                                        <Styled(span)>
-                                                                          <span
-                                                                            className="emotion-2"
+                                                                      <Styled(span)>
+                                                                        <span
+                                                                          className="emotion-2"
+                                                                        >
+                                                                          <Styled(span)
+                                                                            size="medium"
                                                                           >
-                                                                            <Styled(span)
-                                                                              size="medium"
+                                                                            <span
+                                                                              className="emotion-25"
                                                                             >
-                                                                              <span
-                                                                                className="emotion-25"
-                                                                              >
-                                                                                …
-                                                                              </span>
-                                                                            </Styled(span)>
-                                                                          </span>
-                                                                        </Styled(span)>
-                                                                      </span>
-                                                                    </Button>
+                                                                              …
+                                                                            </span>
+                                                                          </Styled(span)>
+                                                                        </span>
+                                                                      </Styled(span)>
+                                                                    </span>
                                                                   </Button>
-                                                                </ThemeProvider>
+                                                                </Button>
                                                               </ThemeProvider>
-                                                            </Themed(Button)>
-                                                          </WithTheme(Themed(Button))>
+                                                            </ThemeProvider>
+                                                          </Themed(Button)>
+                                                        </WithTheme(Themed(Button))>
+                                                        <Button
+                                                          aria-label="Last page, 10"
+                                                          element="button"
+                                                          key="10"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 10"
                                                             element="button"
-                                                            key="10"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={10}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 10"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={10}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 10"
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-25"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-25"
-                                                                      >
-                                                                        10
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      10
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -33520,415 +33343,398 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="large"
-                                                          totalPages={10}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="large"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-106"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="large"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-106"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                          <WithTheme(Themed(Button))
+                                                        </Button>
+                                                        <WithTheme(Themed(Button))
+                                                          disabled={true}
+                                                          element="span"
+                                                          key="8"
+                                                          minimal={true}
+                                                          size="medium"
+                                                        >
+                                                          <Themed(Button)
                                                             disabled={true}
                                                             element="span"
-                                                            key="8"
                                                             minimal={true}
                                                             size="medium"
                                                           >
-                                                            <Themed(Button)
-                                                              disabled={true}
-                                                              element="span"
-                                                              minimal={true}
-                                                              size="medium"
-                                                            >
+                                                            <ThemeProvider>
                                                               <ThemeProvider>
-                                                                <ThemeProvider>
+                                                                <Button
+                                                                  disabled={true}
+                                                                  element="span"
+                                                                  minimal={true}
+                                                                  size="medium"
+                                                                  type="button"
+                                                                >
                                                                   <Button
                                                                     disabled={true}
                                                                     element="span"
                                                                     minimal={true}
                                                                     size="medium"
+                                                                    text="…"
                                                                     type="button"
                                                                   >
-                                                                    <Button
-                                                                      disabled={true}
-                                                                      element="span"
-                                                                      minimal={true}
-                                                                      size="medium"
-                                                                      text="…"
-                                                                      type="button"
+                                                                    <span
+                                                                      className="emotion-27"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-27"
-                                                                      >
-                                                                        <Styled(span)>
-                                                                          <span
-                                                                            className="emotion-2"
+                                                                      <Styled(span)>
+                                                                        <span
+                                                                          className="emotion-2"
+                                                                        >
+                                                                          <Styled(span)
+                                                                            size="medium"
                                                                           >
-                                                                            <Styled(span)
-                                                                              size="medium"
+                                                                            <span
+                                                                              className="emotion-25"
                                                                             >
-                                                                              <span
-                                                                                className="emotion-25"
-                                                                              >
-                                                                                …
-                                                                              </span>
-                                                                            </Styled(span)>
-                                                                          </span>
-                                                                        </Styled(span)>
-                                                                      </span>
-                                                                    </Button>
+                                                                              …
+                                                                            </span>
+                                                                          </Styled(span)>
+                                                                        </span>
+                                                                      </Styled(span)>
+                                                                    </span>
                                                                   </Button>
-                                                                </ThemeProvider>
+                                                                </Button>
                                                               </ThemeProvider>
-                                                            </Themed(Button)>
-                                                          </WithTheme(Themed(Button))>
+                                                            </ThemeProvider>
+                                                          </Themed(Button)>
+                                                        </WithTheme(Themed(Button))>
+                                                        <Button
+                                                          aria-label="Last page, 10"
+                                                          element="button"
+                                                          key="10"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="large"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 10"
                                                             element="button"
-                                                            key="10"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="large"
+                                                            text={10}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 10"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-109"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="large"
-                                                              text={10}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 10"
-                                                                className="emotion-109"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="large"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="large"
+                                                                    <span
+                                                                      className="emotion-101"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-101"
-                                                                      >
-                                                                        10
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      10
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -34818,415 +34624,398 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="jumbo"
-                                                          totalPages={10}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="jumbo"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-156"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="jumbo"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-156"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="6"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="6"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={6}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={6}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        6
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      6
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="7"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="7"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={7}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={7}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        7
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      7
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                          <WithTheme(Themed(Button))
+                                                        </Button>
+                                                        <WithTheme(Themed(Button))
+                                                          disabled={true}
+                                                          element="span"
+                                                          key="8"
+                                                          minimal={true}
+                                                          size="medium"
+                                                        >
+                                                          <Themed(Button)
                                                             disabled={true}
                                                             element="span"
-                                                            key="8"
                                                             minimal={true}
                                                             size="medium"
                                                           >
-                                                            <Themed(Button)
-                                                              disabled={true}
-                                                              element="span"
-                                                              minimal={true}
-                                                              size="medium"
-                                                            >
+                                                            <ThemeProvider>
                                                               <ThemeProvider>
-                                                                <ThemeProvider>
+                                                                <Button
+                                                                  disabled={true}
+                                                                  element="span"
+                                                                  minimal={true}
+                                                                  size="medium"
+                                                                  type="button"
+                                                                >
                                                                   <Button
                                                                     disabled={true}
                                                                     element="span"
                                                                     minimal={true}
                                                                     size="medium"
+                                                                    text="…"
                                                                     type="button"
                                                                   >
-                                                                    <Button
-                                                                      disabled={true}
-                                                                      element="span"
-                                                                      minimal={true}
-                                                                      size="medium"
-                                                                      text="…"
-                                                                      type="button"
+                                                                    <span
+                                                                      className="emotion-27"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-27"
-                                                                      >
-                                                                        <Styled(span)>
-                                                                          <span
-                                                                            className="emotion-2"
+                                                                      <Styled(span)>
+                                                                        <span
+                                                                          className="emotion-2"
+                                                                        >
+                                                                          <Styled(span)
+                                                                            size="medium"
                                                                           >
-                                                                            <Styled(span)
-                                                                              size="medium"
+                                                                            <span
+                                                                              className="emotion-25"
                                                                             >
-                                                                              <span
-                                                                                className="emotion-25"
-                                                                              >
-                                                                                …
-                                                                              </span>
-                                                                            </Styled(span)>
-                                                                          </span>
-                                                                        </Styled(span)>
-                                                                      </span>
-                                                                    </Button>
+                                                                              …
+                                                                            </span>
+                                                                          </Styled(span)>
+                                                                        </span>
+                                                                      </Styled(span)>
+                                                                    </span>
                                                                   </Button>
-                                                                </ThemeProvider>
+                                                                </Button>
                                                               </ThemeProvider>
-                                                            </Themed(Button)>
-                                                          </WithTheme(Themed(Button))>
+                                                            </ThemeProvider>
+                                                          </Themed(Button)>
+                                                        </WithTheme(Themed(Button))>
+                                                        <Button
+                                                          aria-label="Last page, 10"
+                                                          element="button"
+                                                          key="10"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="jumbo"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 10"
                                                             element="button"
-                                                            key="10"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="jumbo"
+                                                            text={10}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 10"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-159"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="jumbo"
-                                                              text={10}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 10"
-                                                                className="emotion-159"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-2"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-2"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="jumbo"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="jumbo"
+                                                                    <span
+                                                                      className="emotion-151"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-151"
-                                                                      >
-                                                                        10
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      10
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -36590,347 +36379,330 @@ exports[`Pagination demo examples Snapshots: visible-range 1`] = `
                                                       </Button>
                                                     </Button>
                                                   </IncrementButton>
-                                                  <Buttons
-                                                    currentPage={5}
-                                                    handleClick={[Function]}
-                                                    handleIncrement={[Function]}
-                                                    messages={
-                                                      Object {
-                                                        "next": "Next",
-                                                        "pageLabel": [Function],
-                                                        "previous": "Previous",
-                                                      }
-                                                    }
-                                                    onPageChange={[Function]}
+                                                  <Button
+                                                    element="button"
+                                                    key="1"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
                                                     size="medium"
-                                                    totalPages={10}
-                                                    visibleRange={3}
+                                                    type="button"
                                                   >
                                                     <Button
                                                       element="button"
-                                                      key="1"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={1}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-3"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={1}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-3"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  1
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                1
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                    <WithTheme(Themed(Button))
+                                                  </Button>
+                                                  <WithTheme(Themed(Button))
+                                                    disabled={true}
+                                                    element="span"
+                                                    key="3"
+                                                    minimal={true}
+                                                    size="medium"
+                                                  >
+                                                    <Themed(Button)
                                                       disabled={true}
                                                       element="span"
-                                                      key="3"
                                                       minimal={true}
                                                       size="medium"
                                                     >
-                                                      <Themed(Button)
-                                                        disabled={true}
-                                                        element="span"
-                                                        minimal={true}
-                                                        size="medium"
-                                                      >
+                                                      <ThemeProvider>
                                                         <ThemeProvider>
-                                                          <ThemeProvider>
+                                                          <Button
+                                                            disabled={true}
+                                                            element="span"
+                                                            minimal={true}
+                                                            size="medium"
+                                                            type="button"
+                                                          >
                                                             <Button
                                                               disabled={true}
                                                               element="span"
                                                               minimal={true}
                                                               size="medium"
+                                                              text="…"
                                                               type="button"
                                                             >
-                                                              <Button
-                                                                disabled={true}
-                                                                element="span"
-                                                                minimal={true}
-                                                                size="medium"
-                                                                text="…"
-                                                                type="button"
+                                                              <span
+                                                                className="emotion-9"
                                                               >
-                                                                <span
-                                                                  className="emotion-9"
-                                                                >
-                                                                  <Styled(span)>
-                                                                    <span
-                                                                      className="emotion-2"
+                                                                <Styled(span)>
+                                                                  <span
+                                                                    className="emotion-2"
+                                                                  >
+                                                                    <Styled(span)
+                                                                      size="medium"
                                                                     >
-                                                                      <Styled(span)
-                                                                        size="medium"
+                                                                      <span
+                                                                        className="emotion-1"
                                                                       >
-                                                                        <span
-                                                                          className="emotion-1"
-                                                                        >
-                                                                          …
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </span>
-                                                                  </Styled(span)>
-                                                                </span>
-                                                              </Button>
+                                                                        …
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </span>
+                                                                </Styled(span)>
+                                                              </span>
                                                             </Button>
-                                                          </ThemeProvider>
+                                                          </Button>
                                                         </ThemeProvider>
-                                                      </Themed(Button)>
-                                                    </WithTheme(Themed(Button))>
+                                                      </ThemeProvider>
+                                                    </Themed(Button)>
+                                                  </WithTheme(Themed(Button))>
+                                                  <Button
+                                                    element="button"
+                                                    key="4"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="4"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={4}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-3"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={4}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-3"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  4
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                4
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    aria-current={true}
+                                                    aria-label="Current page, 5"
+                                                    element="button"
+                                                    key="5"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={true}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       aria-current={true}
                                                       aria-label="Current page, 5"
                                                       element="button"
-                                                      key="5"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={true}
                                                       size="medium"
+                                                      text={5}
                                                       type="button"
                                                     >
-                                                      <Button
+                                                      <button
                                                         aria-current={true}
                                                         aria-label="Current page, 5"
-                                                        element="button"
-                                                        minimal={true}
+                                                        className="emotion-15"
                                                         onClick={[Function]}
-                                                        primary={true}
-                                                        size="medium"
-                                                        text={5}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          aria-current={true}
-                                                          aria-label="Current page, 5"
-                                                          className="emotion-15"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  5
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                5
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
+                                                  </Button>
+                                                  <Button
+                                                    element="button"
+                                                    key="6"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       element="button"
-                                                      key="6"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={6}
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        element="button"
-                                                        minimal={true}
+                                                      <button
+                                                        className="emotion-3"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={6}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="emotion-3"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  6
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                6
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                    <WithTheme(Themed(Button))
+                                                  </Button>
+                                                  <WithTheme(Themed(Button))
+                                                    disabled={true}
+                                                    element="span"
+                                                    key="7"
+                                                    minimal={true}
+                                                    size="medium"
+                                                  >
+                                                    <Themed(Button)
                                                       disabled={true}
                                                       element="span"
-                                                      key="7"
                                                       minimal={true}
                                                       size="medium"
                                                     >
-                                                      <Themed(Button)
-                                                        disabled={true}
-                                                        element="span"
-                                                        minimal={true}
-                                                        size="medium"
-                                                      >
+                                                      <ThemeProvider>
                                                         <ThemeProvider>
-                                                          <ThemeProvider>
+                                                          <Button
+                                                            disabled={true}
+                                                            element="span"
+                                                            minimal={true}
+                                                            size="medium"
+                                                            type="button"
+                                                          >
                                                             <Button
                                                               disabled={true}
                                                               element="span"
                                                               minimal={true}
                                                               size="medium"
+                                                              text="…"
                                                               type="button"
                                                             >
-                                                              <Button
-                                                                disabled={true}
-                                                                element="span"
-                                                                minimal={true}
-                                                                size="medium"
-                                                                text="…"
-                                                                type="button"
+                                                              <span
+                                                                className="emotion-9"
                                                               >
-                                                                <span
-                                                                  className="emotion-9"
-                                                                >
-                                                                  <Styled(span)>
-                                                                    <span
-                                                                      className="emotion-2"
+                                                                <Styled(span)>
+                                                                  <span
+                                                                    className="emotion-2"
+                                                                  >
+                                                                    <Styled(span)
+                                                                      size="medium"
                                                                     >
-                                                                      <Styled(span)
-                                                                        size="medium"
+                                                                      <span
+                                                                        className="emotion-1"
                                                                       >
-                                                                        <span
-                                                                          className="emotion-1"
-                                                                        >
-                                                                          …
-                                                                        </span>
-                                                                      </Styled(span)>
-                                                                    </span>
-                                                                  </Styled(span)>
-                                                                </span>
-                                                              </Button>
+                                                                        …
+                                                                      </span>
+                                                                    </Styled(span)>
+                                                                  </span>
+                                                                </Styled(span)>
+                                                              </span>
                                                             </Button>
-                                                          </ThemeProvider>
+                                                          </Button>
                                                         </ThemeProvider>
-                                                      </Themed(Button)>
-                                                    </WithTheme(Themed(Button))>
+                                                      </ThemeProvider>
+                                                    </Themed(Button)>
+                                                  </WithTheme(Themed(Button))>
+                                                  <Button
+                                                    aria-label="Last page, 10"
+                                                    element="button"
+                                                    key="10"
+                                                    minimal={true}
+                                                    onClick={[Function]}
+                                                    primary={false}
+                                                    size="medium"
+                                                    type="button"
+                                                  >
                                                     <Button
                                                       aria-label="Last page, 10"
                                                       element="button"
-                                                      key="10"
                                                       minimal={true}
                                                       onClick={[Function]}
                                                       primary={false}
                                                       size="medium"
+                                                      text={10}
                                                       type="button"
                                                     >
-                                                      <Button
+                                                      <button
                                                         aria-label="Last page, 10"
-                                                        element="button"
-                                                        minimal={true}
+                                                        className="emotion-3"
                                                         onClick={[Function]}
-                                                        primary={false}
-                                                        size="medium"
-                                                        text={10}
                                                         type="button"
                                                       >
-                                                        <button
-                                                          aria-label="Last page, 10"
-                                                          className="emotion-3"
-                                                          onClick={[Function]}
-                                                          type="button"
-                                                        >
-                                                          <Styled(span)>
-                                                            <span
-                                                              className="emotion-2"
+                                                        <Styled(span)>
+                                                          <span
+                                                            className="emotion-2"
+                                                          >
+                                                            <Styled(span)
+                                                              size="medium"
                                                             >
-                                                              <Styled(span)
-                                                                size="medium"
+                                                              <span
+                                                                className="emotion-1"
                                                               >
-                                                                <span
-                                                                  className="emotion-1"
-                                                                >
-                                                                  10
-                                                                </span>
-                                                              </Styled(span)>
-                                                            </span>
-                                                          </Styled(span)>
-                                                        </button>
-                                                      </Button>
+                                                                10
+                                                              </span>
+                                                            </Styled(span)>
+                                                          </span>
+                                                        </Styled(span)>
+                                                      </button>
                                                     </Button>
-                                                  </Buttons>
+                                                  </Button>
                                                   <IncrementButton
                                                     currentPage={5}
                                                     direction="next"

--- a/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
+++ b/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
@@ -14448,237 +14448,220 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="medium"
-                                                          totalPages={5}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="medium"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-56"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="medium"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-56"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-52"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-52"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-51"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-51"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-52"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-52"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-51"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-51"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-52"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-52"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-51"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-51"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-52"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-52"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-51"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-51"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 5"
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 5"
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 5"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-59"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 5"
-                                                                className="emotion-59"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-52"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-52"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-51"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-51"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -32220,237 +32203,220 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="medium"
-                                                          totalPages={5}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="medium"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-92"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="medium"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-92"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-88"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-88"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-87"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-87"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-95"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-95"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-88"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-88"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-87"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-87"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-95"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-95"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-88"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-88"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-87"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-87"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-95"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-95"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-88"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-88"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-87"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-87"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 5"
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 5"
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 5"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-95"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 5"
-                                                                className="emotion-95"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-88"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-88"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-87"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-87"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"
@@ -43604,237 +43570,220 @@ button:focus > .emotion-4 {
                                                             </Button>
                                                           </Button>
                                                         </IncrementButton>
-                                                        <Buttons
-                                                          currentPage={1}
-                                                          handleClick={[Function]}
-                                                          handleIncrement={[Function]}
-                                                          messages={
-                                                            Object {
-                                                              "next": "Next",
-                                                              "pageLabel": [Function],
-                                                              "previous": "Previous",
-                                                            }
-                                                          }
-                                                          onPageChange={[Function]}
+                                                        <Button
+                                                          aria-current={true}
+                                                          aria-label="Current page, 1"
+                                                          element="button"
+                                                          key="1"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={true}
                                                           size="medium"
-                                                          totalPages={5}
-                                                          visibleRange={5}
+                                                          type="button"
                                                         >
                                                           <Button
                                                             aria-current={true}
                                                             aria-label="Current page, 1"
                                                             element="button"
-                                                            key="1"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={true}
                                                             size="medium"
+                                                            text={1}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-current={true}
                                                               aria-label="Current page, 1"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-126"
                                                               onClick={[Function]}
-                                                              primary={true}
-                                                              size="medium"
-                                                              text={1}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-current={true}
-                                                                aria-label="Current page, 1"
-                                                                className="emotion-126"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-122"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-122"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-121"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-121"
-                                                                      >
-                                                                        1
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      1
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="2"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="2"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={2}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-129"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={2}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-129"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-122"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-122"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-121"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-121"
-                                                                      >
-                                                                        2
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      2
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="3"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="3"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={3}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-129"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={3}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-129"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-122"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-122"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-121"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-121"
-                                                                      >
-                                                                        3
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      3
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          element="button"
+                                                          key="4"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             element="button"
-                                                            key="4"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={4}
                                                             type="button"
                                                           >
-                                                            <Button
-                                                              element="button"
-                                                              minimal={true}
+                                                            <button
+                                                              className="emotion-129"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={4}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                className="emotion-129"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-122"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-122"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-121"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-121"
-                                                                      >
-                                                                        4
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      4
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
+                                                        </Button>
+                                                        <Button
+                                                          aria-label="Last page, 5"
+                                                          element="button"
+                                                          key="5"
+                                                          minimal={true}
+                                                          onClick={[Function]}
+                                                          primary={false}
+                                                          size="medium"
+                                                          type="button"
+                                                        >
                                                           <Button
                                                             aria-label="Last page, 5"
                                                             element="button"
-                                                            key="5"
                                                             minimal={true}
                                                             onClick={[Function]}
                                                             primary={false}
                                                             size="medium"
+                                                            text={5}
                                                             type="button"
                                                           >
-                                                            <Button
+                                                            <button
                                                               aria-label="Last page, 5"
-                                                              element="button"
-                                                              minimal={true}
+                                                              className="emotion-129"
                                                               onClick={[Function]}
-                                                              primary={false}
-                                                              size="medium"
-                                                              text={5}
                                                               type="button"
                                                             >
-                                                              <button
-                                                                aria-label="Last page, 5"
-                                                                className="emotion-129"
-                                                                onClick={[Function]}
-                                                                type="button"
-                                                              >
-                                                                <Styled(span)>
-                                                                  <span
-                                                                    className="emotion-122"
+                                                              <Styled(span)>
+                                                                <span
+                                                                  className="emotion-122"
+                                                                >
+                                                                  <Styled(span)
+                                                                    size="medium"
                                                                   >
-                                                                    <Styled(span)
-                                                                      size="medium"
+                                                                    <span
+                                                                      className="emotion-121"
                                                                     >
-                                                                      <span
-                                                                        className="emotion-121"
-                                                                      >
-                                                                        5
-                                                                      </span>
-                                                                    </Styled(span)>
-                                                                  </span>
-                                                                </Styled(span)>
-                                                              </button>
-                                                            </Button>
+                                                                      5
+                                                                    </span>
+                                                                  </Styled(span)>
+                                                                </span>
+                                                              </Styled(span)>
+                                                            </button>
                                                           </Button>
-                                                        </Buttons>
+                                                        </Button>
                                                         <IncrementButton
                                                           currentPage={1}
                                                           direction="next"


### PR DESCRIPTION
### Description

* Updates the Pagination Pages subcomponent - converts the internal Buttons component to a simple function instead of an actual component.  This way it can still just return an array, without the need for an additional wrapper element.  This means that the DOM structure did not need to change.
* Exclude the Pagination demo example snapshot tests from being tested in older React versions as they use the Table component, which uses the context polyfill, which renders differently in different React versions.

### Motivation and context

Closes #760

### Screenshots, videos, or demo, if appropriate

Not really applicable...

http://760-pagination--mineral-ui.netlify.com

### How to test

1. `npm run jest:react`

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
