### PR TITLE
[Tooltip] Add cursor prop

### DIFF
--- a/src/library/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/library/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -6743,6 +6743,7 @@ Array [
       "aria-haspopup": true,
       "aria-owns": "dropdown-30-content",
       "children": undefined,
+      "cursor": undefined,
       "disabled": undefined,
       "onBlur": [Function],
       "onClick": [Function],

--- a/src/library/Popover/Popover.js
+++ b/src/library/Popover/Popover.js
@@ -27,6 +27,11 @@ type Props = {
    */
   content: $FlowFixMe | RenderFn,
   /**
+   * @Private Cursor applied when hovering the popover trigger; accepts any
+   * [valid CSS value](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor)
+   */
+  cursor?: string,
+  /**
    * Open the Popover upon initialization. Primarily for use with uncontrolled
    * components.
    */
@@ -274,7 +279,7 @@ export default class Popover extends Component<Props, State> {
   getTriggerProps: PropGetter = (props = {}) => {
     const isOpen = this.getControllableValue('isOpen');
     const contentId = this.getContentId();
-    const { children, disabled } = this.props;
+    const { children, cursor, disabled } = this.props;
 
     let child, childDisabled;
     if (!isRenderProp(children)) {
@@ -289,6 +294,7 @@ export default class Popover extends Component<Props, State> {
       'aria-expanded': isOpen,
       'aria-owns': contentId,
       children: child,
+      cursor,
       disabled: child && childDisabled ? childDisabled : disabled,
       ref: this.setTriggerRef,
       role: 'button',

--- a/src/library/Popover/PopoverTrigger.js
+++ b/src/library/Popover/PopoverTrigger.js
@@ -4,14 +4,20 @@ import { Target } from 'react-popper';
 import { createStyledComponent } from '../styles';
 
 type Props = {
-  children: React$Node
+  children: React$Node,
+  /**
+   * Cursor applied when hovering the popover trigger; accepts any
+   * [valid CSS value](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor)
+   */
+  cursor?: string
 };
 
 const Root = createStyledComponent(
   Target,
-  {
+  ({ cursor }) => ({
+    cursor,
     display: 'inline-block'
-  },
+  }),
   {
     displayName: 'PopoverTrigger'
   }
@@ -19,9 +25,10 @@ const Root = createStyledComponent(
 
 export default class PopoverTrigger extends Component<Props> {
   render() {
-    const { children, ...restProps } = this.props;
+    const { children, cursor, ...restProps } = this.props;
     const rootProps = {
-      component: 'span'
+      component: 'span',
+      cursor
     };
 
     return (

--- a/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -4262,6 +4262,7 @@ Array [
       "aria-expanded": false,
       "aria-owns": "popover-43-content",
       "children": undefined,
+      "cursor": undefined,
       "disabled": undefined,
       "onBlur": [Function],
       "onClick": [Function],

--- a/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
@@ -24801,6 +24801,7 @@ Array [
       "aria-readonly": undefined,
       "aria-required": undefined,
       "children": undefined,
+      "cursor": undefined,
       "disabled": undefined,
       "isOpen": false,
       "item": undefined,

--- a/src/library/Tooltip/Tooltip.js
+++ b/src/library/Tooltip/Tooltip.js
@@ -11,6 +11,11 @@ import PopoverContent from '../Popover/PopoverContent';
 type Props = {
   /** Trigger for the Tooltip */
   children: React$Node,
+  /**
+   * Cursor applied when hovering the tooltip trigger; accepts any
+   * [valid CSS value](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor)
+   */
+  cursor?: string,
   /** Content of the Tooltip */
   content: string,
   /**

--- a/src/library/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
+++ b/src/library/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
@@ -529,7 +529,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
           content={[Function]}
           focusTriggerOnClose={false}
           hasArrow={true}
-          id="tooltip-21"
+          id="tooltip-27"
           isOpen={true}
           onClose={[Function]}
           onOpen={[Function]}
@@ -539,7 +539,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
             content={[Function]}
             focusTriggerOnClose={false}
             hasArrow={true}
-            id="tooltip-21"
+            id="tooltip-27"
             isOpen={true}
             onClose={[Function]}
             onOpen={[Function]}
@@ -551,7 +551,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                   content={[Function]}
                   focusTriggerOnClose={false}
                   hasArrow={true}
-                  id="tooltip-21"
+                  id="tooltip-27"
                   isOpen={true}
                   onClose={[Function]}
                   onOpen={[Function]}
@@ -561,7 +561,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                     content={[Function]}
                     focusTriggerOnClose={false}
                     hasArrow={true}
-                    id="tooltip-21"
+                    id="tooltip-27"
                     isOpen={true}
                     onClose={[Function]}
                     onOpen={[Function]}
@@ -570,16 +570,16 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                   >
                     <Popover
                       className="emotion-13"
-                      id="tooltip-21"
+                      id="tooltip-27"
                       tag="span"
                     >
                       <span
                         className="emotion-13"
-                        id="tooltip-21"
+                        id="tooltip-27"
                       >
                         <PopoverTrigger
-                          aria-describedby="tooltip-21-content"
-                          aria-owns="tooltip-21-content"
+                          aria-describedby="tooltip-27-content"
+                          aria-owns="tooltip-27-content"
                           element="button"
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -602,8 +602,8 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                 className="emotion-3"
                               >
                                 <Button
-                                  aria-describedby="tooltip-21-content"
-                                  aria-owns="tooltip-21-content"
+                                  aria-describedby="tooltip-27-content"
+                                  aria-owns="tooltip-27-content"
                                   element="button"
                                   onBlur={[Function]}
                                   onClick={[Function]}
@@ -616,8 +616,8 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                   type="button"
                                 >
                                   <Button
-                                    aria-describedby="tooltip-21-content"
-                                    aria-owns="tooltip-21-content"
+                                    aria-describedby="tooltip-27-content"
+                                    aria-owns="tooltip-27-content"
                                     element="button"
                                     onBlur={[Function]}
                                     onClick={[Function]}
@@ -631,8 +631,8 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                     type="button"
                                   >
                                     <button
-                                      aria-describedby="tooltip-21-content"
-                                      aria-owns="tooltip-21-content"
+                                      aria-describedby="tooltip-27-content"
+                                      aria-owns="tooltip-27-content"
                                       className="emotion-2"
                                       onBlur={[Function]}
                                       onClick={[Function]}
@@ -668,14 +668,14 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                         <PopoverContent
                           aria-live="polite"
                           hasArrow={true}
-                          id="tooltip-21-content"
+                          id="tooltip-27-content"
                           onBlur={[Function]}
                           placement="top"
                           role="tooltip"
                         >
                           <PopoverContent
                             aria-live="polite"
-                            id="tooltip-21-content"
+                            id="tooltip-27-content"
                             onBlur={[Function]}
                             placement="top"
                             role="tooltip"
@@ -683,7 +683,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                             <PopoverContent
                               aria-live="polite"
                               className="emotion-9"
-                              id="tooltip-21-content"
+                              id="tooltip-27-content"
                               onBlur={[Function]}
                               placement="top"
                               role="tooltip"
@@ -691,7 +691,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                               <RtlPopper
                                 aria-live="polite"
                                 className="emotion-9"
-                                id="tooltip-21-content"
+                                id="tooltip-27-content"
                                 onBlur={[Function]}
                                 placement="top"
                                 role="tooltip"
@@ -701,7 +701,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                   className="emotion-9"
                                   component="div"
                                   eventsEnabled={true}
-                                  id="tooltip-21-content"
+                                  id="tooltip-27-content"
                                   modifiers={Object {}}
                                   onBlur={[Function]}
                                   placement="top"
@@ -711,7 +711,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                   <div
                                     aria-live="polite"
                                     className="emotion-9"
-                                    id="tooltip-21-content"
+                                    id="tooltip-27-content"
                                     onBlur={[Function]}
                                     role="tooltip"
                                     style={
@@ -838,6 +838,417 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
     </div>
   </Styled(div)>
 </App>
+`;
+
+exports[`Tooltip demo examples Snapshots: cursor 1`] = `
+.emotion-3 {
+  display: inline-block;
+}
+
+.emotion-0 {
+  border-bottom-style: dashed;
+  border-bottom-color: currentcolor;
+  border-bottom-width: 1px;
+}
+
+.emotion-15 {
+  font-family: "Open Sans";
+}
+
+.emotion-15 > * {
+  margin-right: 1.5em;
+}
+
+.emotion-1 {
+  cursor: help;
+  display: inline-block;
+}
+
+.emotion-6 {
+  cursor: not-allowed;
+  display: inline-block;
+}
+
+.emotion-11 {
+  cursor: move;
+  display: inline-block;
+}
+
+<Styled(div)>
+  <div
+    className="emotion-15"
+  >
+    <Tooltip
+      content="Help"
+      cursor="help"
+      hasArrow={true}
+    >
+      <WithTheme(Themed(Popover))
+        content={[Function]}
+        cursor="help"
+        focusTriggerOnClose={false}
+        hasArrow={true}
+        id="tooltip-17"
+        isOpen={false}
+        onClose={[Function]}
+        onOpen={[Function]}
+      >
+        <Themed(Popover)
+          content={[Function]}
+          cursor="help"
+          focusTriggerOnClose={false}
+          hasArrow={true}
+          id="tooltip-17"
+          isOpen={false}
+          onClose={[Function]}
+          onOpen={[Function]}
+        >
+          <ThemeProvider>
+            <ThemeProvider>
+              <Popover
+                content={[Function]}
+                cursor="help"
+                focusTriggerOnClose={false}
+                hasArrow={true}
+                id="tooltip-17"
+                isOpen={false}
+                onClose={[Function]}
+                onOpen={[Function]}
+                placement="bottom"
+              >
+                <Popover
+                  content={[Function]}
+                  cursor="help"
+                  focusTriggerOnClose={false}
+                  hasArrow={true}
+                  id="tooltip-17"
+                  isOpen={false}
+                  onClose={[Function]}
+                  onOpen={[Function]}
+                  placement="bottom"
+                  tag="span"
+                >
+                  <Popover
+                    className="emotion-3"
+                    id="tooltip-17"
+                    tag="span"
+                  >
+                    <span
+                      className="emotion-3"
+                      id="tooltip-17"
+                    >
+                      <PopoverTrigger
+                        aria-describedby="tooltip-17-content"
+                        aria-owns="tooltip-17-content"
+                        cursor="help"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <PopoverTrigger
+                          component="span"
+                          cursor="help"
+                        >
+                          <PopoverTrigger
+                            className="emotion-1"
+                            component="span"
+                            cursor="help"
+                          >
+                            <span
+                              className="emotion-1"
+                              cursor="help"
+                            >
+                              <Styled(span)
+                                aria-describedby="tooltip-17-content"
+                                aria-owns="tooltip-17-content"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
+                              >
+                                <span
+                                  aria-describedby="tooltip-17-content"
+                                  aria-owns="tooltip-17-content"
+                                  className="emotion-0"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
+                                  tabIndex={0}
+                                >
+                                  Help
+                                </span>
+                              </Styled(span)>
+                            </span>
+                          </PopoverTrigger>
+                        </PopoverTrigger>
+                      </PopoverTrigger>
+                    </span>
+                  </Popover>
+                </Popover>
+              </Popover>
+            </ThemeProvider>
+          </ThemeProvider>
+        </Themed(Popover)>
+      </WithTheme(Themed(Popover))>
+    </Tooltip>
+    <Tooltip
+      content="Not Allowed"
+      cursor="not-allowed"
+      hasArrow={true}
+    >
+      <WithTheme(Themed(Popover))
+        content={[Function]}
+        cursor="not-allowed"
+        focusTriggerOnClose={false}
+        hasArrow={true}
+        id="tooltip-18"
+        isOpen={false}
+        onClose={[Function]}
+        onOpen={[Function]}
+      >
+        <Themed(Popover)
+          content={[Function]}
+          cursor="not-allowed"
+          focusTriggerOnClose={false}
+          hasArrow={true}
+          id="tooltip-18"
+          isOpen={false}
+          onClose={[Function]}
+          onOpen={[Function]}
+        >
+          <ThemeProvider>
+            <ThemeProvider>
+              <Popover
+                content={[Function]}
+                cursor="not-allowed"
+                focusTriggerOnClose={false}
+                hasArrow={true}
+                id="tooltip-18"
+                isOpen={false}
+                onClose={[Function]}
+                onOpen={[Function]}
+                placement="bottom"
+              >
+                <Popover
+                  content={[Function]}
+                  cursor="not-allowed"
+                  focusTriggerOnClose={false}
+                  hasArrow={true}
+                  id="tooltip-18"
+                  isOpen={false}
+                  onClose={[Function]}
+                  onOpen={[Function]}
+                  placement="bottom"
+                  tag="span"
+                >
+                  <Popover
+                    className="emotion-3"
+                    id="tooltip-18"
+                    tag="span"
+                  >
+                    <span
+                      className="emotion-3"
+                      id="tooltip-18"
+                    >
+                      <PopoverTrigger
+                        aria-describedby="tooltip-18-content"
+                        aria-owns="tooltip-18-content"
+                        cursor="not-allowed"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <PopoverTrigger
+                          component="span"
+                          cursor="not-allowed"
+                        >
+                          <PopoverTrigger
+                            className="emotion-6"
+                            component="span"
+                            cursor="not-allowed"
+                          >
+                            <span
+                              className="emotion-6"
+                              cursor="not-allowed"
+                            >
+                              <Styled(span)
+                                aria-describedby="tooltip-18-content"
+                                aria-owns="tooltip-18-content"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
+                              >
+                                <span
+                                  aria-describedby="tooltip-18-content"
+                                  aria-owns="tooltip-18-content"
+                                  className="emotion-0"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
+                                  tabIndex={0}
+                                >
+                                  Not Allowed
+                                </span>
+                              </Styled(span)>
+                            </span>
+                          </PopoverTrigger>
+                        </PopoverTrigger>
+                      </PopoverTrigger>
+                    </span>
+                  </Popover>
+                </Popover>
+              </Popover>
+            </ThemeProvider>
+          </ThemeProvider>
+        </Themed(Popover)>
+      </WithTheme(Themed(Popover))>
+    </Tooltip>
+    <Tooltip
+      content="Move"
+      cursor="move"
+      hasArrow={true}
+    >
+      <WithTheme(Themed(Popover))
+        content={[Function]}
+        cursor="move"
+        focusTriggerOnClose={false}
+        hasArrow={true}
+        id="tooltip-19"
+        isOpen={false}
+        onClose={[Function]}
+        onOpen={[Function]}
+      >
+        <Themed(Popover)
+          content={[Function]}
+          cursor="move"
+          focusTriggerOnClose={false}
+          hasArrow={true}
+          id="tooltip-19"
+          isOpen={false}
+          onClose={[Function]}
+          onOpen={[Function]}
+        >
+          <ThemeProvider>
+            <ThemeProvider>
+              <Popover
+                content={[Function]}
+                cursor="move"
+                focusTriggerOnClose={false}
+                hasArrow={true}
+                id="tooltip-19"
+                isOpen={false}
+                onClose={[Function]}
+                onOpen={[Function]}
+                placement="bottom"
+              >
+                <Popover
+                  content={[Function]}
+                  cursor="move"
+                  focusTriggerOnClose={false}
+                  hasArrow={true}
+                  id="tooltip-19"
+                  isOpen={false}
+                  onClose={[Function]}
+                  onOpen={[Function]}
+                  placement="bottom"
+                  tag="span"
+                >
+                  <Popover
+                    className="emotion-3"
+                    id="tooltip-19"
+                    tag="span"
+                  >
+                    <span
+                      className="emotion-3"
+                      id="tooltip-19"
+                    >
+                      <PopoverTrigger
+                        aria-describedby="tooltip-19-content"
+                        aria-owns="tooltip-19-content"
+                        cursor="move"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <PopoverTrigger
+                          component="span"
+                          cursor="move"
+                        >
+                          <PopoverTrigger
+                            className="emotion-11"
+                            component="span"
+                            cursor="move"
+                          >
+                            <span
+                              className="emotion-11"
+                              cursor="move"
+                            >
+                              <Styled(span)
+                                aria-describedby="tooltip-19-content"
+                                aria-owns="tooltip-19-content"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                role="button"
+                                tabIndex={0}
+                              >
+                                <span
+                                  aria-describedby="tooltip-19-content"
+                                  aria-owns="tooltip-19-content"
+                                  className="emotion-0"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  role="button"
+                                  tabIndex={0}
+                                >
+                                  Move
+                                </span>
+                              </Styled(span)>
+                            </span>
+                          </PopoverTrigger>
+                        </PopoverTrigger>
+                      </PopoverTrigger>
+                    </span>
+                  </Popover>
+                </Popover>
+              </Popover>
+            </ThemeProvider>
+          </ThemeProvider>
+        </Themed(Popover)>
+      </WithTheme(Themed(Popover))>
+    </Tooltip>
+  </div>
+</Styled(div)>
 `;
 
 exports[`Tooltip demo examples Snapshots: disabled 1`] = `
@@ -983,7 +1394,7 @@ exports[`Tooltip demo examples Snapshots: disabled 1`] = `
               >
                 <Styled(svg)
                   aria-hidden={null}
-                  aria-labelledby="icon-title-icon-18"
+                  aria-labelledby="icon-title-icon-24"
                   focusable="false"
                   role="img"
                   rtl={false}
@@ -992,14 +1403,14 @@ exports[`Tooltip demo examples Snapshots: disabled 1`] = `
                 >
                   <svg
                     aria-hidden={null}
-                    aria-labelledby="icon-title-icon-18"
+                    aria-labelledby="icon-title-icon-24"
                     className="emotion-0"
                     focusable="false"
                     role="img"
                     viewBox="0 0 24 24"
                   >
                     <title
-                      id="icon-title-icon-18"
+                      id="icon-title-icon-24"
                     >
                       account settings
                     </title>

--- a/src/website/app/demos/Tooltip/examples/cursor.js
+++ b/src/website/app/demos/Tooltip/examples/cursor.js
@@ -1,0 +1,25 @@
+/* @flow */
+import { createStyledComponent } from '../../../../../library/styles';
+import Tooltip from '../../../../../library/Tooltip';
+
+const DemoLayout = createStyledComponent('div', ({ theme }) => ({
+  fontFamily: theme.fontFamily,
+
+  '& > *': {
+    marginRight: theme.space_inline_lg
+  }
+}));
+
+export default {
+  id: 'cursor',
+  title: 'Cursor',
+  description: `Tooltips can apply any of the
+[valid CSS cursor values](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor). `,
+  scope: { DemoLayout, Tooltip },
+  source: `
+    <DemoLayout>
+      <Tooltip cursor="help" content="Help">Help</Tooltip>
+      <Tooltip cursor="not-allowed" content="Not Allowed">Not Allowed</Tooltip>
+      <Tooltip cursor="move" content="Move">Move</Tooltip>
+    </DemoLayout>`
+};

--- a/src/website/app/demos/Tooltip/examples/index.js
+++ b/src/website/app/demos/Tooltip/examples/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import basic from './basic';
+import cursor from './cursor';
 import controlled from './controlled';
 import disabled from './disabled';
 import importSyntax from './importSyntax';
@@ -17,6 +18,7 @@ export default [
   overflow,
   scrolling,
   portal,
+  cursor,
   disabled,
   controlled
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: "[ComponentName] Clear, brief title using imperative tense" ~or~ "type-of-change(what-is-changed): Clear, brief title using imperative tense" (the latter should follow type convention from Commitizen: https://github.com/commitizen/cz-cli)
Examples:
* [Button] Add support for type=submit
* test(happo): Update to happo v1.0

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
- Add support for `cursor` prop
- Add example
- Update snapshots (which also affected PopoverTrigger-related render prop snapshots)

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->
Closes #572 

### Screenshots, videos, or demo, if appropriate
<!-- Please share either a reproduction of your work on CodeSandbox (our Mineral UI Starter https://codesandbox.io/s/v410y75m0 may be useful for setup) or a deploy preview. To record and share a video: http://recordit.co/ -->

https://572-tooltip-cursor--mineral-ui.netlify.com/components/tooltip

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Navigate to Tooltip > [Cursor example](https://572-tooltip-cursor--mineral-ui.netlify.com/components/tooltip/cursor)
3. Confirm it works correctly and docs are clear with no typos

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- New feature (non-breaking change which adds functionality)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered **[n/a]**
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change **[n/a]**

<!-- If any of the above need further details, you should include those here. -->

### How does this PR make you feel?
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
![Lizard chasing a cursor on screen](https://media.giphy.com/media/2ExyJTKo5dkZ2/giphy.gif)
