### PR TITLE
[Perf] Transform Component PropTypes

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -62,19 +62,16 @@ module.exports = {
     if (isProduction) {
       plugins.push(
         'babel-plugin-transform-react-constant-elements',
-        'babel-plugin-transform-react-inline-elements'
+        'babel-plugin-transform-react-inline-elements',
+        ['transform-react-remove-prop-types', {
+          mode: 'wrap',
+          ignoreFilenames: ['node_modules'],
+          'plugins': [
+            ['babel-plugin-flow-react-proptypes', { 'omitRuntimeTypeExport': true }],
+            'babel-plugin-transform-flow-strip-types'
+          ]
+        }]
       );
-
-      if (TARGET === 'website') {
-        plugins.push(
-          ['transform-react-remove-prop-types', {
-            'plugins': [
-              ['babel-plugin-flow-react-proptypes', { 'omitRuntimeTypeExport': true }],
-              'babel-plugin-transform-flow-strip-types'
-            ]
-          }]
-        );
-      }
     }
 
     return plugins;


### PR DESCRIPTION
### Description

Enable component prop-types to be removed in user apps during production mode minification

### Motivation and context

I noticed that Mineral prop-types were still in code when using CRA in production mode.

We were previously applying [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) only to the website as we want to ship prop-types for components.  Using the plugins `wrap` option however, we can apply this to the components as well.  This wraps the prop-type definitions in a process.env.NODE_ENV check, enabling their continued use by users in development, but stripping them out in production, during minification, thus resulting in smaller bundles.

### Screenshots, videos, or demo, if appropriate

https://transform-proptypes--mineral-ui.netlify.com/

### How to test

1. Checkout the `transform-proptypes` branch 
-------
Development
1. Start the app - `npm start`
1. Visit Button size example and change the size to something invalid
1. Note the propTypes error in the console
1. In dev tools, or in the locally built static files, in some of the minified files, e.g. `0.js`, search for `.propTypes =` and note that the value is being set to a non-empty object.  (You can do this test in CRA too)

<details>
  <summary>Here is an example, showing Button's propTypes</summary>
  <pre>
    w.propTypes = {
        children: function() {
            return ("function" === typeof React$Node ? f.default.instanceOf(React$Node) : f.default.any).apply(this, arguments)
        },
        circular: f.default.bool,
        disabled: f.default.bool,
        element: function() {
            return ("function" === typeof $FlowFixMe ? f.default.instanceOf($FlowFixMe) : f.default.any).apply(this, arguments)
        },
        fullWidth: f.default.bool,
        iconEnd: function() {
            return ("function" === typeof React$Element ? f.default.instanceOf(React$Element) : f.default.any).apply(this, arguments)
        },
        iconStart: function() {
            return ("function" === typeof React$Element ? f.default.instanceOf(React$Element) : f.default.any).apply(this, arguments)
        },
        minimal: f.default.bool,
        onClick: f.default.func,
        primary: f.default.bool,
        size: f.default.oneOf(["small", "medium", "large", "jumbo"]),
        type: f.default.string,
        variant: f.default.oneOf(["danger", "success", "warning"])
    },
</pre>
</details>

-------
Production
1. Start the app - `NODE_ENV=production npm start`
1. Visit Button size example and change the size to something invalid
1. Note NO propTypes error in the console
1. In dev tools, or in the locally built static files, in some of the minified files, e.g. `0.js`, search for `.propTypes =` and note that the value is being set to an empty object.  (You can do this test in CRA too)
-------
In CRA,  I also compared file sizes of the production build.

`import * as mineral from 'mineral-ui'`

Before: 126.98 KB
After: 121.96 KB (-5.03 KB)

### Types of changes

- Other (provide details below)

Update babel config to apply prop-type transform to components.

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)- **[n/a]**
* [x] Automated tests written and passing- **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered- **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
