### PR TITLE
refactor(dialog): Update Dialog_transitionDuration theme variable to include units

### DIFF
--- a/src/library/Dialog/Dialog.js
+++ b/src/library/Dialog/Dialog.js
@@ -85,7 +85,7 @@ type State = {
 };
 
 export const componentTheme = (baseTheme: Object) => ({
-  Dialog_transitionDuration: 250,
+  Dialog_transitionDuration: '250ms',
   Dialog_zIndex: baseTheme.zIndex_1600,
 
   DialogCloseButton_margin: baseTheme.space_inline_sm,
@@ -119,7 +119,7 @@ const styles = {
     return {
       opacity: state === 'entered' ? 1 : 0,
       position: 'relative',
-      transition: `opacity ${theme.Dialog_transitionDuration}ms ease`,
+      transition: `opacity ${theme.Dialog_transitionDuration} ease`,
       willChange: 'opacity',
       zIndex: theme.Dialog_zIndex
     };
@@ -215,7 +215,7 @@ const Animation = withTheme(({ children, theme, ...restProps }: Object) => {
     <Transition
       appear
       mountOnEnter
-      timeout={componentTheme(theme).Dialog_transitionDuration}
+      timeout={parseFloat(componentTheme(theme).Dialog_transitionDuration)}
       unmountOnExit
       {...restProps}>
       {(state) => <Animate state={state}>{children}</Animate>}


### PR DESCRIPTION
### Description

Update `Dialog_transitionDuration` theme variable to include units

* More consistent with CSS timing API
* Allows user to specify value in other time units - `s` or `ms`
* Fixes incorrect display of theme variable in website theme documentation, which previously indicated units were px.

### Motivation and context

Noticed incorrect units in website documentation

### Screenshots, videos, or demo, if appropriate

https://dialog-transition--mineral-ui.netlify.com/components/dialog#theme-variables

**Before:**
<img width="429" alt="screen shot 2018-09-07 at 10 21 26 am" src="https://user-images.githubusercontent.com/202773/45230991-e3624f00-b287-11e8-940d-aaddda30de86.png">

**After:**
<img width="374" alt="screen shot 2018-09-07 at 10 21 52 am" src="https://user-images.githubusercontent.com/202773/45230998-e8270300-b287-11e8-997d-beb4a5b6de1a.png">

### How to test

* Visit demo and verify change.
* Verify dialog still transitions properly

### Types of changes

- Other (provide details below)

Fixes website documentation issue by changing a component theme variable value.  The likelihood that someone has overridden this theme variable is remote and combined with the small potential impact leads me to believe that this should not be considered a breaking change.  

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - **[n/a]**" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
