### PR TITLE
[Text] Update to utilize new React Context API

### DIFF
--- a/src/library/Text/ElementContext.js
+++ b/src/library/Text/ElementContext.js
@@ -1,0 +1,8 @@
+/* @flow */
+import createReactContext, { type Context } from 'create-react-context';
+
+type ElementContextType = string | void;
+
+const ElementContext: Context<ElementContextType> = createReactContext();
+
+export default ElementContext;

--- a/src/library/Text/Text.js
+++ b/src/library/Text/Text.js
@@ -1,11 +1,11 @@
 /* @flow */
 import React, { Component } from 'react';
-import { string } from 'prop-types';
 import { createStyledComponent } from '../styles';
 import { rtlTextAlign } from '../utils';
+import ElementContext from './ElementContext';
 import TextProvider from './TextProvider';
 
-type Props = {
+export type Props = {
   /** Available horizontal alignments */
   align?: 'start' | 'end' | 'center' | 'justify',
   /** Available styles */
@@ -206,19 +206,20 @@ export default class Text extends Component<Props> {
     element: 'p'
   };
 
-  static contextTypes = {
-    parentElement: string
-  };
-
   render() {
     const { inherit, ...restProps } = this.props;
-    const parentElement = this.context.parentElement;
-    const rootProps = {
-      inherit: inherit === false || !parentElement ? inherit : true,
-      parentElement,
-      ...restProps
-    };
 
-    return <TextProvider {...rootProps} />;
+    return (
+      <ElementContext.Consumer>
+        {(parentElement) => {
+          const rootProps = {
+            inherit: inherit === false || !parentElement ? inherit : true,
+            parentElement,
+            ...restProps
+          };
+          return <TextProvider {...rootProps} />;
+        }}
+      </ElementContext.Consumer>
+    );
   }
 }

--- a/src/library/Text/TextProvider.js
+++ b/src/library/Text/TextProvider.js
@@ -1,52 +1,10 @@
 /* @flow */
 import React, { Component } from 'react';
 import memoizeOne from 'memoize-one';
-import { string } from 'prop-types';
-import { createRootNode } from './Text';
-
-type Props = {
-  /** Available horizontal alignments */
-  align?: 'start' | 'end' | 'center' | 'justify',
-  /** Available styles */
-  appearance?:
-    | 'h1'
-    | 'h2'
-    | 'h3'
-    | 'h4'
-    | 'h5'
-    | 'h6'
-    | 'mouse'
-    | 'p'
-    | 'prose',
-  /** Rendered content */
-  children: React$Node,
-  /** Color of text */
-  color?: string,
-  /** The rendered HTML element, e.g. `'span'`, `'strong'` */
-  element?: string,
-  /** Available font weights */
-  fontWeight?: 'regular' | 'semiBold' | 'bold' | 'extraBold' | number,
-  /** Inherit all styles from parent */
-  inherit?: boolean,
-  /** Remove top & bottom margins */
-  noMargins?: boolean,
-  /** @Private See use of context */
-  parentElement?: string,
-  /** Force display to one line and truncate with ellipsis at given max-width */
-  truncate?: boolean | number | string
-};
+import { type Props, createRootNode } from './Text';
+import ElementContext from './ElementContext';
 
 export default class TextProvider extends Component<Props> {
-  static childContextTypes = {
-    parentElement: string
-  };
-
-  getChildContext() {
-    return {
-      parentElement: this.props.element
-    };
-  }
-
   // Must be an instance method to avoid affecting other instances memoized keys
   getRootNode = memoizeOne(
     createRootNode,
@@ -61,6 +19,10 @@ export default class TextProvider extends Component<Props> {
       ...restProps
     };
 
-    return <Root {...rootProps} />;
+    return (
+      <ElementContext.Provider value={this.props.element}>
+        <Root {...rootProps} />
+      </ElementContext.Provider>
+    );
   }
 }


### PR DESCRIPTION
### Description
* Update Text and TextProvider to utilize new React Context API

### Motivation and context
Closes #680 

### Screenshots, videos, or demo, if appropriate

https://680-text-context--mineral-ui.netlify.com/components/text

### How to test

1. `cd mineral-ui && npm start`
1. Navigate to Text > [Nested Components](https://680-text-context--mineral-ui.netlify.com/components/text/nested) section
1. Ensure that styles are as expected
1. Navigate to Text > Nested Elements section (dev-only)
1. Ensure that styles are as expected

### Types of changes
- Other: Update to new API so that transition is smoother when the next major version of React is released

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered [n/a]
* [x] Documentation created or updated [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change [n/a]

### How does this PR make you feel?
![Mind blown](https://media.giphy.com/media/26ufdipQqU2lhNA4g/giphy.gif)
