### PR TITLE
chore(website): Clean up demoRoutes usage

### DIFF
--- a/src/website/app/App.js
+++ b/src/website/app/App.js
@@ -14,15 +14,10 @@ declare var GOOGLE_TRACKING_ID: string;
 type Props = {
   children?: any,
   className?: string,
-  demoRoutes: Array<DemoRoute>,
   history: Object,
-  location?: any
-};
-
-type DemoRoute = {
-  description: string,
-  slug: string,
-  title: string
+  location?: {
+    search: string
+  }
 };
 
 const siteTheme = {
@@ -126,13 +121,11 @@ class App extends Component<Props> {
   }
 
   render() {
-    const { demoRoutes } = this.props;
-
     return (
       <ThemeProvider>
         <ThemeProvider theme={siteTheme}>
           <div>
-            <Router demoRoutes={demoRoutes} />
+            <Router />
             <BaselineGrid />
           </div>
         </ThemeProvider>

--- a/src/website/app/Page.js
+++ b/src/website/app/Page.js
@@ -23,10 +23,12 @@ import _Nav from './Nav';
 import siteColors from './siteColors';
 import { heroTheme } from './pages/Home/index';
 
+import { type DemoRoutes } from './demos/routes';
+
 type Props = {
   children: React$Node,
   chromeless?: boolean,
-  demoRoutes: Array<DemoRoute>,
+  demoRoutes: DemoRoutes,
   glitched?: boolean,
   headerContent?: React$Node,
   pageMeta?: {
@@ -36,12 +38,6 @@ type Props = {
   },
   slug?: string,
   type?: number
-};
-
-type DemoRoute = {
-  description: string,
-  slug: string,
-  title: string
 };
 
 type State = {

--- a/src/website/app/Router.js
+++ b/src/website/app/Router.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import flatten from 'lodash/flatten';
 import createKeyMap from './utils/createKeyMap';
+import demoRoutes from './demos/routes';
 import ComponentDocExample from './ComponentDocExample';
 import Page from './Page';
 import sections from './pages';
@@ -10,16 +11,6 @@ import ComponentDoc from './pages/ComponentDoc';
 import NotFound from './pages/NotFound';
 import Loadable from './Loadable';
 import ScrollToIdOnMount from './ScrollToIdOnMount';
-
-type Props = {
-  demoRoutes: Array<DemoRoute>
-};
-
-type DemoRoute = {
-  description: string,
-  slug: string,
-  title: string
-};
 
 const AsyncHome = Loadable({
   loader: () => import('./pages/Home')
@@ -31,8 +22,7 @@ const getPageHeader = (heading: string, title: string) => {
 # ${title}`;
 };
 
-export default function Router(props: Props) {
-  const { demoRoutes } = props;
+export default function Router() {
   const flatDemoRoutes = flatten(demoRoutes);
   const keyedDemoRoutes = createKeyMap(flatDemoRoutes, 'slug');
   const firstDemoSlug = flatDemoRoutes[0].slug;

--- a/src/website/app/demos/routes.js
+++ b/src/website/app/demos/routes.js
@@ -1,5 +1,15 @@
 /* @flow */
-export default [
+
+export type DemoRoutes = Array<DemoRoute>;
+export type DemoRoute = Array<Route> | Route;
+type Route = {
+  description: string,
+  redirect?: string,
+  slug: string,
+  title: string
+};
+
+const demoRoutes: DemoRoutes = [
   {
     description:
       'Avatar provides a graphic representation of an identity. It can display an image, text, or an icon.',
@@ -151,6 +161,7 @@ export default [
   },
   [
     {
+      description: 'Redirect layout to box',
       redirect: 'box',
       slug: 'layout',
       title: 'Layout'
@@ -291,3 +302,5 @@ export default [
     title: 'Tooltip'
   }
 ];
+
+export default demoRoutes;

--- a/src/website/index.js
+++ b/src/website/index.js
@@ -4,12 +4,11 @@ import { render } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import 'babel-polyfill';
 import App from './app/App';
-import demoRoutes from './app/demos/routes';
 require('./index.css');
 
 render(
   <BrowserRouter>
-    <App demoRoutes={demoRoutes} />
+    <App />
   </BrowserRouter>,
   global.document.getElementById('app')
 );


### PR DESCRIPTION
### Description

Clean up demoRoutes usage

* Fix Flow types
* Avoid unnecessary prop passing; now just imported in Router

### Motivation and context

Extracted this update from my Table render props work

### Screenshots, videos, or demo, if appropriate

https://routes--mineral-ui.netlify.com/

### How to test

Just check that you can still navigate around the website.

### Types of changes

- Other (provide details below)

Just leaving the campsite cleaner than when I arrived... 🏕 

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
