### PR TITLE
Fix error when importing from package index

### DIFF
--- a/src/library/index.js
+++ b/src/library/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+export { default as Dropdown } from './Dropdown';
 export { default as Avatar } from './Avatar';
 export { default as Box } from './Box';
 export { default as Button } from './Button';
@@ -23,7 +24,6 @@ export {
   DialogHeader,
   DialogTitle
 } from './Dialog';
-export { default as Dropdown } from './Dropdown';
 export { default as Flex, FlexItem } from './Flex';
 export { FormField, FormFieldset, FormFieldDivider } from './Form';
 export { default as Grid, GridItem } from './Grid';


### PR DESCRIPTION
### Description

Fix error when importing from package index.

It looks like this is some sort of dependency resolution order issue.  This probably isn't a great solution, but rather a quick fix for the immediate problem.  I'll continue to do some more investigation in/after the `ez-grok` work.

### Motivation and context

Closes #791 

### Screenshots, videos, or demo, if appropriate

https://791-import-error--mineral-ui.netlify.com/

### How to test

1. Checkout the `791-import-error` branch
1. Build local mineral-ui package and import it in latest CRA
1. Add `import * as mineral from 'mineral-ui';  console.log(mineral);` to App.js
1. View App in production mode (`npm run build && serve -s build`) and ensure that there are no console errors.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **existing coverage**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
