### PR TITLE
[Table]: Add columnKey and rowIndex to table rows and cells

### DIFF
--- a/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
+++ b/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
@@ -16319,26 +16319,33 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={0}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={0}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={0}
                                         >
                                           <tr
                                             className="emotion-27"
                                           >
                                             <TableCell
+                                              columnKey="name"
                                               content="Mineral"
                                               element="td"
                                               key="name"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="name"
                                                 content="Mineral"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16348,14 +16355,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="color"
                                               content="Color"
                                               element="td"
                                               key="color"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="color"
                                                 content="Color"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16365,14 +16376,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="luster"
                                               content="Luster"
                                               element="td"
                                               key="luster"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="luster"
                                                 content="Luster"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16382,14 +16397,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalSystem"
                                               content="Crystal System"
                                               element="td"
                                               key="crystalSystem"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="crystalSystem"
                                                 content="Crystal System"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16399,14 +16418,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalHabit"
                                               content="Crystal Habit"
                                               element="td"
                                               key="crystalHabit"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="crystalHabit"
                                                 content="Crystal Habit"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16465,26 +16488,33 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={1}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={1}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={1}
                                         >
                                           <tr
                                             className="emotion-27"
                                           >
                                             <TableCell
+                                              columnKey="name"
                                               content="Mineral"
                                               element="td"
                                               key="name"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="name"
                                                 content="Mineral"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16494,14 +16524,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="color"
                                               content="Color"
                                               element="td"
                                               key="color"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="color"
                                                 content="Color"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16511,14 +16545,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="luster"
                                               content="Luster"
                                               element="td"
                                               key="luster"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="luster"
                                                 content="Luster"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16528,14 +16566,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalSystem"
                                               content="Crystal System"
                                               element="td"
                                               key="crystalSystem"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="crystalSystem"
                                                 content="Crystal System"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -16545,14 +16587,18 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalHabit"
                                               content="Crystal Habit"
                                               element="td"
                                               key="crystalHabit"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="crystalHabit"
                                                 content="Crystal Habit"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -21427,26 +21473,33 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                 "sortColumnDescending": "Sort column in descending order",
                                               }
                                             }
+                                            rowIndex={0}
                                           >
                                             <TableRow
                                               isSelectable={false}
+                                              rowIndex={0}
                                             >
                                               <TableRow
                                                 density="compact"
                                                 isSelectable={false}
+                                                rowIndex={0}
                                               >
                                                 <tr
                                                   className="emotion-27"
                                                 >
                                                   <TableCell
+                                                    columnKey="اسم"
                                                     content="معدني"
                                                     element="td"
                                                     key="اسم"
+                                                    rowIndex={0}
                                                   >
                                                     <TableCell
+                                                      columnKey="اسم"
                                                       content="معدني"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={0}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21456,14 +21509,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="اللون"
                                                     content="اللون"
                                                     element="td"
                                                     key="اللون"
+                                                    rowIndex={0}
                                                   >
                                                     <TableCell
+                                                      columnKey="اللون"
                                                       content="اللون"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={0}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21473,14 +21530,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="بريق"
                                                     content="بريق"
                                                     element="td"
                                                     key="بريق"
+                                                    rowIndex={0}
                                                   >
                                                     <TableCell
+                                                      columnKey="بريق"
                                                       content="بريق"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={0}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21490,14 +21551,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="النظام"
                                                     content="نظام الكريستال"
                                                     element="td"
                                                     key="النظام"
+                                                    rowIndex={0}
                                                   >
                                                     <TableCell
+                                                      columnKey="النظام"
                                                       content="نظام الكريستال"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={0}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21507,14 +21572,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="عادة"
                                                     content="الكريستال العادة"
                                                     element="td"
                                                     key="عادة"
+                                                    rowIndex={0}
                                                   >
                                                     <TableCell
+                                                      columnKey="عادة"
                                                       content="الكريستال العادة"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={0}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21573,26 +21642,33 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                 "sortColumnDescending": "Sort column in descending order",
                                               }
                                             }
+                                            rowIndex={1}
                                           >
                                             <TableRow
                                               isSelectable={false}
+                                              rowIndex={1}
                                             >
                                               <TableRow
                                                 density="compact"
                                                 isSelectable={false}
+                                                rowIndex={1}
                                               >
                                                 <tr
                                                   className="emotion-27"
                                                 >
                                                   <TableCell
+                                                    columnKey="اسم"
                                                     content="معدني"
                                                     element="td"
                                                     key="اسم"
+                                                    rowIndex={1}
                                                   >
                                                     <TableCell
+                                                      columnKey="اسم"
                                                       content="معدني"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={1}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21602,14 +21678,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="اللون"
                                                     content="اللون"
                                                     element="td"
                                                     key="اللون"
+                                                    rowIndex={1}
                                                   >
                                                     <TableCell
+                                                      columnKey="اللون"
                                                       content="اللون"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={1}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21619,14 +21699,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="بريق"
                                                     content="بريق"
                                                     element="td"
                                                     key="بريق"
+                                                    rowIndex={1}
                                                   >
                                                     <TableCell
+                                                      columnKey="بريق"
                                                       content="بريق"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={1}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21636,14 +21720,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="النظام"
                                                     content="نظام الكريستال"
                                                     element="td"
                                                     key="النظام"
+                                                    rowIndex={1}
                                                   >
                                                     <TableCell
+                                                      columnKey="النظام"
                                                       content="نظام الكريستال"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={1}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21653,14 +21741,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="عادة"
                                                     content="الكريستال العادة"
                                                     element="td"
                                                     key="عادة"
+                                                    rowIndex={1}
                                                   >
                                                     <TableCell
+                                                      columnKey="عادة"
                                                       content="الكريستال العادة"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={1}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21719,26 +21811,33 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                 "sortColumnDescending": "Sort column in descending order",
                                               }
                                             }
+                                            rowIndex={2}
                                           >
                                             <TableRow
                                               isSelectable={false}
+                                              rowIndex={2}
                                             >
                                               <TableRow
                                                 density="compact"
                                                 isSelectable={false}
+                                                rowIndex={2}
                                               >
                                                 <tr
                                                   className="emotion-27"
                                                 >
                                                   <TableCell
+                                                    columnKey="اسم"
                                                     content="معدني"
                                                     element="td"
                                                     key="اسم"
+                                                    rowIndex={2}
                                                   >
                                                     <TableCell
+                                                      columnKey="اسم"
                                                       content="معدني"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={2}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21748,14 +21847,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="اللون"
                                                     content="اللون"
                                                     element="td"
                                                     key="اللون"
+                                                    rowIndex={2}
                                                   >
                                                     <TableCell
+                                                      columnKey="اللون"
                                                       content="اللون"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={2}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21765,14 +21868,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="بريق"
                                                     content="بريق"
                                                     element="td"
                                                     key="بريق"
+                                                    rowIndex={2}
                                                   >
                                                     <TableCell
+                                                      columnKey="بريق"
                                                       content="بريق"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={2}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21782,14 +21889,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="النظام"
                                                     content="نظام الكريستال"
                                                     element="td"
                                                     key="النظام"
+                                                    rowIndex={2}
                                                   >
                                                     <TableCell
+                                                      columnKey="النظام"
                                                       content="نظام الكريستال"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={2}
                                                     >
                                                       <td
                                                         className="emotion-29"
@@ -21799,14 +21910,18 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                     </TableCell>
                                                   </TableCell>
                                                   <TableCell
+                                                    columnKey="عادة"
                                                     content="الكريستال العادة"
                                                     element="td"
                                                     key="عادة"
+                                                    rowIndex={2}
                                                   >
                                                     <TableCell
+                                                      columnKey="عادة"
                                                       content="الكريستال العادة"
                                                       density="compact"
                                                       element="td"
+                                                      rowIndex={2}
                                                     >
                                                       <td
                                                         className="emotion-29"

--- a/src/library/Table/TableBase.js
+++ b/src/library/Table/TableBase.js
@@ -159,6 +159,7 @@ export default class TableBase extends Component<Props, State> {
                 columns,
                 data: rowData,
                 messages,
+                rowIndex: index,
                 toggle: selectable && selectable.toggle
               };
               return (

--- a/src/library/Table/TableCell.js
+++ b/src/library/Table/TableCell.js
@@ -5,17 +5,21 @@ import { createStyledComponent, getNormalizedValue, pxToEm } from '../styles';
 import { isRenderProp, rtlTextAlign } from '../utils';
 import { TableContext } from './TableBase';
 
-import { type RenderFn } from './Table';
+import type { RenderFn } from './Table';
 
 type Props = {
   /** Rendered content */
   children?: React$Node,
+  /** Column key */
+  columnKey?: string,
   /** @Private Rendered element */
   element?: string,
   /** Remove padding */
   noPadding?: boolean,
   /** See Table's Column type */
   primary?: boolean,
+  /** Row index */
+  rowIndex?: number,
   /**
    * Provides custom rendering control. See the
    * [custom cell example](/components/table/#custom-cell) and

--- a/src/library/Table/TableDataRow.js
+++ b/src/library/Table/TableDataRow.js
@@ -13,6 +13,7 @@ type Props = {
   columns: Columns,
   data: Row,
   messages: Messages,
+  rowIndex: number,
   toggle?: Toggle
 };
 
@@ -32,6 +33,7 @@ export default class TableDataRow extends Component<Props> {
       columns,
       data,
       messages,
+      rowIndex,
       toggle,
       ...restProps
     } = this.props;
@@ -40,6 +42,8 @@ export default class TableDataRow extends Component<Props> {
     const cells = columns.map(({ cell: render, key, ...restColumn }) => {
       const cellProps = {
         children: data[key],
+        columnKey: key,
+        rowIndex,
         key,
         render,
         ...restColumn
@@ -65,6 +69,7 @@ export default class TableDataRow extends Component<Props> {
       isSelected: checked,
       isSelectable: selectable,
       ...(data.row ? { render: data.row } : undefined),
+      rowIndex,
       ...restProps
     };
 

--- a/src/library/Table/TableRow.js
+++ b/src/library/Table/TableRow.js
@@ -18,7 +18,9 @@ type Props = {
    * [custom row example](/components/table/#custom-row) and
    * our [render props guide](/render-props).
    */
-  render?: RenderFn
+  render?: RenderFn,
+  /** Row index */
+  rowIndex?: number
 };
 
 // prettier-ignore

--- a/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
+++ b/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
@@ -2453,26 +2453,33 @@ button:focus > .emotion-4 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={0}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={0}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={0}
                                     >
                                       <tr
                                         className="emotion-78"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-80"
@@ -2482,15 +2489,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={0}
                                           textAlign="end"
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                             textAlign="end"
                                           >
                                             <td
@@ -2501,15 +2512,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains Make For Hearty Filler"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={0}
                                           textAlign="center"
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains Make For Hearty Filler"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                             textAlign="center"
                                           >
                                             <td
@@ -2520,15 +2535,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={0}
                                           textAlign="justify"
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                             textAlign="justify"
                                           >
                                             <td
@@ -2587,26 +2606,33 @@ button:focus > .emotion-4 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={1}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={1}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={1}
                                     >
                                       <tr
                                         className="emotion-78"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-80"
@@ -2616,15 +2642,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={1}
                                           textAlign="end"
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                             textAlign="end"
                                           >
                                             <td
@@ -2635,15 +2665,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains Make For Hearty Filler"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={1}
                                           textAlign="center"
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains Make For Hearty Filler"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                             textAlign="center"
                                           >
                                             <td
@@ -2654,15 +2688,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={1}
                                           textAlign="justify"
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                             textAlign="justify"
                                           >
                                             <td
@@ -2721,26 +2759,33 @@ button:focus > .emotion-4 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={2}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={2}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={2}
                                     >
                                       <tr
                                         className="emotion-78"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-80"
@@ -2750,15 +2795,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={2}
                                           textAlign="end"
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                             textAlign="end"
                                           >
                                             <td
@@ -2769,15 +2818,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains Make For Hearty Filler"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={2}
                                           textAlign="center"
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains Make For Hearty Filler"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                             textAlign="center"
                                           >
                                             <td
@@ -2788,15 +2841,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={2}
                                           textAlign="justify"
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                             textAlign="justify"
                                           >
                                             <td
@@ -2855,26 +2912,33 @@ button:focus > .emotion-4 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={3}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={3}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={3}
                                     >
                                       <tr
                                         className="emotion-78"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-80"
@@ -2884,15 +2948,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={3}
                                           textAlign="end"
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                             textAlign="end"
                                           >
                                             <td
@@ -2903,15 +2971,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains Make For Hearty Filler"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={3}
                                           textAlign="center"
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains Make For Hearty Filler"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                             textAlign="center"
                                           >
                                             <td
@@ -2922,15 +2994,19 @@ button:focus > .emotion-4 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={3}
                                           textAlign="justify"
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                             textAlign="justify"
                                           >
                                             <td
@@ -3899,26 +3975,33 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -3928,14 +4011,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -3945,14 +4032,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -3962,14 +4053,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -3979,14 +4074,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4045,26 +4144,33 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4074,14 +4180,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4091,14 +4201,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4108,14 +4222,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4125,14 +4243,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4191,26 +4313,33 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4220,14 +4349,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4237,14 +4370,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4254,14 +4391,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4271,14 +4412,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4337,26 +4482,33 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4366,14 +4518,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4383,14 +4539,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4400,14 +4560,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -4417,14 +4581,18 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -5538,26 +5706,33 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -5567,15 +5742,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={0}
                                       textAlign="end"
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                         textAlign="end"
                                       >
                                         <td
@@ -5586,15 +5765,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={0}
                                       textAlign="center"
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                         textAlign="center"
                                       >
                                         <td
@@ -5605,15 +5788,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={0}
                                       textAlign="justify"
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                         textAlign="justify"
                                       >
                                         <td
@@ -5624,14 +5811,18 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -5693,26 +5884,33 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -5722,15 +5920,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={1}
                                       textAlign="end"
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                         textAlign="end"
                                       >
                                         <td
@@ -5741,15 +5943,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={1}
                                       textAlign="center"
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                         textAlign="center"
                                       >
                                         <td
@@ -5760,15 +5966,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={1}
                                       textAlign="justify"
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                         textAlign="justify"
                                       >
                                         <td
@@ -5779,14 +5989,18 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -5848,26 +6062,33 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -5877,15 +6098,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={2}
                                       textAlign="end"
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                         textAlign="end"
                                       >
                                         <td
@@ -5896,15 +6121,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={2}
                                       textAlign="center"
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                         textAlign="center"
                                       >
                                         <td
@@ -5915,15 +6144,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={2}
                                       textAlign="justify"
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                         textAlign="justify"
                                       >
                                         <td
@@ -5934,14 +6167,18 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -6003,26 +6240,33 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -6032,15 +6276,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={3}
                                       textAlign="end"
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                         textAlign="end"
                                       >
                                         <td
@@ -6051,15 +6299,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={3}
                                       textAlign="center"
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                         textAlign="center"
                                       >
                                         <td
@@ -6070,15 +6322,19 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={3}
                                       textAlign="justify"
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                         textAlign="justify"
                                       >
                                         <td
@@ -6089,14 +6345,18 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7086,26 +7346,33 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fresh Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fresh Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7115,14 +7382,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Veritable Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Veritable Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7132,14 +7403,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Good Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Good Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7149,14 +7424,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Delectable Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Delectable Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7166,14 +7445,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Powerful Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Powerful Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7232,26 +7515,33 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fresh Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fresh Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7261,14 +7551,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Veritable Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Veritable Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7278,14 +7572,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Good Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Good Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7295,14 +7593,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Delectable Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Delectable Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7312,14 +7614,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Powerful Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Powerful Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7378,26 +7684,33 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fresh Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fresh Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7407,14 +7720,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Veritable Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Veritable Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7424,14 +7741,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Good Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Good Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7441,14 +7762,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Delectable Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Delectable Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7458,14 +7783,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Powerful Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Powerful Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7524,26 +7853,33 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fresh Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fresh Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7553,14 +7889,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Veritable Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Veritable Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7570,14 +7910,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Good Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Good Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7587,14 +7931,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Delectable Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Delectable Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -7604,14 +7952,18 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Powerful Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Powerful Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -8677,26 +9029,33 @@ tr:hover > .emotion-35 {
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -8706,20 +9065,26 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
                                       render={[Function]}
+                                      rowIndex={0}
                                     >
                                       <CustomCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <Styled(td)
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           density="compact"
                                           element="td"
+                                          rowIndex={0}
                                         >
                                           <td
                                             className="emotion-35"
@@ -8810,14 +9175,18 @@ tr:hover > .emotion-35 {
                                       </CustomCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -8827,14 +9196,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -8844,14 +9217,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -8911,26 +9288,33 @@ tr:hover > .emotion-35 {
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -8940,20 +9324,26 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
                                       render={[Function]}
+                                      rowIndex={1}
                                     >
                                       <CustomCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <Styled(td)
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           density="compact"
                                           element="td"
+                                          rowIndex={1}
                                         >
                                           <td
                                             className="emotion-35"
@@ -9044,14 +9434,18 @@ tr:hover > .emotion-35 {
                                       </CustomCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9061,14 +9455,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9078,14 +9476,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9145,26 +9547,33 @@ tr:hover > .emotion-35 {
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9174,20 +9583,26 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
                                       render={[Function]}
+                                      rowIndex={2}
                                     >
                                       <CustomCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <Styled(td)
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           density="compact"
                                           element="td"
+                                          rowIndex={2}
                                         >
                                           <td
                                             className="emotion-35"
@@ -9278,14 +9693,18 @@ tr:hover > .emotion-35 {
                                       </CustomCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9295,14 +9714,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9312,14 +9735,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9379,26 +9806,33 @@ tr:hover > .emotion-35 {
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9408,20 +9842,26 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
                                       render={[Function]}
+                                      rowIndex={3}
                                     >
                                       <CustomCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <Styled(td)
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           density="compact"
                                           element="td"
+                                          rowIndex={3}
                                         >
                                           <td
                                             className="emotion-35"
@@ -9512,14 +9952,18 @@ tr:hover > .emotion-35 {
                                       </CustomCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9529,14 +9973,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -9546,14 +9994,18 @@ tr:hover > .emotion-35 {
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -10560,30 +11012,37 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-22"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       emoji="🍎"
                                       headerCell={[Function]}
                                       key="Fruits"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
                                         emoji="🍎"
                                         headerCell={[Function]}
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10593,18 +11052,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       emoji="🥗"
                                       headerCell={[Function]}
                                       key="Vegetables"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
                                         emoji="🥗"
                                         headerCell={[Function]}
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10614,18 +11077,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       emoji="🌾"
                                       headerCell={[Function]}
                                       key="Grains"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
                                         emoji="🌾"
                                         headerCell={[Function]}
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10635,18 +11102,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       emoji="🥚"
                                       headerCell={[Function]}
                                       key="Dairy"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
                                         emoji="🥚"
                                         headerCell={[Function]}
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10656,18 +11127,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       emoji="🍗"
                                       headerCell={[Function]}
                                       key="Protein"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
                                         emoji="🍗"
                                         headerCell={[Function]}
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10736,30 +11211,37 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-22"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       emoji="🍎"
                                       headerCell={[Function]}
                                       key="Fruits"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
                                         emoji="🍎"
                                         headerCell={[Function]}
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10769,18 +11251,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       emoji="🥗"
                                       headerCell={[Function]}
                                       key="Vegetables"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
                                         emoji="🥗"
                                         headerCell={[Function]}
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10790,18 +11276,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       emoji="🌾"
                                       headerCell={[Function]}
                                       key="Grains"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
                                         emoji="🌾"
                                         headerCell={[Function]}
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10811,18 +11301,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       emoji="🥚"
                                       headerCell={[Function]}
                                       key="Dairy"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
                                         emoji="🥚"
                                         headerCell={[Function]}
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10832,18 +11326,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       emoji="🍗"
                                       headerCell={[Function]}
                                       key="Protein"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
                                         emoji="🍗"
                                         headerCell={[Function]}
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10912,30 +11410,37 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <tr
                                     className="emotion-22"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       emoji="🍎"
                                       headerCell={[Function]}
                                       key="Fruits"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
                                         emoji="🍎"
                                         headerCell={[Function]}
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10945,18 +11450,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       emoji="🥗"
                                       headerCell={[Function]}
                                       key="Vegetables"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
                                         emoji="🥗"
                                         headerCell={[Function]}
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10966,18 +11475,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       emoji="🌾"
                                       headerCell={[Function]}
                                       key="Grains"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
                                         emoji="🌾"
                                         headerCell={[Function]}
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-24"
@@ -10987,18 +11500,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       emoji="🥚"
                                       headerCell={[Function]}
                                       key="Dairy"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
                                         emoji="🥚"
                                         headerCell={[Function]}
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-24"
@@ -11008,18 +11525,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       emoji="🍗"
                                       headerCell={[Function]}
                                       key="Protein"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
                                         emoji="🍗"
                                         headerCell={[Function]}
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-24"
@@ -11088,30 +11609,37 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-22"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       emoji="🍎"
                                       headerCell={[Function]}
                                       key="Fruits"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
                                         emoji="🍎"
                                         headerCell={[Function]}
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-24"
@@ -11121,18 +11649,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       emoji="🥗"
                                       headerCell={[Function]}
                                       key="Vegetables"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
                                         emoji="🥗"
                                         headerCell={[Function]}
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-24"
@@ -11142,18 +11674,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       emoji="🌾"
                                       headerCell={[Function]}
                                       key="Grains"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
                                         emoji="🌾"
                                         headerCell={[Function]}
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-24"
@@ -11163,18 +11699,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       emoji="🥚"
                                       headerCell={[Function]}
                                       key="Dairy"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
                                         emoji="🥚"
                                         headerCell={[Function]}
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-24"
@@ -11184,18 +11724,22 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       emoji="🍗"
                                       headerCell={[Function]}
                                       key="Protein"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
                                         emoji="🍗"
                                         headerCell={[Function]}
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-24"
@@ -12181,26 +12725,33 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12210,14 +12761,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12227,14 +12782,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12244,14 +12803,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12261,14 +12824,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12327,26 +12894,33 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12356,14 +12930,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12373,14 +12951,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12390,14 +12972,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12407,14 +12993,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12469,18 +13059,22 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
                                 render={[Function]}
+                                rowIndex={2}
                               >
                                 <CustomRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <Styled(tr)
                                     density="compact"
                                     isSelectable={false}
+                                    rowIndex={2}
                                   >
                                     <tr
                                       className="emotion-43"
@@ -12550,26 +13144,33 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12579,14 +13180,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12596,14 +13201,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12613,14 +13222,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12630,14 +13243,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12696,26 +13313,33 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={4}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={4}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={4}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       element="td"
                                       key="Fruits"
+                                      rowIndex={4}
                                     >
                                       <TableCell
+                                        columnKey="Fruits"
                                         content="Fruits"
                                         density="compact"
                                         element="td"
+                                        rowIndex={4}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12725,14 +13349,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       element="td"
                                       key="Vegetables"
+                                      rowIndex={4}
                                     >
                                       <TableCell
+                                        columnKey="Vegetables"
                                         content="Vegetables"
                                         density="compact"
                                         element="td"
+                                        rowIndex={4}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12742,14 +13370,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       element="td"
                                       key="Grains"
+                                      rowIndex={4}
                                     >
                                       <TableCell
+                                        columnKey="Grains"
                                         content="Grains"
                                         density="compact"
                                         element="td"
+                                        rowIndex={4}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12759,14 +13391,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       element="td"
                                       key="Dairy"
+                                      rowIndex={4}
                                     >
                                       <TableCell
+                                        columnKey="Dairy"
                                         content="Dairy"
                                         density="compact"
                                         element="td"
+                                        rowIndex={4}
                                       >
                                         <td
                                           className="emotion-29"
@@ -12776,14 +13412,18 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       element="td"
                                       key="Protein"
+                                      rowIndex={4}
                                     >
                                       <TableCell
+                                        columnKey="Protein"
                                         content="Protein"
                                         density="compact"
                                         element="td"
+                                        rowIndex={4}
                                       >
                                         <td
                                           className="emotion-29"
@@ -17412,28 +18052,35 @@ button:focus > .emotion-30 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={0}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={0}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={0}
                                     >
                                       <tr
                                         className="emotion-132"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Fruits"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17443,16 +18090,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Vegetables"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17462,16 +18113,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Grains"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17481,16 +18136,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Dairy"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17500,16 +18159,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Protein"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17573,28 +18236,35 @@ button:focus > .emotion-30 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={1}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={1}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={1}
                                     >
                                       <tr
                                         className="emotion-132"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Fruits"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17604,16 +18274,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Vegetables"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17623,16 +18297,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Grains"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17642,16 +18320,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Dairy"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17661,16 +18343,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Protein"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17734,28 +18420,35 @@ button:focus > .emotion-30 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={2}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={2}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={2}
                                     >
                                       <tr
                                         className="emotion-132"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Fruits"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17765,16 +18458,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Vegetables"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17784,16 +18481,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Grains"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17803,16 +18504,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Dairy"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17822,16 +18527,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Protein"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17895,28 +18604,35 @@ button:focus > .emotion-30 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={3}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={3}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={3}
                                     >
                                       <tr
                                         className="emotion-132"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Fruits"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17926,16 +18642,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Vegetables"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17945,16 +18665,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Grains"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17964,16 +18688,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Dairy"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-134"
@@ -17983,16 +18711,20 @@ button:focus > .emotion-30 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           headerCell={[Function]}
                                           key="Protein"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
                                             headerCell={[Function]}
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-134"
@@ -18959,26 +19691,33 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={0}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={0}
                             >
                               <TableRow
                                 density="spacious"
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -18988,14 +19727,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19005,14 +19748,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19022,14 +19769,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19039,14 +19790,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19105,26 +19860,33 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={1}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={1}
                             >
                               <TableRow
                                 density="spacious"
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19134,14 +19896,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19151,14 +19917,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19168,14 +19938,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19185,14 +19959,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19251,26 +20029,33 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={2}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={2}
                             >
                               <TableRow
                                 density="spacious"
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19280,14 +20065,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19297,14 +20086,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19314,14 +20107,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19331,14 +20128,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19397,26 +20198,33 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={3}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={3}
                             >
                               <TableRow
                                 density="spacious"
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19426,14 +20234,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19443,14 +20255,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19460,14 +20276,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -19477,14 +20297,18 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="spacious"
                                       element="td"
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20468,28 +21292,35 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={0}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={0}
                             >
                               <TableRow
                                 density="compact"
                                 highContrast={true}
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20499,15 +21330,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20517,15 +21352,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20535,15 +21374,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20553,15 +21396,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={0}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20620,28 +21467,35 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={1}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={1}
                             >
                               <TableRow
                                 density="compact"
                                 highContrast={true}
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20651,15 +21505,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20669,15 +21527,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20687,15 +21549,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20705,15 +21571,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={1}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20772,28 +21642,35 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={2}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={2}
                             >
                               <TableRow
                                 density="compact"
                                 highContrast={true}
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20803,15 +21680,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20821,15 +21702,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20839,15 +21724,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20857,15 +21746,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={2}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20924,28 +21817,35 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={3}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={3}
                             >
                               <TableRow
                                 density="compact"
                                 highContrast={true}
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20955,15 +21855,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20973,15 +21877,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -20991,15 +21899,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -21009,15 +21921,19 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
                                       highContrast={true}
+                                      rowIndex={3}
                                     >
                                       <td
                                         className="emotion-29"
@@ -22600,26 +23516,33 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={0}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={0}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={0}
                                         >
                                           <tr
                                             className="emotion-27"
                                           >
                                             <TableCell
+                                              columnKey="name"
                                               content="Mineral"
                                               element="td"
                                               key="name"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="name"
                                                 content="Mineral"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22629,14 +23552,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="color"
                                               content="Color"
                                               element="td"
                                               key="color"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="color"
                                                 content="Color"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22646,14 +23573,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="luster"
                                               content="Luster"
                                               element="td"
                                               key="luster"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="luster"
                                                 content="Luster"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22663,14 +23594,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalSystem"
                                               content="Crystal System"
                                               element="td"
                                               key="crystalSystem"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="crystalSystem"
                                                 content="Crystal System"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22680,14 +23615,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalHabit"
                                               content="Crystal Habit"
                                               element="td"
                                               key="crystalHabit"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="crystalHabit"
                                                 content="Crystal Habit"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22746,26 +23685,33 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={1}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={1}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={1}
                                         >
                                           <tr
                                             className="emotion-27"
                                           >
                                             <TableCell
+                                              columnKey="name"
                                               content="Mineral"
                                               element="td"
                                               key="name"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="name"
                                                 content="Mineral"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22775,14 +23721,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="color"
                                               content="Color"
                                               element="td"
                                               key="color"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="color"
                                                 content="Color"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22792,14 +23742,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="luster"
                                               content="Luster"
                                               element="td"
                                               key="luster"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="luster"
                                                 content="Luster"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22809,14 +23763,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalSystem"
                                               content="Crystal System"
                                               element="td"
                                               key="crystalSystem"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="crystalSystem"
                                                 content="Crystal System"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22826,14 +23784,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalHabit"
                                               content="Crystal Habit"
                                               element="td"
                                               key="crystalHabit"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="crystalHabit"
                                                 content="Crystal Habit"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22892,26 +23854,33 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={2}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={2}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={2}
                                         >
                                           <tr
                                             className="emotion-27"
                                           >
                                             <TableCell
+                                              columnKey="name"
                                               content="Mineral"
                                               element="td"
                                               key="name"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="name"
                                                 content="Mineral"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22921,14 +23890,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="color"
                                               content="Color"
                                               element="td"
                                               key="color"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="color"
                                                 content="Color"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22938,14 +23911,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="luster"
                                               content="Luster"
                                               element="td"
                                               key="luster"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="luster"
                                                 content="Luster"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22955,14 +23932,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalSystem"
                                               content="Crystal System"
                                               element="td"
                                               key="crystalSystem"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="crystalSystem"
                                                 content="Crystal System"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -22972,14 +23953,18 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="crystalHabit"
                                               content="Crystal Habit"
                                               element="td"
                                               key="crystalHabit"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="crystalHabit"
                                                 content="Crystal Habit"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-29"
@@ -24695,27 +25680,34 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={0}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={0}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={0}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruit"
                                       content="Fruit"
                                       element="td"
                                       key="Fruit"
                                       primary={true}
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Fruit"
                                         content="Fruit"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                         scope="row"
                                       >
                                         <th
@@ -24727,14 +25719,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Family"
                                       content="Family"
                                       element="td"
                                       key="Family"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Family"
                                         content="Family"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24744,14 +25740,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Etymology"
                                       content="Etymology"
                                       element="td"
                                       key="Etymology"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Etymology"
                                         content="Etymology"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24761,14 +25761,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Color"
                                       content="Color"
                                       element="td"
                                       key="Color"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Color"
                                         content="Color"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24778,14 +25782,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Taste"
                                       content="Taste"
                                       element="td"
                                       key="Taste"
+                                      rowIndex={0}
                                     >
                                       <TableCell
+                                        columnKey="Taste"
                                         content="Taste"
                                         density="compact"
                                         element="td"
+                                        rowIndex={0}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24845,27 +25853,34 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={1}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={1}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={1}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruit"
                                       content="Fruit"
                                       element="td"
                                       key="Fruit"
                                       primary={true}
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Fruit"
                                         content="Fruit"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                         scope="row"
                                       >
                                         <th
@@ -24877,14 +25892,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Family"
                                       content="Family"
                                       element="td"
                                       key="Family"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Family"
                                         content="Family"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24894,14 +25913,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Etymology"
                                       content="Etymology"
                                       element="td"
                                       key="Etymology"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Etymology"
                                         content="Etymology"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24911,14 +25934,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Color"
                                       content="Color"
                                       element="td"
                                       key="Color"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Color"
                                         content="Color"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24928,14 +25955,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Taste"
                                       content="Taste"
                                       element="td"
                                       key="Taste"
+                                      rowIndex={1}
                                     >
                                       <TableCell
+                                        columnKey="Taste"
                                         content="Taste"
                                         density="compact"
                                         element="td"
+                                        rowIndex={1}
                                       >
                                         <td
                                           className="emotion-29"
@@ -24995,27 +26026,34 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={2}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={2}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={2}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruit"
                                       content="Fruit"
                                       element="td"
                                       key="Fruit"
                                       primary={true}
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Fruit"
                                         content="Fruit"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                         scope="row"
                                       >
                                         <th
@@ -25027,14 +26065,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Family"
                                       content="Family"
                                       element="td"
                                       key="Family"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Family"
                                         content="Family"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25044,14 +26086,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Etymology"
                                       content="Etymology"
                                       element="td"
                                       key="Etymology"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Etymology"
                                         content="Etymology"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25061,14 +26107,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Color"
                                       content="Color"
                                       element="td"
                                       key="Color"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Color"
                                         content="Color"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25078,14 +26128,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Taste"
                                       content="Taste"
                                       element="td"
                                       key="Taste"
+                                      rowIndex={2}
                                     >
                                       <TableCell
+                                        columnKey="Taste"
                                         content="Taste"
                                         density="compact"
                                         element="td"
+                                        rowIndex={2}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25145,27 +26199,34 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                   "sortColumnDescending": "Sort column in descending order",
                                 }
                               }
+                              rowIndex={3}
                             >
                               <TableRow
                                 isSelectable={false}
+                                rowIndex={3}
                               >
                                 <TableRow
                                   density="compact"
                                   isSelectable={false}
+                                  rowIndex={3}
                                 >
                                   <tr
                                     className="emotion-27"
                                   >
                                     <TableCell
+                                      columnKey="Fruit"
                                       content="Fruit"
                                       element="td"
                                       key="Fruit"
                                       primary={true}
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Fruit"
                                         content="Fruit"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                         scope="row"
                                       >
                                         <th
@@ -25177,14 +26238,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Family"
                                       content="Family"
                                       element="td"
                                       key="Family"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Family"
                                         content="Family"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25194,14 +26259,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Etymology"
                                       content="Etymology"
                                       element="td"
                                       key="Etymology"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Etymology"
                                         content="Etymology"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25211,14 +26280,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Color"
                                       content="Color"
                                       element="td"
                                       key="Color"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Color"
                                         content="Color"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -25228,14 +26301,18 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                       </TableCell>
                                     </TableCell>
                                     <TableCell
+                                      columnKey="Taste"
                                       content="Taste"
                                       element="td"
                                       key="Taste"
+                                      rowIndex={3}
                                     >
                                       <TableCell
+                                        columnKey="Taste"
                                         content="Taste"
                                         density="compact"
                                         element="td"
+                                        rowIndex={3}
                                       >
                                         <td
                                           className="emotion-29"
@@ -27204,27 +28281,34 @@ button:focus > .emotion-4 {
                                             "sortColumnDescending": "ترتيب العمود في تنازلي الطلب",
                                           }
                                         }
+                                        rowIndex={0}
                                       >
                                         <TableRow
                                           isSelectable={false}
+                                          rowIndex={0}
                                         >
                                           <TableRow
                                             density="compact"
                                             isSelectable={false}
+                                            rowIndex={0}
                                           >
                                             <tr
                                               className="emotion-55"
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="ثمار"
                                                 element="td"
                                                 key="Fruits"
+                                                rowIndex={0}
                                                 sortable={true}
                                               >
                                                 <TableCell
+                                                  columnKey="Fruits"
                                                   content="ثمار"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={0}
                                                   sortable={true}
                                                 >
                                                   <td
@@ -27235,15 +28319,19 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="خضروات"
                                                 element="td"
                                                 key="Vegetables"
+                                                rowIndex={0}
                                                 textAlign="center"
                                               >
                                                 <TableCell
+                                                  columnKey="Vegetables"
                                                   content="خضروات"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={0}
                                                   textAlign="center"
                                                 >
                                                   <td
@@ -27254,14 +28342,18 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="بقوليات"
                                                 element="td"
                                                 key="Grains"
+                                                rowIndex={0}
                                               >
                                                 <TableCell
+                                                  columnKey="Grains"
                                                   content="بقوليات"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={0}
                                                 >
                                                   <td
                                                     className="emotion-57"
@@ -27271,16 +28363,20 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="الألبان"
                                                 element="td"
                                                 key="Dairy"
+                                                rowIndex={0}
                                                 sortable={true}
                                                 textAlign="end"
                                               >
                                                 <TableCell
+                                                  columnKey="Dairy"
                                                   content="الألبان"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={0}
                                                   sortable={true}
                                                   textAlign="end"
                                                 >
@@ -27292,14 +28388,18 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="بروتين"
                                                 element="td"
                                                 key="Protein"
+                                                rowIndex={0}
                                               >
                                                 <TableCell
+                                                  columnKey="Protein"
                                                   content="بروتين"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={0}
                                                 >
                                                   <td
                                                     className="emotion-57"
@@ -27362,27 +28462,34 @@ button:focus > .emotion-4 {
                                             "sortColumnDescending": "ترتيب العمود في تنازلي الطلب",
                                           }
                                         }
+                                        rowIndex={1}
                                       >
                                         <TableRow
                                           isSelectable={false}
+                                          rowIndex={1}
                                         >
                                           <TableRow
                                             density="compact"
                                             isSelectable={false}
+                                            rowIndex={1}
                                           >
                                             <tr
                                               className="emotion-55"
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="ثمار"
                                                 element="td"
                                                 key="Fruits"
+                                                rowIndex={1}
                                                 sortable={true}
                                               >
                                                 <TableCell
+                                                  columnKey="Fruits"
                                                   content="ثمار"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={1}
                                                   sortable={true}
                                                 >
                                                   <td
@@ -27393,15 +28500,19 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="خضروات"
                                                 element="td"
                                                 key="Vegetables"
+                                                rowIndex={1}
                                                 textAlign="center"
                                               >
                                                 <TableCell
+                                                  columnKey="Vegetables"
                                                   content="خضروات"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={1}
                                                   textAlign="center"
                                                 >
                                                   <td
@@ -27412,14 +28523,18 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="بقوليات"
                                                 element="td"
                                                 key="Grains"
+                                                rowIndex={1}
                                               >
                                                 <TableCell
+                                                  columnKey="Grains"
                                                   content="بقوليات"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={1}
                                                 >
                                                   <td
                                                     className="emotion-57"
@@ -27429,16 +28544,20 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="الألبان"
                                                 element="td"
                                                 key="Dairy"
+                                                rowIndex={1}
                                                 sortable={true}
                                                 textAlign="end"
                                               >
                                                 <TableCell
+                                                  columnKey="Dairy"
                                                   content="الألبان"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={1}
                                                   sortable={true}
                                                   textAlign="end"
                                                 >
@@ -27450,14 +28569,18 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="بروتين"
                                                 element="td"
                                                 key="Protein"
+                                                rowIndex={1}
                                               >
                                                 <TableCell
+                                                  columnKey="Protein"
                                                   content="بروتين"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={1}
                                                 >
                                                   <td
                                                     className="emotion-57"
@@ -27520,27 +28643,34 @@ button:focus > .emotion-4 {
                                             "sortColumnDescending": "ترتيب العمود في تنازلي الطلب",
                                           }
                                         }
+                                        rowIndex={2}
                                       >
                                         <TableRow
                                           isSelectable={false}
+                                          rowIndex={2}
                                         >
                                           <TableRow
                                             density="compact"
                                             isSelectable={false}
+                                            rowIndex={2}
                                           >
                                             <tr
                                               className="emotion-55"
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="ثمار"
                                                 element="td"
                                                 key="Fruits"
+                                                rowIndex={2}
                                                 sortable={true}
                                               >
                                                 <TableCell
+                                                  columnKey="Fruits"
                                                   content="ثمار"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={2}
                                                   sortable={true}
                                                 >
                                                   <td
@@ -27551,15 +28681,19 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="خضروات"
                                                 element="td"
                                                 key="Vegetables"
+                                                rowIndex={2}
                                                 textAlign="center"
                                               >
                                                 <TableCell
+                                                  columnKey="Vegetables"
                                                   content="خضروات"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={2}
                                                   textAlign="center"
                                                 >
                                                   <td
@@ -27570,14 +28704,18 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="بقوليات"
                                                 element="td"
                                                 key="Grains"
+                                                rowIndex={2}
                                               >
                                                 <TableCell
+                                                  columnKey="Grains"
                                                   content="بقوليات"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={2}
                                                 >
                                                   <td
                                                     className="emotion-57"
@@ -27587,16 +28725,20 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="الألبان"
                                                 element="td"
                                                 key="Dairy"
+                                                rowIndex={2}
                                                 sortable={true}
                                                 textAlign="end"
                                               >
                                                 <TableCell
+                                                  columnKey="Dairy"
                                                   content="الألبان"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={2}
                                                   sortable={true}
                                                   textAlign="end"
                                                 >
@@ -27608,14 +28750,18 @@ button:focus > .emotion-4 {
                                                 </TableCell>
                                               </TableCell>
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="بروتين"
                                                 element="td"
                                                 key="Protein"
+                                                rowIndex={2}
                                               >
                                                 <TableCell
+                                                  columnKey="Protein"
                                                   content="بروتين"
                                                   density="compact"
                                                   element="td"
+                                                  rowIndex={2}
                                                 >
                                                   <td
                                                     className="emotion-57"
@@ -28709,18 +29855,22 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={0}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={0}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={0}
                                     >
                                       <tr
                                         className="emotion-27"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content={
                                             <span>
                                               Fresh Fruits
@@ -28729,8 +29879,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Fruits"
                                           label="Fruits"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content={
                                               <span>
                                                 Fresh Fruits
@@ -28739,6 +29891,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Fruits"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28748,6 +29901,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content={
                                             <span>
                                               Veritable Vegetables
@@ -28756,8 +29910,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Vegetables"
                                           label="Vegetables"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content={
                                               <span>
                                                 Veritable Vegetables
@@ -28766,6 +29922,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Vegetables"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28775,6 +29932,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content={
                                             <span>
                                               Good Grains
@@ -28783,8 +29941,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Grains"
                                           label="Grains"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content={
                                               <span>
                                                 Good Grains
@@ -28793,6 +29953,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Grains"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28802,6 +29963,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content={
                                             <span>
                                               Delectable Dairy
@@ -28810,8 +29972,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Dairy"
                                           label="Dairy"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content={
                                               <span>
                                                 Delectable Dairy
@@ -28820,6 +29984,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Dairy"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28829,6 +29994,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content={
                                             <span>
                                               Powerful Protein
@@ -28837,8 +30003,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Protein"
                                           label="Protein"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content={
                                               <span>
                                                 Powerful Protein
@@ -28847,6 +30015,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Protein"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28920,18 +30089,22 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={1}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={1}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={1}
                                     >
                                       <tr
                                         className="emotion-27"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content={
                                             <span>
                                               Fresh Fruits
@@ -28940,8 +30113,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Fruits"
                                           label="Fruits"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content={
                                               <span>
                                                 Fresh Fruits
@@ -28950,6 +30125,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Fruits"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28959,6 +30135,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content={
                                             <span>
                                               Veritable Vegetables
@@ -28967,8 +30144,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Vegetables"
                                           label="Vegetables"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content={
                                               <span>
                                                 Veritable Vegetables
@@ -28977,6 +30156,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Vegetables"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-29"
@@ -28986,6 +30166,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content={
                                             <span>
                                               Good Grains
@@ -28994,8 +30175,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Grains"
                                           label="Grains"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content={
                                               <span>
                                                 Good Grains
@@ -29004,6 +30187,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Grains"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29013,6 +30197,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content={
                                             <span>
                                               Delectable Dairy
@@ -29021,8 +30206,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Dairy"
                                           label="Dairy"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content={
                                               <span>
                                                 Delectable Dairy
@@ -29031,6 +30218,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Dairy"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29040,6 +30228,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content={
                                             <span>
                                               Powerful Protein
@@ -29048,8 +30237,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Protein"
                                           label="Protein"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content={
                                               <span>
                                                 Powerful Protein
@@ -29058,6 +30249,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Protein"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29131,18 +30323,22 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={2}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={2}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={2}
                                     >
                                       <tr
                                         className="emotion-27"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content={
                                             <span>
                                               Fresh Fruits
@@ -29151,8 +30347,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Fruits"
                                           label="Fruits"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content={
                                               <span>
                                                 Fresh Fruits
@@ -29161,6 +30359,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Fruits"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29170,6 +30369,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content={
                                             <span>
                                               Veritable Vegetables
@@ -29178,8 +30378,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Vegetables"
                                           label="Vegetables"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content={
                                               <span>
                                                 Veritable Vegetables
@@ -29188,6 +30390,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Vegetables"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29197,6 +30400,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content={
                                             <span>
                                               Good Grains
@@ -29205,8 +30409,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Grains"
                                           label="Grains"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content={
                                               <span>
                                                 Good Grains
@@ -29215,6 +30421,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Grains"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29224,6 +30431,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content={
                                             <span>
                                               Delectable Dairy
@@ -29232,8 +30440,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Dairy"
                                           label="Dairy"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content={
                                               <span>
                                                 Delectable Dairy
@@ -29242,6 +30452,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Dairy"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29251,6 +30462,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content={
                                             <span>
                                               Powerful Protein
@@ -29259,8 +30471,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Protein"
                                           label="Protein"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content={
                                               <span>
                                                 Powerful Protein
@@ -29269,6 +30483,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Protein"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29342,18 +30557,22 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={3}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={3}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={3}
                                     >
                                       <tr
                                         className="emotion-27"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content={
                                             <span>
                                               Fresh Fruits
@@ -29362,8 +30581,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Fruits"
                                           label="Fruits"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content={
                                               <span>
                                                 Fresh Fruits
@@ -29372,6 +30593,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Fruits"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29381,6 +30603,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content={
                                             <span>
                                               Veritable Vegetables
@@ -29389,8 +30612,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Vegetables"
                                           label="Vegetables"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content={
                                               <span>
                                                 Veritable Vegetables
@@ -29399,6 +30624,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Vegetables"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29408,6 +30634,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content={
                                             <span>
                                               Good Grains
@@ -29416,8 +30643,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Grains"
                                           label="Grains"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content={
                                               <span>
                                                 Good Grains
@@ -29426,6 +30655,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Grains"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29435,6 +30665,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content={
                                             <span>
                                               Delectable Dairy
@@ -29443,8 +30674,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Dairy"
                                           label="Dairy"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content={
                                               <span>
                                                 Delectable Dairy
@@ -29453,6 +30686,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Dairy"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-29"
@@ -29462,6 +30696,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content={
                                             <span>
                                               Powerful Protein
@@ -29470,8 +30705,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                           element="td"
                                           key="Protein"
                                           label="Protein"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content={
                                               <span>
                                                 Powerful Protein
@@ -29480,6 +30717,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                             density="compact"
                                             element="td"
                                             label="Protein"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-29"
@@ -31340,16 +32578,19 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={0}
                                   toggle={[Function]}
                                 >
                                   <TableRow
                                     isSelectable={true}
                                     isSelected={false}
+                                    rowIndex={0}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={true}
                                       isSelected={false}
+                                      rowIndex={0}
                                     >
                                       <tr
                                         className="emotion-39"
@@ -31544,14 +32785,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableSelectableCell>
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31561,14 +32806,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31578,14 +32827,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31595,14 +32848,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31612,14 +32869,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31679,16 +32940,19 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={1}
                                   toggle={[Function]}
                                 >
                                   <TableRow
                                     isSelectable={true}
                                     isSelected={true}
+                                    rowIndex={1}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={true}
                                       isSelected={true}
+                                      rowIndex={1}
                                     >
                                       <tr
                                         className="emotion-68"
@@ -31883,14 +33147,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableSelectableCell>
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31900,14 +33168,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31917,14 +33189,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31934,14 +33210,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-49"
@@ -31951,14 +33231,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-49"
@@ -32019,16 +33303,19 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={2}
                                   toggle={[Function]}
                                 >
                                   <TableRow
                                     isSelectable={true}
                                     isSelected={false}
+                                    rowIndex={2}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={true}
                                       isSelected={false}
+                                      rowIndex={2}
                                     >
                                       <tr
                                         className="emotion-39"
@@ -32235,14 +33522,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableSelectableCell>
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-49"
@@ -32252,14 +33543,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-49"
@@ -32269,14 +33564,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-49"
@@ -32286,14 +33585,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-49"
@@ -32303,14 +33606,18 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-49"
@@ -34647,16 +35954,19 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={0}
                                       toggle={[Function]}
                                     >
                                       <TableRow
                                         isSelectable={true}
                                         isSelected={false}
+                                        rowIndex={0}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={true}
                                           isSelected={false}
+                                          rowIndex={0}
                                         >
                                           <tr
                                             className="emotion-60"
@@ -34851,14 +36161,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableSelectableCell>
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -34868,14 +36182,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -34885,14 +36203,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -34902,14 +36224,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -34919,14 +36245,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -34986,16 +36316,19 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={1}
                                       toggle={[Function]}
                                     >
                                       <TableRow
                                         isSelectable={true}
                                         isSelected={false}
+                                        rowIndex={1}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={true}
                                           isSelected={false}
+                                          rowIndex={1}
                                         >
                                           <tr
                                             className="emotion-60"
@@ -35190,14 +36523,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableSelectableCell>
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35207,14 +36544,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35224,14 +36565,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35241,14 +36586,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35258,14 +36607,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35325,16 +36678,19 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={2}
                                       toggle={[Function]}
                                     >
                                       <TableRow
                                         isSelectable={true}
                                         isSelected={false}
+                                        rowIndex={2}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={true}
                                           isSelected={false}
+                                          rowIndex={2}
                                         >
                                           <tr
                                             className="emotion-60"
@@ -35529,14 +36885,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableSelectableCell>
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35546,14 +36906,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35563,14 +36927,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35580,14 +36948,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35597,14 +36969,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35664,16 +37040,19 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={3}
                                       toggle={[Function]}
                                     >
                                       <TableRow
                                         isSelectable={true}
                                         isSelected={false}
+                                        rowIndex={3}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={true}
                                           isSelected={false}
+                                          rowIndex={3}
                                         >
                                           <tr
                                             className="emotion-60"
@@ -35868,14 +37247,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableSelectableCell>
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35885,14 +37268,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35902,14 +37289,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35919,14 +37310,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -35936,14 +37331,18 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-70"
@@ -38298,16 +39697,19 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                               "sortColumnDescending": "Sort column in descending order",
                                             }
                                           }
+                                          rowIndex={0}
                                           toggle={[Function]}
                                         >
                                           <TableRow
                                             isSelectable={true}
                                             isSelected={false}
+                                            rowIndex={0}
                                           >
                                             <TableRow
                                               density="compact"
                                               isSelectable={true}
                                               isSelected={false}
+                                              rowIndex={0}
                                             >
                                               <tr
                                                 className="emotion-39"
@@ -38502,14 +39904,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableSelectableCell>
                                                 <TableCell
+                                                  columnKey="name"
                                                   content="Mineral"
                                                   element="td"
                                                   key="name"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="name"
                                                     content="Mineral"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38519,14 +39925,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="color"
                                                   content="Color"
                                                   element="td"
                                                   key="color"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="color"
                                                     content="Color"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38536,14 +39946,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="luster"
                                                   content="Luster"
                                                   element="td"
                                                   key="luster"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="luster"
                                                     content="Luster"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38553,14 +39967,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalSystem"
                                                   content="Crystal System"
                                                   element="td"
                                                   key="crystalSystem"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalSystem"
                                                     content="Crystal System"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38570,14 +39988,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalHabit"
                                                   content="Crystal Habit"
                                                   element="td"
                                                   key="crystalHabit"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalHabit"
                                                     content="Crystal Habit"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38637,16 +40059,19 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                               "sortColumnDescending": "Sort column in descending order",
                                             }
                                           }
+                                          rowIndex={1}
                                           toggle={[Function]}
                                         >
                                           <TableRow
                                             isSelectable={true}
                                             isSelected={false}
+                                            rowIndex={1}
                                           >
                                             <TableRow
                                               density="compact"
                                               isSelectable={true}
                                               isSelected={false}
+                                              rowIndex={1}
                                             >
                                               <tr
                                                 className="emotion-39"
@@ -38841,14 +40266,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableSelectableCell>
                                                 <TableCell
+                                                  columnKey="name"
                                                   content="Mineral"
                                                   element="td"
                                                   key="name"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="name"
                                                     content="Mineral"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38858,14 +40287,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="color"
                                                   content="Color"
                                                   element="td"
                                                   key="color"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="color"
                                                     content="Color"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38875,14 +40308,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="luster"
                                                   content="Luster"
                                                   element="td"
                                                   key="luster"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="luster"
                                                     content="Luster"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38892,14 +40329,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalSystem"
                                                   content="Crystal System"
                                                   element="td"
                                                   key="crystalSystem"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalSystem"
                                                     content="Crystal System"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38909,14 +40350,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalHabit"
                                                   content="Crystal Habit"
                                                   element="td"
                                                   key="crystalHabit"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalHabit"
                                                     content="Crystal Habit"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -38976,16 +40421,19 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                               "sortColumnDescending": "Sort column in descending order",
                                             }
                                           }
+                                          rowIndex={2}
                                           toggle={[Function]}
                                         >
                                           <TableRow
                                             isSelectable={true}
                                             isSelected={false}
+                                            rowIndex={2}
                                           >
                                             <TableRow
                                               density="compact"
                                               isSelectable={true}
                                               isSelected={false}
+                                              rowIndex={2}
                                             >
                                               <tr
                                                 className="emotion-39"
@@ -39180,14 +40628,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableSelectableCell>
                                                 <TableCell
+                                                  columnKey="name"
                                                   content="Mineral"
                                                   element="td"
                                                   key="name"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="name"
                                                     content="Mineral"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -39197,14 +40649,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="color"
                                                   content="Color"
                                                   element="td"
                                                   key="color"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="color"
                                                     content="Color"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -39214,14 +40670,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="luster"
                                                   content="Luster"
                                                   element="td"
                                                   key="luster"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="luster"
                                                     content="Luster"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -39231,14 +40691,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalSystem"
                                                   content="Crystal System"
                                                   element="td"
                                                   key="crystalSystem"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalSystem"
                                                     content="Crystal System"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -39248,14 +40712,18 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalHabit"
                                                   content="Crystal Habit"
                                                   element="td"
                                                   key="crystalHabit"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalHabit"
                                                     content="Crystal Habit"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-49"
@@ -42326,26 +43794,33 @@ button:focus > .emotion-23 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={0}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={0}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={0}
                                     >
                                       <tr
                                         className="emotion-83"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42355,14 +43830,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42372,14 +43851,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={0}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42389,15 +43872,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={0}
                                           sortComparator={[Function]}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                             sortComparator={[Function]}
                                           >
                                             <td
@@ -42408,15 +43895,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={0}
                                           sortable={false}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={0}
                                             sortable={false}
                                           >
                                             <td
@@ -42478,26 +43969,33 @@ button:focus > .emotion-23 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={1}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={1}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={1}
                                     >
                                       <tr
                                         className="emotion-83"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42507,14 +44005,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42524,14 +44026,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={1}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42541,15 +44047,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={1}
                                           sortComparator={[Function]}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                             sortComparator={[Function]}
                                           >
                                             <td
@@ -42560,15 +44070,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={1}
                                           sortable={false}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={1}
                                             sortable={false}
                                           >
                                             <td
@@ -42630,26 +44144,33 @@ button:focus > .emotion-23 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={2}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={2}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={2}
                                     >
                                       <tr
                                         className="emotion-83"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42659,14 +44180,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42676,14 +44201,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={2}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42693,15 +44222,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={2}
                                           sortComparator={[Function]}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                             sortComparator={[Function]}
                                           >
                                             <td
@@ -42712,15 +44245,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={2}
                                           sortable={false}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={2}
                                             sortable={false}
                                           >
                                             <td
@@ -42782,26 +44319,33 @@ button:focus > .emotion-23 {
                                       "sortColumnDescending": "Sort column in descending order",
                                     }
                                   }
+                                  rowIndex={3}
                                 >
                                   <TableRow
                                     isSelectable={false}
+                                    rowIndex={3}
                                   >
                                     <TableRow
                                       density="compact"
                                       isSelectable={false}
+                                      rowIndex={3}
                                     >
                                       <tr
                                         className="emotion-83"
                                       >
                                         <TableCell
+                                          columnKey="Fruits"
                                           content="Fruits"
                                           element="td"
                                           key="Fruits"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Fruits"
                                             content="Fruits"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42811,14 +44355,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Vegetables"
                                           content="Vegetables"
                                           element="td"
                                           key="Vegetables"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Vegetables"
                                             content="Vegetables"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42828,14 +44376,18 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Grains"
                                           content="Grains"
                                           element="td"
                                           key="Grains"
+                                          rowIndex={3}
                                         >
                                           <TableCell
+                                            columnKey="Grains"
                                             content="Grains"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                           >
                                             <td
                                               className="emotion-85"
@@ -42845,15 +44397,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Dairy"
                                           content="Dairy"
                                           element="td"
                                           key="Dairy"
+                                          rowIndex={3}
                                           sortComparator={[Function]}
                                         >
                                           <TableCell
+                                            columnKey="Dairy"
                                             content="Dairy"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                             sortComparator={[Function]}
                                           >
                                             <td
@@ -42864,15 +44420,19 @@ button:focus > .emotion-23 {
                                           </TableCell>
                                         </TableCell>
                                         <TableCell
+                                          columnKey="Protein"
                                           content="Protein"
                                           element="td"
                                           key="Protein"
+                                          rowIndex={3}
                                           sortable={false}
                                         >
                                           <TableCell
+                                            columnKey="Protein"
                                             content="Protein"
                                             density="compact"
                                             element="td"
+                                            rowIndex={3}
                                             sortable={false}
                                           >
                                             <td
@@ -45888,26 +47448,33 @@ button:focus > .emotion-44 {
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={0}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={0}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={0}
                                         >
                                           <tr
                                             className="emotion-118"
                                           >
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -45917,14 +47484,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -45934,14 +47505,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -45951,14 +47526,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -45968,14 +47547,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={0}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={0}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46034,26 +47617,33 @@ button:focus > .emotion-44 {
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={1}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={1}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={1}
                                         >
                                           <tr
                                             className="emotion-118"
                                           >
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46063,14 +47653,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46080,14 +47674,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46097,14 +47695,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46114,14 +47716,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={1}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={1}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46180,26 +47786,33 @@ button:focus > .emotion-44 {
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={2}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={2}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={2}
                                         >
                                           <tr
                                             className="emotion-118"
                                           >
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46209,14 +47822,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46226,14 +47843,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46243,14 +47864,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46260,14 +47885,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={2}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={2}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46326,26 +47955,33 @@ button:focus > .emotion-44 {
                                           "sortColumnDescending": "Sort column in descending order",
                                         }
                                       }
+                                      rowIndex={3}
                                     >
                                       <TableRow
                                         isSelectable={false}
+                                        rowIndex={3}
                                       >
                                         <TableRow
                                           density="compact"
                                           isSelectable={false}
+                                          rowIndex={3}
                                         >
                                           <tr
                                             className="emotion-118"
                                           >
                                             <TableCell
+                                              columnKey="Fruits"
                                               content="Fruits"
                                               element="td"
                                               key="Fruits"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Fruits"
                                                 content="Fruits"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46355,14 +47991,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Vegetables"
                                               content="Vegetables"
                                               element="td"
                                               key="Vegetables"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Vegetables"
                                                 content="Vegetables"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46372,14 +48012,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Grains"
                                               content="Grains"
                                               element="td"
                                               key="Grains"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Grains"
                                                 content="Grains"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46389,14 +48033,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Dairy"
                                               content="Dairy"
                                               element="td"
                                               key="Dairy"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Dairy"
                                                 content="Dairy"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -46406,14 +48054,18 @@ button:focus > .emotion-44 {
                                               </TableCell>
                                             </TableCell>
                                             <TableCell
+                                              columnKey="Protein"
                                               content="Protein"
                                               element="td"
                                               key="Protein"
+                                              rowIndex={3}
                                             >
                                               <TableCell
+                                                columnKey="Protein"
                                                 content="Protein"
                                                 density="compact"
                                                 element="td"
+                                                rowIndex={3}
                                               >
                                                 <td
                                                   className="emotion-120"
@@ -49399,26 +51051,33 @@ button:focus > .emotion-23 {
                                               "sortColumnDescending": "Sort column in descending order",
                                             }
                                           }
+                                          rowIndex={0}
                                         >
                                           <TableRow
                                             isSelectable={false}
+                                            rowIndex={0}
                                           >
                                             <TableRow
                                               density="compact"
                                               isSelectable={false}
+                                              rowIndex={0}
                                             >
                                               <tr
                                                 className="emotion-97"
                                               >
                                                 <TableCell
+                                                  columnKey="name"
                                                   content="Mineral"
                                                   element="td"
                                                   key="name"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="name"
                                                     content="Mineral"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49428,14 +51087,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="color"
                                                   content="Color"
                                                   element="td"
                                                   key="color"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="color"
                                                     content="Color"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49445,14 +51108,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="luster"
                                                   content="Luster"
                                                   element="td"
                                                   key="luster"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="luster"
                                                     content="Luster"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49462,14 +51129,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalSystem"
                                                   content="Crystal System"
                                                   element="td"
                                                   key="crystalSystem"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalSystem"
                                                     content="Crystal System"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49479,14 +51150,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalHabit"
                                                   content="Crystal Habit"
                                                   element="td"
                                                   key="crystalHabit"
+                                                  rowIndex={0}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalHabit"
                                                     content="Crystal Habit"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={0}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49545,26 +51220,33 @@ button:focus > .emotion-23 {
                                               "sortColumnDescending": "Sort column in descending order",
                                             }
                                           }
+                                          rowIndex={1}
                                         >
                                           <TableRow
                                             isSelectable={false}
+                                            rowIndex={1}
                                           >
                                             <TableRow
                                               density="compact"
                                               isSelectable={false}
+                                              rowIndex={1}
                                             >
                                               <tr
                                                 className="emotion-97"
                                               >
                                                 <TableCell
+                                                  columnKey="name"
                                                   content="Mineral"
                                                   element="td"
                                                   key="name"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="name"
                                                     content="Mineral"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49574,14 +51256,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="color"
                                                   content="Color"
                                                   element="td"
                                                   key="color"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="color"
                                                     content="Color"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49591,14 +51277,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="luster"
                                                   content="Luster"
                                                   element="td"
                                                   key="luster"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="luster"
                                                     content="Luster"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49608,14 +51298,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalSystem"
                                                   content="Crystal System"
                                                   element="td"
                                                   key="crystalSystem"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalSystem"
                                                     content="Crystal System"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49625,14 +51319,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalHabit"
                                                   content="Crystal Habit"
                                                   element="td"
                                                   key="crystalHabit"
+                                                  rowIndex={1}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalHabit"
                                                     content="Crystal Habit"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={1}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49691,26 +51389,33 @@ button:focus > .emotion-23 {
                                               "sortColumnDescending": "Sort column in descending order",
                                             }
                                           }
+                                          rowIndex={2}
                                         >
                                           <TableRow
                                             isSelectable={false}
+                                            rowIndex={2}
                                           >
                                             <TableRow
                                               density="compact"
                                               isSelectable={false}
+                                              rowIndex={2}
                                             >
                                               <tr
                                                 className="emotion-97"
                                               >
                                                 <TableCell
+                                                  columnKey="name"
                                                   content="Mineral"
                                                   element="td"
                                                   key="name"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="name"
                                                     content="Mineral"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49720,14 +51425,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="color"
                                                   content="Color"
                                                   element="td"
                                                   key="color"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="color"
                                                     content="Color"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49737,14 +51446,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="luster"
                                                   content="Luster"
                                                   element="td"
                                                   key="luster"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="luster"
                                                     content="Luster"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49754,14 +51467,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalSystem"
                                                   content="Crystal System"
                                                   element="td"
                                                   key="crystalSystem"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalSystem"
                                                     content="Crystal System"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -49771,14 +51488,18 @@ button:focus > .emotion-23 {
                                                   </TableCell>
                                                 </TableCell>
                                                 <TableCell
+                                                  columnKey="crystalHabit"
                                                   content="Crystal Habit"
                                                   element="td"
                                                   key="crystalHabit"
+                                                  rowIndex={2}
                                                 >
                                                   <TableCell
+                                                    columnKey="crystalHabit"
                                                     content="Crystal Habit"
                                                     density="compact"
                                                     element="td"
+                                                    rowIndex={2}
                                                   >
                                                     <td
                                                       className="emotion-99"
@@ -51488,27 +53209,34 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={0}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={0}
                             >
                               <TableRow
                                 density="compact"
                                 isSelectable={false}
+                                rowIndex={0}
                                 striped={true}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
+                                      rowIndex={0}
                                       striped={true}
                                     >
                                       <td
@@ -51519,14 +53247,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
+                                      rowIndex={0}
                                       striped={true}
                                     >
                                       <td
@@ -51537,14 +53269,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
+                                      rowIndex={0}
                                       striped={true}
                                     >
                                       <td
@@ -51555,14 +53291,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
+                                      rowIndex={0}
                                       striped={true}
                                     >
                                       <td
@@ -51573,14 +53313,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={0}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
+                                      rowIndex={0}
                                       striped={true}
                                     >
                                       <td
@@ -51640,27 +53384,34 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={1}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={1}
                             >
                               <TableRow
                                 density="compact"
                                 isSelectable={false}
+                                rowIndex={1}
                                 striped={true}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
+                                      rowIndex={1}
                                       striped={true}
                                     >
                                       <td
@@ -51671,14 +53422,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
+                                      rowIndex={1}
                                       striped={true}
                                     >
                                       <td
@@ -51689,14 +53444,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
+                                      rowIndex={1}
                                       striped={true}
                                     >
                                       <td
@@ -51707,14 +53466,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
+                                      rowIndex={1}
                                       striped={true}
                                     >
                                       <td
@@ -51725,14 +53488,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={1}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
+                                      rowIndex={1}
                                       striped={true}
                                     >
                                       <td
@@ -51792,27 +53559,34 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={2}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={2}
                             >
                               <TableRow
                                 density="compact"
                                 isSelectable={false}
+                                rowIndex={2}
                                 striped={true}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
+                                      rowIndex={2}
                                       striped={true}
                                     >
                                       <td
@@ -51823,14 +53597,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
+                                      rowIndex={2}
                                       striped={true}
                                     >
                                       <td
@@ -51841,14 +53619,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
+                                      rowIndex={2}
                                       striped={true}
                                     >
                                       <td
@@ -51859,14 +53641,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
+                                      rowIndex={2}
                                       striped={true}
                                     >
                                       <td
@@ -51877,14 +53663,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={2}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
+                                      rowIndex={2}
                                       striped={true}
                                     >
                                       <td
@@ -51944,27 +53734,34 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                 "sortColumnDescending": "Sort column in descending order",
                               }
                             }
+                            rowIndex={3}
                           >
                             <TableRow
                               isSelectable={false}
+                              rowIndex={3}
                             >
                               <TableRow
                                 density="compact"
                                 isSelectable={false}
+                                rowIndex={3}
                                 striped={true}
                               >
                                 <tr
                                   className="emotion-27"
                                 >
                                   <TableCell
+                                    columnKey="Fruits"
                                     content="Fruits"
                                     element="td"
                                     key="Fruits"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Fruits"
                                       content="Fruits"
                                       density="compact"
                                       element="td"
+                                      rowIndex={3}
                                       striped={true}
                                     >
                                       <td
@@ -51975,14 +53772,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Vegetables"
                                     content="Vegetables"
                                     element="td"
                                     key="Vegetables"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Vegetables"
                                       content="Vegetables"
                                       density="compact"
                                       element="td"
+                                      rowIndex={3}
                                       striped={true}
                                     >
                                       <td
@@ -51993,14 +53794,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Grains"
                                     content="Grains"
                                     element="td"
                                     key="Grains"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Grains"
                                       content="Grains"
                                       density="compact"
                                       element="td"
+                                      rowIndex={3}
                                       striped={true}
                                     >
                                       <td
@@ -52011,14 +53816,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Dairy"
                                     content="Dairy"
                                     element="td"
                                     key="Dairy"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Dairy"
                                       content="Dairy"
                                       density="compact"
                                       element="td"
+                                      rowIndex={3}
                                       striped={true}
                                     >
                                       <td
@@ -52029,14 +53838,18 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                     </TableCell>
                                   </TableCell>
                                   <TableCell
+                                    columnKey="Protein"
                                     content="Protein"
                                     element="td"
                                     key="Protein"
+                                    rowIndex={3}
                                   >
                                     <TableCell
+                                      columnKey="Protein"
                                       content="Protein"
                                       density="compact"
                                       element="td"
+                                      rowIndex={3}
                                       striped={true}
                                     >
                                       <td
@@ -53555,26 +55368,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={0}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={0}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={0}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53584,14 +55404,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53601,14 +55425,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53618,14 +55446,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53635,14 +55467,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53701,26 +55537,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={1}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={1}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={1}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53730,14 +55573,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53747,14 +55594,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53764,14 +55615,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53781,14 +55636,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53847,26 +55706,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={2}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={2}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={2}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53876,14 +55742,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53893,14 +55763,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53910,14 +55784,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53927,14 +55805,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -53993,26 +55875,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={3}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={3}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={3}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -54022,14 +55911,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -54039,14 +55932,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -54056,14 +55953,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -54073,14 +55974,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55036,26 +56941,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={0}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={0}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={0}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55065,14 +56977,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55082,14 +56998,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55099,14 +57019,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55116,14 +57040,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={0}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={0}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55182,26 +57110,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={1}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={1}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={1}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55211,14 +57146,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55228,14 +57167,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55245,14 +57188,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55262,14 +57209,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={1}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={1}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55328,26 +57279,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={2}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={2}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={2}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55357,14 +57315,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55374,14 +57336,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55391,14 +57357,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55408,14 +57378,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={2}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={2}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55474,26 +57448,33 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                     "sortColumnDescending": "Sort column in descending order",
                                                                   }
                                                                 }
+                                                                rowIndex={3}
                                                               >
                                                                 <TableRow
                                                                   isSelectable={false}
+                                                                  rowIndex={3}
                                                                 >
                                                                   <TableRow
                                                                     density="compact"
                                                                     isSelectable={false}
+                                                                    rowIndex={3}
                                                                   >
                                                                     <tr
                                                                       className="emotion-27"
                                                                     >
                                                                       <TableCell
+                                                                        columnKey="Fruits"
                                                                         content="Fruits"
                                                                         element="td"
                                                                         key="Fruits"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Fruits"
                                                                           content="Fruits"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55503,14 +57484,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Vegetables"
                                                                         content="Vegetables"
                                                                         element="td"
                                                                         key="Vegetables"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Vegetables"
                                                                           content="Vegetables"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55520,14 +57505,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Grains"
                                                                         content="Grains"
                                                                         element="td"
                                                                         key="Grains"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Grains"
                                                                           content="Grains"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55537,14 +57526,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Dairy"
                                                                         content="Dairy"
                                                                         element="td"
                                                                         key="Dairy"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Dairy"
                                                                           content="Dairy"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55554,14 +57547,18 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                         </TableCell>
                                                                       </TableCell>
                                                                       <TableCell
+                                                                        columnKey="Protein"
                                                                         content="Protein"
                                                                         element="td"
                                                                         key="Protein"
+                                                                        rowIndex={3}
                                                                       >
                                                                         <TableCell
+                                                                          columnKey="Protein"
                                                                           content="Protein"
                                                                           density="compact"
                                                                           element="td"
+                                                                          rowIndex={3}
                                                                         >
                                                                           <td
                                                                             className="emotion-29"
@@ -55623,10 +57620,12 @@ Array [
   Object {
     "props": Object {
       "children": "aa0",
+      "columnKey": "aa",
       "content": "AA",
       "density": "compact",
       "element": "td",
       "highContrast": undefined,
+      "rowIndex": 0,
       "striped": undefined,
     },
   },
@@ -55714,8 +57713,10 @@ Array [
     "props": Object {
       "children": Array [
         <TableCell
+          columnKey="aa"
           content="AA"
           element="td"
+          rowIndex={0}
         >
           aa0
         </TableCell>,
@@ -55724,6 +57725,7 @@ Array [
       "highContrast": undefined,
       "isSelectable": false,
       "isSelected": undefined,
+      "rowIndex": 0,
       "striped": undefined,
     },
   },


### PR DESCRIPTION
### Description

Provides `columnKey` and `rowIndex` to table cells.  Gives user a way to access other data in row, e.g. previous and next cells.

### Motivation and context

This feature has been requested by users for use with custom cell renderers.

Is it sufficient to provide `rowIndex` and `columnKey` or do we need to provide `rowData`?  Here, we provide the indexes instead of a data object in order to attempt to avoid unnecessary cell re-renders when any row data is changed.   With the current solution, there is no danger of unnecessary re-rendering and the `rowIndex` and `columnKey` can be used to look up information in the main data source.

### Screenshots, videos, or demo, if appropriate

https://table-row-index--mineral-ui.netlify.com/components/table/

### How to test

1. Go to the [custom cell](https://table-row-index--mineral-ui.netlify.com/components/table/custom-cell) example.
2. Add the following block to the render method `CustomCell` class.
```js
const { columnKey: currentKey, rowIndex } = this.props;
const columnKeys = columns.map(column => column.key);
const currentIndex = columnKeys.indexOf(currentKey);
const currentValue = data[rowIndex][currentKey];
const prevKey = columnKeys[currentIndex - 1];
const prevValue = data[rowIndex][prevKey];
const nextKey = columnKeys[currentIndex + 1];
const nextValue = data[rowIndex][nextKey];
console.log({ prevValue, currentValue, nextValue });   
```
3. Note that you can use the new props to access the previous and next data in the row.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add " - **[n/a]**" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **existing snapshots**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
