### PR TITLE
Component display names

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
     "plugin:flowtype/recommended",
     "prettier",
     "prettier/flowtype",
-    "prettier/react",
+    "prettier/react"
   ],
   "parser": "babel-eslint",
   "parserOptions": {
@@ -41,6 +41,7 @@
       "allow": ["warn", "error"]
     }],
     "no-unused-vars": ["error", {"vars": "all", "varsIgnorePattern": "[Ii]gnore"}],
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "react/display-name": ["error", { "ignoreTranspilerName": true }]
   }
 }

--- a/src/library/Avatar/Avatar.js
+++ b/src/library/Avatar/Avatar.js
@@ -7,6 +7,8 @@ import { avatarPropTypes } from './propTypes';
 import type { AvatarDefaultProps, AvatarProps } from './types';
 
 export default class Avatar extends Component<AvatarProps> {
+  static displayName = 'Avatar';
+
   static defaultProps: AvatarDefaultProps = {
     shape: SHAPE.circle,
     size: SIZE.large

--- a/src/library/Box/Box.js
+++ b/src/library/Box/Box.js
@@ -7,6 +7,8 @@ import { boxPropTypes } from './propTypes';
 import type { BoxDefaultProps, BoxProps } from './types';
 
 export default class Box extends Component<BoxProps> {
+  static displayName = 'Box';
+
   static defaultProps: BoxDefaultProps = {
     element: 'div'
   };

--- a/src/library/Button/__tests__/Button.spec.js
+++ b/src/library/Button/__tests__/Button.spec.js
@@ -16,9 +16,8 @@ function shallowButton(props = {}) {
   return shallow(<Button {...buttonProps} />);
 }
 
-function NonFilteringLink(props = {}) {
-  return <a {...props}>Do Something</a>;
-}
+// eslint-disable-next-line react/display-name
+const NonFilteringLink = (props) => <a {...props}>Do Something</a>;
 
 const mountButton = (props = {}) => {
   const buttonProps = {

--- a/src/library/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/library/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -7250,7 +7250,7 @@ exports[`Button type prop is filtered when type=[button type] when element=NonFi
     text="Do Something"
     type="button"
   >
-    <Button
+    <NonFilteringLink
       className="emotion-0"
       onClick={[MockFunction]}
       size="large"
@@ -7262,7 +7262,7 @@ exports[`Button type prop is filtered when type=[button type] when element=NonFi
       >
         Do Something
       </a>
-    </Button>
+    </NonFilteringLink>
   </Button>
 </Button>
 `;
@@ -7683,7 +7683,7 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=Non
     text="Do Something"
     type="video"
   >
-    <Button
+    <NonFilteringLink
       className="emotion-0"
       onClick={[MockFunction]}
       size="large"
@@ -7697,7 +7697,7 @@ exports[`Button type prop is not filtered when type=[MIME type] when element=Non
       >
         Do Something
       </a>
-    </Button>
+    </NonFilteringLink>
   </Button>
 </Button>
 `;

--- a/src/library/ButtonGroup/ButtonGroup.js
+++ b/src/library/ButtonGroup/ButtonGroup.js
@@ -16,7 +16,7 @@ import type { ButtonGroupProps, ButtonGroupState } from './types';
 // production, as long as it is set statically on each component
 // https://github.com/facebook/react/issues/4915#issuecomment-335803765
 const isButtonComponent = (element: React$Element<*>) => {
-  return /Button/.test(element.type.displayName);
+  return element.type && /Button/.test(element.type.displayName);
 };
 
 const isItemAtIndexChecked = (

--- a/src/library/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/library/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -747,7 +747,7 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                         placement="bottom"
                         tag="span"
                       >
-                        <Popover
+                        <Manager
                           className="emotion-8"
                           data-index={1}
                           id="tooltip-19"
@@ -777,7 +777,7 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                               <PopoverTrigger
                                 component="span"
                               >
-                                <PopoverTrigger
+                                <Target
                                   className="emotion-6"
                                   component="span"
                                 >
@@ -846,11 +846,11 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                                       </Button>
                                     </Button>
                                   </span>
-                                </PopoverTrigger>
+                                </Target>
                               </PopoverTrigger>
                             </PopoverTrigger>
                           </span>
-                        </Popover>
+                        </Manager>
                       </Popover>
                     </Popover>
                   </ThemeProvider>
@@ -876,7 +876,7 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
               placement="bottom"
               tag="span"
             >
-              <Popover
+              <Manager
                 className="emotion-8"
                 data-index={2}
                 onClick={[Function]}
@@ -901,7 +901,7 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                     <PopoverTrigger
                       component="span"
                     >
-                      <PopoverTrigger
+                      <Target
                         className="emotion-6"
                         component="span"
                       >
@@ -961,11 +961,11 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                             </Button>
                           </Button>
                         </span>
-                      </PopoverTrigger>
+                      </Target>
                     </PopoverTrigger>
                   </PopoverTrigger>
                 </span>
-              </Popover>
+              </Manager>
             </Popover>
           </Popover>
           <Dropdown
@@ -1024,7 +1024,7 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                 tag="span"
                 triggerRef={[Function]}
               >
-                <Popover
+                <Manager
                   className="emotion-8"
                   data-index={3}
                   id="dropdown-21"
@@ -1055,7 +1055,7 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                       <PopoverTrigger
                         component="span"
                       >
-                        <PopoverTrigger
+                        <Target
                           className="emotion-6"
                           component="span"
                         >
@@ -1157,11 +1157,11 @@ exports[`ButtonGroup demo examples Snapshots: composition 1`] = `
                               </Button>
                             </Button>
                           </span>
-                        </PopoverTrigger>
+                        </Target>
                       </PopoverTrigger>
                     </PopoverTrigger>
                   </span>
-                </Popover>
+                </Manager>
               </Popover>
             </Popover>
           </Dropdown>

--- a/src/library/Card/Card.js
+++ b/src/library/Card/Card.js
@@ -23,4 +23,5 @@ export default function Card(props: CardProps) {
   return <Root {...rootProps} />;
 }
 
+Card.displayName = 'Card';
 Card.propTypes = cardPropTypes;

--- a/src/library/Card/CardActions.js
+++ b/src/library/Card/CardActions.js
@@ -19,4 +19,5 @@ export default function CardActions(props: CardActionsProps) {
   return <Root {...restProps}>{actions}</Root>;
 }
 
+CardActions.displayName = 'CardActions';
 CardActions.propTypes = cardActionsPropTypes;

--- a/src/library/Card/CardBlock.js
+++ b/src/library/Card/CardBlock.js
@@ -15,4 +15,5 @@ export default function CardBlock(props: CardBlockProps) {
   );
 }
 
+CardBlock.displayName = 'CardBlock';
 CardBlock.propTypes = cardBlockPropTypes;

--- a/src/library/Card/CardDivider.js
+++ b/src/library/Card/CardDivider.js
@@ -9,4 +9,5 @@ export default function CardDivider(props: CardDividerProps) {
   return <Root {...props} role="separator" />;
 }
 
+CardDivider.displayName = 'CardDivider';
 CardDivider.propTypes = cardDividerPropTypes;

--- a/src/library/Card/CardFooter.js
+++ b/src/library/Card/CardFooter.js
@@ -21,6 +21,8 @@ export default class CardFooter extends Component<
   CardFooterProps,
   CardFooterState
 > {
+  static displayName = 'CardFooter';
+
   static defaultProps: CardFooterDefaultProps = {
     triggerTitle: (isOpen: boolean) =>
       isOpen ? 'Collapse contents' : 'Expand contents'

--- a/src/library/Card/CardImage.js
+++ b/src/library/Card/CardImage.js
@@ -9,4 +9,5 @@ export default function CardImage(props: CardImageProps) {
   return <Root {...props} />;
 }
 
+CardImage.displayName = 'CardImage';
 CardImage.propTypes = cardImagePropTypes;

--- a/src/library/Card/CardStatus.js
+++ b/src/library/Card/CardStatus.js
@@ -30,4 +30,5 @@ export default function CardStatus(props: CardStatusProps) {
   );
 }
 
+CardStatus.displayName = 'CardStatus';
 CardStatus.propTypes = cardStatusPropTypes;

--- a/src/library/Card/CardTitle.js
+++ b/src/library/Card/CardTitle.js
@@ -59,4 +59,5 @@ export default function CardTitle(props: CardTitleProps) {
   );
 }
 
+CardTitle.displayName = 'CardTitle';
 CardTitle.propTypes = cardTitlePropTypes;

--- a/src/library/Card/CardTitleMenu.js
+++ b/src/library/Card/CardTitleMenu.js
@@ -26,6 +26,7 @@ const CardTitleMenu = (props: CardTitleMenuProps) => {
   );
 };
 
+CardTitleMenu.displayName = 'CardTitleMenu';
 const defaultProps: CardTitleMenuDefaultProps = {
   triggerTitle: 'Card actions'
 };

--- a/src/library/Card/__tests__/__snapshots__/CardTitle.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/CardTitle.spec.js.snap
@@ -424,7 +424,7 @@ exports[`CardTitle demo examples Snapshots: actions-menu 1`] = `
                                   tag="span"
                                   triggerRef={[Function]}
                                 >
-                                  <Popover
+                                  <Manager
                                     className="emotion-8"
                                     id="dropdown-1"
                                     tag="span"
@@ -456,7 +456,7 @@ exports[`CardTitle demo examples Snapshots: actions-menu 1`] = `
                                         <PopoverTrigger
                                           component="span"
                                         >
-                                          <PopoverTrigger
+                                          <Target
                                             className="emotion-6"
                                             component="span"
                                           >
@@ -585,11 +585,11 @@ exports[`CardTitle demo examples Snapshots: actions-menu 1`] = `
                                                 </Button>
                                               </Styled(Button)>
                                             </span>
-                                          </PopoverTrigger>
+                                          </Target>
                                         </PopoverTrigger>
                                       </PopoverTrigger>
                                     </span>
-                                  </Popover>
+                                  </Manager>
                                 </Popover>
                               </Popover>
                             </Dropdown>

--- a/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/library/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -4723,7 +4723,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="small"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -4819,7 +4819,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -5008,7 +5008,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="medium"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -5104,7 +5104,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -5293,7 +5293,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -5389,7 +5389,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -5578,7 +5578,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="jumbo"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -5674,7 +5674,7 @@ exports[`Checkbox demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button

--- a/src/library/Choice/Choice.js
+++ b/src/library/Choice/Choice.js
@@ -6,6 +6,8 @@ import { ChoiceRoot as Root, Control, Input, Text } from './styled';
 import type { ChoiceDefaultProps, ChoiceProps } from './types';
 
 export default class Choice extends PureComponent<ChoiceProps> {
+  static displayName = 'Choice';
+
   static defaultProps: ChoiceDefaultProps = {
     labelPosition: LABEL_POSITION.end,
     size: SIZE.large

--- a/src/library/Choice/ChoiceGroup.js
+++ b/src/library/Choice/ChoiceGroup.js
@@ -72,6 +72,7 @@ const defaultProps: ChoiceGroupDefaultProps = {
   size: SIZE.large
 };
 
+ChoiceGroup.displayName = 'ChoiceGroup';
 ChoiceGroup.defaultProps = defaultProps;
 
 export default ChoiceGroup;

--- a/src/library/Dialog/Dialog.js
+++ b/src/library/Dialog/Dialog.js
@@ -43,6 +43,8 @@ const Animation = withTheme(({ children, theme, ...restProps }: Object) => {
 });
 
 export default class Dialog extends Component<DialogProps, DialogState> {
+  static displayName = 'Dialog';
+
   static defaultProps: DialogDefaultProps = {
     closeButtonLabel: 'close',
     closeOnClickOutside: true,

--- a/src/library/Dialog/DialogActions.js
+++ b/src/library/Dialog/DialogActions.js
@@ -33,6 +33,7 @@ const DialogActions = (props: DialogActionsProps) => {
   return <Root {...rootProps}>{actions}</Root>;
 };
 
+DialogActions.displayName = 'DialogActions';
 DialogActions.propTypes = dialogActionsPropTypes;
 
 export default DialogActions;

--- a/src/library/Dialog/DialogBody.js
+++ b/src/library/Dialog/DialogBody.js
@@ -10,6 +10,8 @@ import { dialogBodyPropTypes } from './propTypes';
 import type { DialogBodyProps } from './types';
 
 export default class DialogBody extends Component<DialogBodyProps> {
+  static displayName = 'DialogBody';
+
   static propTypes = dialogBodyPropTypes;
 
   render() {

--- a/src/library/Dialog/DialogFooter.js
+++ b/src/library/Dialog/DialogFooter.js
@@ -7,6 +7,7 @@ import type { DialogFooterProps } from './types';
 
 const DialogFooter = (props: DialogFooterProps) => <Root {...props} />;
 
+DialogFooter.displayName = 'DialogFooter';
 DialogFooter.propTypes = dialogFooterPropTypes;
 
 export default DialogFooter;

--- a/src/library/Dialog/DialogHeader.js
+++ b/src/library/Dialog/DialogHeader.js
@@ -26,6 +26,7 @@ const DialogHeader = (props: DialogHeaderProps) => {
   );
 };
 
+DialogHeader.displayName = 'DialogHeader';
 DialogHeader.propTypes = dialogHeaderPropTypes;
 
 export default DialogHeader;

--- a/src/library/Dialog/DialogRow.js
+++ b/src/library/Dialog/DialogRow.js
@@ -6,6 +6,8 @@ import { createDialogRowRootNode } from './styled';
 import type { DialogRowDefaultProps, DialogRowProps } from './types';
 
 export default class DialogRow extends Component<DialogRowProps> {
+  static displayName = 'DialogRow';
+
   static defaultProps: DialogRowDefaultProps = {
     element: 'div'
   };

--- a/src/library/Dialog/DialogTitle.js
+++ b/src/library/Dialog/DialogTitle.js
@@ -29,6 +29,7 @@ const DialogTitle = ({
     ...restProps
   };
 
+  // eslint-disable-next-line react/display-name
   const TitleContent = (props) => <DialogTitleTitle id={id} {...props} />;
 
   const title = textWithThemeOverrides({
@@ -56,6 +57,7 @@ const defaultProps: DialogTitleDefaultProps = {
   element: ELEMENT.h1
 };
 
+DialogTitle.displayName = 'DialogTitle';
 DialogTitle.defaultProps = defaultProps;
 DialogTitle.propTypes = dialogTitlePropTypes;
 

--- a/src/library/Dialog/__tests__/__snapshots__/Dialog.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/Dialog.spec.js.snap
@@ -823,7 +823,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
         title="Lorem ipsum dolor sit amet"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           actions={
             Array [
               Object {
@@ -941,7 +941,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -1016,7 +1016,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -1024,7 +1024,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-30"
                                           element="div"
                                         >
@@ -1066,7 +1066,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-20"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -1151,7 +1151,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                                                                             }
                                                                                             size="large"
                                                                                           >
-                                                                                            <TextInput
+                                                                                            <WithTheme(Themed(FauxControl))
                                                                                               className="emotion-14"
                                                                                               control={[Function]}
                                                                                               controlProps={
@@ -1249,7 +1249,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                                                                                   </ThemeProvider>
                                                                                                 </ThemeProvider>
                                                                                               </Themed(FauxControl)>
-                                                                                            </TextInput>
+                                                                                            </WithTheme(Themed(FauxControl))>
                                                                                           </TextInput>
                                                                                         </TextInput>
                                                                                       </label>
@@ -1273,7 +1273,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -1286,7 +1286,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                     <DialogFooter>
@@ -1294,7 +1294,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                         <DialogFooter
                                           element="footer"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-40"
                                             element="footer"
                                           >
@@ -1396,7 +1396,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
                                                 </DialogActions>
                                               </footer>
                                             </Styled(footer)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogFooter>
                                       </withProps(DialogFooter)>
                                     </DialogFooter>
@@ -1413,7 +1413,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
               </mockConstructor>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -2025,7 +2025,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-36"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -2125,7 +2125,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -2200,7 +2200,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -2208,7 +2208,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-21"
                                           element="div"
                                         >
@@ -2250,7 +2250,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-11"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -2318,7 +2318,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -2331,7 +2331,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                     <DialogFooter>
@@ -2339,7 +2339,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                         <DialogFooter
                                           element="footer"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-31"
                                             element="footer"
                                           >
@@ -2436,7 +2436,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
                                                 </DialogActions>
                                               </footer>
                                             </Styled(footer)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogFooter>
                                       </withProps(DialogFooter)>
                                     </DialogFooter>
@@ -2453,7 +2453,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
               </mockConstructor>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -3088,7 +3088,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
         title="Lorem ipsum dolor sit amet"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           actions={
             Array [
               Object {
@@ -3202,7 +3202,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -3277,7 +3277,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -3285,7 +3285,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-21"
                                           element="div"
                                         >
@@ -3327,7 +3327,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-11"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -3396,7 +3396,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -3409,7 +3409,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                     <DialogFooter>
@@ -3417,7 +3417,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                         <DialogFooter
                                           element="footer"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-31"
                                             element="footer"
                                           >
@@ -3514,7 +3514,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
                                                 </DialogActions>
                                               </footer>
                                             </Styled(footer)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogFooter>
                                       </withProps(DialogFooter)>
                                     </DialogFooter>
@@ -3531,7 +3531,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
               </mockConstructor>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -4261,7 +4261,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
         title="Lorem ipsum dolor sit amet"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           actions={
             Array [
               Object {
@@ -4383,7 +4383,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-14"
                                             element="header"
                                           >
@@ -4465,7 +4465,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                                     minimal={true}
                                                     size="small"
                                                   >
-                                                    <CloseButton
+                                                    <WithTheme(Themed(Button))
                                                       aria-label="close"
                                                       className="emotion-9"
                                                       iconStart={<IconClose />}
@@ -4547,12 +4547,12 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(Button)>
-                                                    </CloseButton>
+                                                    </WithTheme(Themed(Button))>
                                                   </CloseButton>
                                                 </withProps(CloseButton)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -4560,7 +4560,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-28"
                                           element="div"
                                         >
@@ -4602,7 +4602,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-18"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -4671,7 +4671,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -4684,7 +4684,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                     <DialogFooter>
@@ -4692,7 +4692,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                         <DialogFooter
                                           element="footer"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-38"
                                             element="footer"
                                           >
@@ -4789,7 +4789,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
                                                 </DialogActions>
                                               </footer>
                                             </Styled(footer)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogFooter>
                                       </withProps(DialogFooter)>
                                     </DialogFooter>
@@ -4806,7 +4806,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
               </mockConstructor>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -5446,7 +5446,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
               title="الأحكام والشروط"
               usePortal={false}
             >
-              <DemoDialog
+              <Dialog
                 actions={
                   Array [
                     Object {
@@ -5560,7 +5560,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                               <DialogHeader
                                                 element="header"
                                               >
-                                                <DialogHeader
+                                                <DialogRow
                                                   className="emotion-7"
                                                   element="header"
                                                 >
@@ -5635,7 +5635,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                                       </WithTheme(DialogTitle)>
                                                     </header>
                                                   </Styled(header)>
-                                                </DialogHeader>
+                                                </DialogRow>
                                               </DialogHeader>
                                             </withProps(DialogHeader)>
                                           </DialogHeader>
@@ -5643,7 +5643,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                             <DialogBody
                                               element="div"
                                             >
-                                              <DialogHeader
+                                              <DialogRow
                                                 className="emotion-21"
                                                 element="div"
                                               >
@@ -5685,7 +5685,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                                                         onScroll={[Function]}
                                                                         scrollY={true}
                                                                       >
-                                                                        <Scroller
+                                                                        <WithTheme(Themed(OverflowContainer))
                                                                           className="emotion-11"
                                                                           containerRef={[Function]}
                                                                           onScroll={[Function]}
@@ -5754,7 +5754,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                                                               </ThemeProvider>
                                                                             </ThemeProvider>
                                                                           </Themed(OverflowContainer)>
-                                                                        </Scroller>
+                                                                        </WithTheme(Themed(OverflowContainer))>
                                                                       </Scroller>
                                                                     </div>
                                                                   </OverflowContainerWithShadows>
@@ -5767,7 +5767,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                                     </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                                   </div>
                                                 </Styled(div)>
-                                              </DialogHeader>
+                                              </DialogRow>
                                             </DialogBody>
                                           </DialogBody>
                                           <DialogFooter>
@@ -5775,7 +5775,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                               <DialogFooter
                                                 element="footer"
                                               >
-                                                <DialogHeader
+                                                <DialogRow
                                                   className="emotion-31"
                                                   element="footer"
                                                 >
@@ -5872,7 +5872,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                                                       </DialogActions>
                                                     </footer>
                                                   </Styled(footer)>
-                                                </DialogHeader>
+                                                </DialogRow>
                                               </DialogFooter>
                                             </withProps(DialogFooter)>
                                           </DialogFooter>
@@ -5889,7 +5889,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
                     </mockConstructor>
                   </Component>
                 </WithTheme(Component)>
-              </DemoDialog>
+              </Dialog>
             </DemoDialog>
           </withProps(DemoDialog)>
         </div>
@@ -6765,7 +6765,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
           title="Lorem ipsum dolor sit amet"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -6879,7 +6879,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -6954,7 +6954,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -6962,7 +6962,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -7004,7 +7004,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -7073,7 +7073,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -7086,7 +7086,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -7094,7 +7094,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-31"
                                               element="footer"
                                             >
@@ -7191,7 +7191,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -7208,7 +7208,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -7255,7 +7255,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
           title="Lorem ipsum dolor sit amet"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -7369,7 +7369,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -7444,7 +7444,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -7452,7 +7452,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -7494,7 +7494,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -7563,7 +7563,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -7576,7 +7576,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -7584,7 +7584,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-31"
                                               element="footer"
                                             >
@@ -7681,7 +7681,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -7698,7 +7698,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -7745,7 +7745,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
           title="Lorem ipsum dolor sit amet"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -7859,7 +7859,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -7934,7 +7934,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -7942,7 +7942,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -7984,7 +7984,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -8053,7 +8053,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -8066,7 +8066,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -8074,7 +8074,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-31"
                                               element="footer"
                                             >
@@ -8171,7 +8171,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -8188,7 +8188,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -8847,7 +8847,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
           }
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -8972,7 +8972,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -9053,7 +9053,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -9061,7 +9061,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -9103,7 +9103,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -9172,7 +9172,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -9185,7 +9185,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -9193,7 +9193,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-31"
                                               element="footer"
                                             >
@@ -9290,7 +9290,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -9307,7 +9307,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -9482,7 +9482,7 @@ exports[`Dialog demo examples Snapshots: trigger 1`] = `
           </button>
         </Button>
       </Button>
-      <DemoDialog
+      <Dialog
         actions={
           Array [
             Object {
@@ -9506,7 +9506,7 @@ exports[`Dialog demo examples Snapshots: trigger 1`] = `
         usePortal={true}
       >
         <Portal />
-      </DemoDialog>
+      </Dialog>
     </div>
   </Demo>
 </Component>
@@ -10349,7 +10349,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
           usePortal={false}
           variant="success"
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -10465,7 +10465,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-8"
                                               element="header"
                                             >
@@ -10574,7 +10574,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -10582,7 +10582,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-22"
                                             element="div"
                                           >
@@ -10624,7 +10624,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-12"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -10693,7 +10693,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -10706,7 +10706,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -10714,7 +10714,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-32"
                                               element="footer"
                                             >
@@ -10815,7 +10815,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -10832,7 +10832,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -10880,7 +10880,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
           usePortal={false}
           variant="warning"
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -10996,7 +10996,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-8"
                                               element="header"
                                             >
@@ -11105,7 +11105,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -11113,7 +11113,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-22"
                                             element="div"
                                           >
@@ -11155,7 +11155,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-12"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -11224,7 +11224,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -11237,7 +11237,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -11245,7 +11245,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-32"
                                               element="footer"
                                             >
@@ -11346,7 +11346,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -11363,7 +11363,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -11411,7 +11411,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
           usePortal={false}
           variant="danger"
         >
-          <DemoDialog
+          <Dialog
             actions={
               Array [
                 Object {
@@ -11527,7 +11527,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-8"
                                               element="header"
                                             >
@@ -11636,7 +11636,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -11644,7 +11644,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-22"
                                             element="div"
                                           >
@@ -11686,7 +11686,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-12"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -11755,7 +11755,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -11768,7 +11768,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                       <DialogFooter>
@@ -11776,7 +11776,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                           <DialogFooter
                                             element="footer"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-32"
                                               element="footer"
                                             >
@@ -11877,7 +11877,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                                                   </DialogActions>
                                                 </footer>
                                               </Styled(footer)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogFooter>
                                         </withProps(DialogFooter)>
                                       </DialogFooter>
@@ -11894,7 +11894,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
                 </mockConstructor>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>

--- a/src/library/Dialog/__tests__/__snapshots__/DialogActions.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogActions.spec.js.snap
@@ -558,7 +558,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-32"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -663,7 +663,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -738,7 +738,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -746,7 +746,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-27"
                                           element="div"
                                         >
@@ -788,7 +788,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-17"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -922,7 +922,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -935,7 +935,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -951,7 +951,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -1683,7 +1683,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
           size="medium"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             className="emotion-32"
             closeButtonLabel="close"
             closeOnClickOutside={false}
@@ -1788,7 +1788,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -1863,7 +1863,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -1871,7 +1871,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-27"
                                             element="div"
                                           >
@@ -1913,7 +1913,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-17"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -2050,7 +2050,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -2063,7 +2063,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                     </div>
@@ -2079,7 +2079,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                 </Transition>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -2102,7 +2102,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
           size="medium"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             className="emotion-32"
             closeButtonLabel="close"
             closeOnClickOutside={false}
@@ -2207,7 +2207,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -2282,7 +2282,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -2290,7 +2290,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-27"
                                             element="div"
                                           >
@@ -2332,7 +2332,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-17"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -2469,7 +2469,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -2482,7 +2482,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                     </div>
@@ -2498,7 +2498,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                 </Transition>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -2521,7 +2521,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
           size="medium"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             className="emotion-32"
             closeButtonLabel="close"
             closeOnClickOutside={false}
@@ -2626,7 +2626,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-7"
                                               element="header"
                                             >
@@ -2701,7 +2701,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -2709,7 +2709,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-27"
                                             element="div"
                                           >
@@ -2751,7 +2751,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-17"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -2888,7 +2888,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -2901,7 +2901,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                     </div>
@@ -2917,7 +2917,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
                 </Transition>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>

--- a/src/library/Dialog/__tests__/__snapshots__/DialogBody.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogBody.spec.js.snap
@@ -366,7 +366,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-26"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -471,7 +471,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -546,7 +546,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -554,7 +554,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-21"
                                           element="div"
                                         >
@@ -596,7 +596,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-11"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -664,7 +664,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -677,7 +677,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -693,7 +693,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -1047,7 +1047,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-25"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -1152,7 +1152,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -1227,7 +1227,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -1235,7 +1235,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-20"
                                           element="div"
                                         >
@@ -1277,7 +1277,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-10"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -1355,7 +1355,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -1368,7 +1368,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -1384,7 +1384,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>

--- a/src/library/Dialog/__tests__/__snapshots__/DialogFooter.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogFooter.spec.js.snap
@@ -586,7 +586,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-35"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -691,7 +691,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -766,7 +766,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -774,7 +774,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-20"
                                           element="div"
                                         >
@@ -816,7 +816,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-10"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -864,7 +864,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -877,7 +877,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                     <DialogFooter>
@@ -885,7 +885,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                         <DialogFooter
                                           element="footer"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-30"
                                             element="footer"
                                           >
@@ -982,7 +982,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
                                                 </DialogActions>
                                               </footer>
                                             </Styled(footer)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogFooter>
                                       </withProps(DialogFooter)>
                                     </DialogFooter>
@@ -999,7 +999,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>

--- a/src/library/Dialog/__tests__/__snapshots__/DialogHeader.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogHeader.spec.js.snap
@@ -347,7 +347,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-25"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -452,7 +452,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -527,7 +527,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -535,7 +535,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-20"
                                           element="div"
                                         >
@@ -577,7 +577,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-10"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -625,7 +625,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -638,7 +638,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -654,7 +654,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -1117,7 +1117,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-28"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -1232,7 +1232,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-10"
                                             element="header"
                                           >
@@ -1368,7 +1368,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
                                                 </Button>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -1376,7 +1376,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-23"
                                           element="div"
                                         >
@@ -1418,7 +1418,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-13"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -1466,7 +1466,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -1479,7 +1479,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -1495,7 +1495,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>

--- a/src/library/Dialog/__tests__/__snapshots__/DialogTitle.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogTitle.spec.js.snap
@@ -347,7 +347,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-25"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -452,7 +452,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -527,7 +527,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -535,7 +535,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-20"
                                           element="div"
                                         >
@@ -577,7 +577,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-10"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -625,7 +625,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -638,7 +638,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -654,7 +654,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -1008,7 +1008,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
         size="medium"
         usePortal={false}
       >
-        <DemoDialog
+        <Dialog
           className="emotion-25"
           closeButtonLabel="close"
           closeOnClickOutside={false}
@@ -1113,7 +1113,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
                                         <DialogHeader
                                           element="header"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-7"
                                             element="header"
                                           >
@@ -1190,7 +1190,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
                                                 </WithTheme(DialogTitle)>
                                               </header>
                                             </Styled(header)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogHeader>
                                       </withProps(DialogHeader)>
                                     </DialogHeader>
@@ -1198,7 +1198,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
                                       <DialogBody
                                         element="div"
                                       >
-                                        <DialogHeader
+                                        <DialogRow
                                           className="emotion-20"
                                           element="div"
                                         >
@@ -1240,7 +1240,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
                                                                   onScroll={[Function]}
                                                                   scrollY={true}
                                                                 >
-                                                                  <Scroller
+                                                                  <WithTheme(Themed(OverflowContainer))
                                                                     className="emotion-10"
                                                                     containerRef={[Function]}
                                                                     onScroll={[Function]}
@@ -1288,7 +1288,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
                                                                         </ThemeProvider>
                                                                       </ThemeProvider>
                                                                     </Themed(OverflowContainer)>
-                                                                  </Scroller>
+                                                                  </WithTheme(Themed(OverflowContainer))>
                                                                 </Scroller>
                                                               </div>
                                                             </OverflowContainerWithShadows>
@@ -1301,7 +1301,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
                                               </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                             </div>
                                           </Styled(div)>
-                                        </DialogHeader>
+                                        </DialogRow>
                                       </DialogBody>
                                     </DialogBody>
                                   </div>
@@ -1317,7 +1317,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
               </Transition>
             </Component>
           </WithTheme(Component)>
-        </DemoDialog>
+        </Dialog>
       </DemoDialog>
     </withProps(DemoDialog)>
   </div>
@@ -1714,7 +1714,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
           size="medium"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             className="emotion-26"
             closeButtonLabel="close"
             closeOnClickOutside={false}
@@ -1819,7 +1819,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-8"
                                               element="header"
                                             >
@@ -1928,7 +1928,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -1936,7 +1936,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -1978,7 +1978,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -2026,7 +2026,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -2039,7 +2039,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                     </div>
@@ -2055,7 +2055,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                 </Transition>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -2078,7 +2078,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
           size="medium"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             className="emotion-26"
             closeButtonLabel="close"
             closeOnClickOutside={false}
@@ -2183,7 +2183,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-8"
                                               element="header"
                                             >
@@ -2292,7 +2292,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -2300,7 +2300,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -2342,7 +2342,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -2390,7 +2390,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -2403,7 +2403,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                     </div>
@@ -2419,7 +2419,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                 </Transition>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>
@@ -2442,7 +2442,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
           size="medium"
           usePortal={false}
         >
-          <DemoDialog
+          <Dialog
             className="emotion-26"
             closeButtonLabel="close"
             closeOnClickOutside={false}
@@ -2547,7 +2547,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                           <DialogHeader
                                             element="header"
                                           >
-                                            <DialogHeader
+                                            <DialogRow
                                               className="emotion-8"
                                               element="header"
                                             >
@@ -2656,7 +2656,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                   </WithTheme(DialogTitle)>
                                                 </header>
                                               </Styled(header)>
-                                            </DialogHeader>
+                                            </DialogRow>
                                           </DialogHeader>
                                         </withProps(DialogHeader)>
                                       </DialogHeader>
@@ -2664,7 +2664,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                         <DialogBody
                                           element="div"
                                         >
-                                          <DialogHeader
+                                          <DialogRow
                                             className="emotion-21"
                                             element="div"
                                           >
@@ -2706,7 +2706,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                                     onScroll={[Function]}
                                                                     scrollY={true}
                                                                   >
-                                                                    <Scroller
+                                                                    <WithTheme(Themed(OverflowContainer))
                                                                       className="emotion-11"
                                                                       containerRef={[Function]}
                                                                       onScroll={[Function]}
@@ -2754,7 +2754,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(OverflowContainer)>
-                                                                    </Scroller>
+                                                                    </WithTheme(Themed(OverflowContainer))>
                                                                   </Scroller>
                                                                 </div>
                                                               </OverflowContainerWithShadows>
@@ -2767,7 +2767,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                                                 </withProps(Styled(WithTheme(Themed(OverflowContainerWithShadows))))>
                                               </div>
                                             </Styled(div)>
-                                          </DialogHeader>
+                                          </DialogRow>
                                         </DialogBody>
                                       </DialogBody>
                                     </div>
@@ -2783,7 +2783,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
                 </Transition>
               </Component>
             </WithTheme(Component)>
-          </DemoDialog>
+          </Dialog>
         </DemoDialog>
       </withProps(DemoDialog)>
     </div>

--- a/src/library/Dropdown/Dropdown.js
+++ b/src/library/Dropdown/Dropdown.js
@@ -24,6 +24,8 @@ import type {
 } from './types';
 
 export default class Dropdown extends Component<DropdownProps, DropdownState> {
+  static displayName = 'Dropdown';
+
   static defaultProps: DropdownDefaultProps = {
     itemKey: 'text',
     placement: PLACEMENT['bottom-start']

--- a/src/library/Dropdown/DropdownContent.js
+++ b/src/library/Dropdown/DropdownContent.js
@@ -5,6 +5,8 @@ import { DropdownContentRoot as Root } from './styled';
 import type { DropdownContentProps } from './types';
 
 export default class DropdownContent extends Component<DropdownContentProps> {
+  static displayName = 'DropdownContent';
+
   render() {
     const { children, ...rootProps } = this.props;
 

--- a/src/library/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/library/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -179,7 +179,7 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
       tag="span"
       triggerRef={[Function]}
     >
-      <Popover
+      <Manager
         className="emotion-5"
         id="dropdown-1"
         tag="span"
@@ -205,7 +205,7 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
             <PopoverTrigger
               component="span"
             >
-              <PopoverTrigger
+              <Target
                 className="emotion-3"
                 component="span"
               >
@@ -273,11 +273,11 @@ exports[`Dropdown demo examples Snapshots: basic 1`] = `
                     </Button>
                   </Button>
                 </span>
-              </PopoverTrigger>
+              </Target>
             </PopoverTrigger>
           </PopoverTrigger>
         </span>
-      </Popover>
+      </Manager>
     </Popover>
   </Popover>
 </Dropdown>
@@ -484,7 +484,7 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
             tag="span"
             triggerRef={[Function]}
           >
-            <Popover
+            <Manager
               className="emotion-5"
               id="dropdown-19"
               tag="span"
@@ -510,7 +510,7 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
                   <PopoverTrigger
                     component="span"
                   >
-                    <PopoverTrigger
+                    <Target
                       className="emotion-3"
                       component="span"
                     >
@@ -578,11 +578,11 @@ exports[`Dropdown demo examples Snapshots: controlled 1`] = `
                           </Button>
                         </Button>
                       </span>
-                    </PopoverTrigger>
+                    </Target>
                   </PopoverTrigger>
                 </PopoverTrigger>
               </span>
-            </Popover>
+            </Manager>
           </Popover>
         </Popover>
       </Dropdown>
@@ -807,7 +807,7 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
         tag="span"
         triggerRef={[Function]}
       >
-        <Popover
+        <Manager
           className="emotion-5"
           id="dropdown-23"
           tag="span"
@@ -833,7 +833,7 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -901,11 +901,11 @@ exports[`Dropdown demo examples Snapshots: custom-item 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </Dropdown>
@@ -1093,7 +1093,7 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
         tag="span"
         triggerRef={[Function]}
       >
-        <Popover
+        <Manager
           className="emotion-5"
           id="dropdown-25"
           tag="span"
@@ -1119,7 +1119,7 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -1187,11 +1187,11 @@ exports[`Dropdown demo examples Snapshots: custom-menu 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </Dropdown>
@@ -1253,7 +1253,7 @@ exports[`Dropdown demo examples Snapshots: custom-trigger 1`] = `
         tag="span"
         triggerRef={[Function]}
       >
-        <Popover
+        <Manager
           className="emotion-2"
           id="dropdown-27"
           tag="span"
@@ -1262,7 +1262,7 @@ exports[`Dropdown demo examples Snapshots: custom-trigger 1`] = `
             className="emotion-2"
             id="dropdown-27"
           >
-            <Styled(PopoverTrigger)
+            <Styled(Target)
               aria-describedby="dropdown-27-content"
               aria-expanded={false}
               aria-haspopup={true}
@@ -1273,7 +1273,7 @@ exports[`Dropdown demo examples Snapshots: custom-trigger 1`] = `
               onKeyDown={[Function]}
               onKeyUp={[Function]}
             >
-              <PopoverTrigger
+              <Target
                 aria-describedby="dropdown-27-content"
                 aria-expanded={false}
                 aria-haspopup={true}
@@ -1304,10 +1304,10 @@ exports[`Dropdown demo examples Snapshots: custom-trigger 1`] = `
                     ▼
                   </span>
                 </button>
-              </PopoverTrigger>
-            </Styled(PopoverTrigger)>
+              </Target>
+            </Styled(Target)>
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </Dropdown>
@@ -1506,7 +1506,7 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
         tag="span"
         triggerRef={[Function]}
       >
-        <Popover
+        <Manager
           className="emotion-5"
           id="dropdown-3"
           tag="span"
@@ -1532,7 +1532,7 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -1600,11 +1600,11 @@ exports[`Dropdown demo examples Snapshots: data 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </Dropdown>
@@ -1788,7 +1788,7 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
       tag="span"
       triggerRef={[Function]}
     >
-      <Popover
+      <Manager
         className="emotion-5"
         id="dropdown-17"
         tag="span"
@@ -1815,7 +1815,7 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
             <PopoverTrigger
               component="span"
             >
-              <PopoverTrigger
+              <Target
                 className="emotion-3"
                 component="span"
               >
@@ -1886,11 +1886,11 @@ exports[`Dropdown demo examples Snapshots: disabled 1`] = `
                     </Button>
                   </Button>
                 </span>
-              </PopoverTrigger>
+              </Target>
             </PopoverTrigger>
           </PopoverTrigger>
         </span>
-      </Popover>
+      </Manager>
     </Popover>
   </Popover>
 </Dropdown>
@@ -2078,7 +2078,7 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
         tag="span"
         triggerRef={[Function]}
       >
-        <Popover
+        <Manager
           className="emotion-5"
           id="dropdown-15"
           tag="span"
@@ -2104,7 +2104,7 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -2172,11 +2172,11 @@ exports[`Dropdown demo examples Snapshots: on-open-close 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </Dropdown>
@@ -2372,7 +2372,7 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
           tag="span"
           triggerRef={[Function]}
         >
-          <Popover
+          <Manager
             className="emotion-5"
             id="dropdown-9"
             tag="span"
@@ -2398,7 +2398,7 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
                 <PopoverTrigger
                   component="span"
                 >
-                  <PopoverTrigger
+                  <Target
                     className="emotion-3"
                     component="span"
                   >
@@ -2466,11 +2466,11 @@ exports[`Dropdown demo examples Snapshots: overflow 1`] = `
                         </Button>
                       </Button>
                     </span>
-                  </PopoverTrigger>
+                  </Target>
                 </PopoverTrigger>
               </PopoverTrigger>
             </span>
-          </Popover>
+          </Manager>
         </Popover>
       </Popover>
     </Dropdown>
@@ -2840,7 +2840,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
           tag="span"
           triggerRef={[Function]}
         >
-          <Popover
+          <Manager
             className="emotion-27"
             id="dropdown-7"
             tag="span"
@@ -2867,7 +2867,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                 <PopoverTrigger
                   component="span"
                 >
-                  <PopoverTrigger
+                  <Target
                     className="emotion-3"
                     component="span"
                   >
@@ -2938,7 +2938,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                         </Button>
                       </Button>
                     </span>
-                  </PopoverTrigger>
+                  </Target>
                 </PopoverTrigger>
               </PopoverTrigger>
               <DropdownContent
@@ -2953,7 +2953,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                   onBlur={[Function]}
                   placement="bottom-start"
                 >
-                  <DropdownContent
+                  <WithTheme(RtlPopper)
                     className="emotion-23"
                     id="dropdown-7-content"
                     onBlur={[Function]}
@@ -3332,7 +3332,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                         </div>
                       </Popper>
                     </RtlPopper>
-                  </DropdownContent>
+                  </WithTheme(RtlPopper)>
                 </DropdownContent>
               </DropdownContent>
               <EventListener
@@ -3354,7 +3354,7 @@ exports[`Dropdown demo examples Snapshots: placement 1`] = `
                 }
               />
             </span>
-          </Popover>
+          </Manager>
         </Popover>
       </Popover>
     </Dropdown>
@@ -3715,7 +3715,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                     triggerRef={[Function]}
                     usePortal={true}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-5"
                       id="dropdown-13"
                       tag="span"
@@ -3742,7 +3742,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-3"
                               component="span"
                             >
@@ -3813,7 +3813,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                                   </Button>
                                 </Button>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                         <Portal />
@@ -3836,7 +3836,7 @@ exports[`Dropdown demo examples Snapshots: portal 1`] = `
                           }
                         />
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </Dropdown>
@@ -4252,7 +4252,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
               tag="span"
               triggerRef={[Function]}
             >
-              <Popover
+              <Manager
                 className="emotion-27"
                 id="dropdown-21"
                 tag="span"
@@ -4279,7 +4279,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                     <PopoverTrigger
                       component="span"
                     >
-                      <PopoverTrigger
+                      <Target
                         className="emotion-3"
                         component="span"
                       >
@@ -4350,7 +4350,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                             </Button>
                           </Button>
                         </span>
-                      </PopoverTrigger>
+                      </Target>
                     </PopoverTrigger>
                   </PopoverTrigger>
                   <DropdownContent
@@ -4365,7 +4365,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                       onBlur={[Function]}
                       placement="bottom-start"
                     >
-                      <DropdownContent
+                      <WithTheme(RtlPopper)
                         className="emotion-23"
                         id="dropdown-21-content"
                         onBlur={[Function]}
@@ -4744,7 +4744,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                             </div>
                           </Popper>
                         </RtlPopper>
-                      </DropdownContent>
+                      </WithTheme(RtlPopper)>
                     </DropdownContent>
                   </DropdownContent>
                   <EventListener
@@ -4766,7 +4766,7 @@ exports[`Dropdown demo examples Snapshots: rtl 1`] = `
                     }
                   />
                 </span>
-              </Popover>
+              </Manager>
             </Popover>
           </Popover>
         </Dropdown>
@@ -5267,7 +5267,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                     tag="span"
                     triggerRef={[Function]}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-27"
                       id="dropdown-11"
                       tag="span"
@@ -5294,7 +5294,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-3"
                               component="span"
                             >
@@ -5365,7 +5365,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                                   </Button>
                                 </Button>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                         <DropdownContent
@@ -5380,7 +5380,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                             onBlur={[Function]}
                             placement="bottom-start"
                           >
-                            <DropdownContent
+                            <WithTheme(RtlPopper)
                               className="emotion-23"
                               id="dropdown-11-content"
                               onBlur={[Function]}
@@ -5759,7 +5759,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                                   </div>
                                 </Popper>
                               </RtlPopper>
-                            </DropdownContent>
+                            </WithTheme(RtlPopper)>
                           </DropdownContent>
                         </DropdownContent>
                         <EventListener
@@ -5781,7 +5781,7 @@ exports[`Dropdown demo examples Snapshots: scrolling-container 1`] = `
                           }
                         />
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </Dropdown>
@@ -6195,7 +6195,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
           triggerRef={[Function]}
           wide={true}
         >
-          <Popover
+          <Manager
             className="emotion-27"
             id="dropdown-5"
             tag="span"
@@ -6222,7 +6222,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                 <PopoverTrigger
                   component="span"
                 >
-                  <PopoverTrigger
+                  <Target
                     className="emotion-3"
                     component="span"
                   >
@@ -6293,7 +6293,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                         </Button>
                       </Button>
                     </span>
-                  </PopoverTrigger>
+                  </Target>
                 </PopoverTrigger>
               </PopoverTrigger>
               <DropdownContent
@@ -6310,7 +6310,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                   placement="bottom-start"
                   wide={true}
                 >
-                  <DropdownContent
+                  <WithTheme(RtlPopper)
                     className="emotion-23"
                     id="dropdown-5-content"
                     onBlur={[Function]}
@@ -6689,7 +6689,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                         </div>
                       </Popper>
                     </RtlPopper>
-                  </DropdownContent>
+                  </WithTheme(RtlPopper)>
                 </DropdownContent>
               </DropdownContent>
               <EventListener
@@ -6711,7 +6711,7 @@ exports[`Dropdown demo examples Snapshots: wide 1`] = `
                 }
               />
             </span>
-          </Popover>
+          </Manager>
         </Popover>
       </Popover>
     </Dropdown>

--- a/src/library/EventListener/EventListener.js
+++ b/src/library/EventListener/EventListener.js
@@ -5,6 +5,8 @@ import { canUseDOM, canUseEventListeners } from 'exenv';
 import type { EventListenerProps, Listeners, Listener } from './types';
 
 export default class EventListener extends Component<EventListenerProps> {
+  static displayName = 'EventListener';
+
   componentDidMount() {
     this.addEventListeners();
   }

--- a/src/library/FauxControl/FauxControl.js
+++ b/src/library/FauxControl/FauxControl.js
@@ -60,6 +60,8 @@ const getIcons = ({
 };
 
 export default class FauxControl extends Component<FauxControlProps> {
+  static displayName = 'FauxControl';
+
   // Must be an instance method to avoid affecting other instances memoized keys
   getControlNode = memoizeOne(
     createControlNode,

--- a/src/library/FauxControl/__tests__/FauxControl.spec.js
+++ b/src/library/FauxControl/__tests__/FauxControl.spec.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import FauxControl from '../FauxControl';
 
+// eslint-disable-next-line react/display-name
 const Control = (props) => <input {...props} />;
 
 function shallowFauxControl(props = {}) {

--- a/src/library/Flex/Flex.js
+++ b/src/library/Flex/Flex.js
@@ -159,13 +159,13 @@ const ThemedRoot = withTheme(
 
 const Flex = (props: FlexProps) => <ThemedRoot {...props} />;
 
+Flex.displayName = 'Flex';
 const defaultProps: FlexDefaultProps = {
   alignItems: ALIGN_ITEMS.stretch,
   direction: DIRECTION.row,
   gutterWidth: GUTTER_WIDTH.md,
   justifyContent: JUSTIFY_CONTENT.start
 };
-
 Flex.defaultProps = defaultProps;
 Flex.propTypes = flexPropTypes;
 

--- a/src/library/Flex/FlexItem.js
+++ b/src/library/Flex/FlexItem.js
@@ -7,6 +7,8 @@ import { flexItemPropTypes } from './propTypes';
 import type { FlexItemDefaultProps, FlexItemProps } from './types';
 
 export default class FlexItem extends Component<FlexItemProps> {
+  static displayName = 'FlexItem';
+
   static defaultProps: FlexItemDefaultProps = {
     grow: 0,
     shrink: 1

--- a/src/library/Flex/__tests__/__snapshots__/FlexItem.spec.js.snap
+++ b/src/library/Flex/__tests__/__snapshots__/FlexItem.spec.js.snap
@@ -673,7 +673,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                 gutterWidth="md"
                 justifyContent="start"
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-21"
                   direction="row"
@@ -714,7 +714,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="stretch"
                               className="emotion-1"
                               element="div"
@@ -736,7 +736,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   stretch
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
@@ -762,7 +762,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="start"
                               className="emotion-6"
                               element="div"
@@ -784,7 +784,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   start
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
@@ -810,7 +810,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="center"
                               className="emotion-11"
                               element="div"
@@ -832,7 +832,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   center
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
@@ -855,7 +855,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="end"
                               className="emotion-16"
                               element="div"
@@ -875,13 +875,13 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   end
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
@@ -922,7 +922,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                 gutterWidth="md"
                 justifyContent="start"
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-48"
                   direction="column"
@@ -960,7 +960,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="stretch"
                               className="emotion-1"
                               element="div"
@@ -980,7 +980,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   stretch
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
@@ -1003,7 +1003,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="start"
                               className="emotion-6"
                               element="div"
@@ -1023,7 +1023,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   start
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
@@ -1046,7 +1046,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="center"
                               className="emotion-11"
                               element="div"
@@ -1066,7 +1066,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   center
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
@@ -1089,7 +1089,7 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               alignSelf="end"
                               className="emotion-16"
                               element="div"
@@ -1109,13 +1109,13 @@ exports[`FlexItem demo examples Snapshots: align-self 1`] = `
                                   end
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </Styled(FlexItem)>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
@@ -1359,7 +1359,7 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
           gutterWidth="md"
           justifyContent="start"
         >
-          <FlexItem
+          <Box
             alignItems="stretch"
             className="emotion-16"
             direction="row"
@@ -1397,7 +1397,7 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -1417,7 +1417,7 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
                             A
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -1440,7 +1440,7 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -1460,7 +1460,7 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
                             B
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -1480,7 +1480,7 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -1498,13 +1498,13 @@ exports[`FlexItem demo examples Snapshots: basic 1`] = `
                             C
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
               </div>
             </Styled(div)>
-          </FlexItem>
+          </Box>
         </Flex>
       </Component>
     </WithTheme(Component)>
@@ -1849,7 +1849,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
   gutterWidth="md"
   justifyContent="start"
 >
-  <FlexItem
+  <Flex
     alignItems="stretch"
     className="emotion-18"
     direction="row"
@@ -1878,7 +1878,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
           gutterWidth="md"
           justifyContent="start"
         >
-          <FlexItem
+          <Box
             alignItems="stretch"
             className="emotion-16"
             direction="row"
@@ -1916,7 +1916,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -1936,7 +1936,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
                             A
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -1965,7 +1965,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
                       padding="lg"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-6"
                         element="div"
                         grow={0}
@@ -1989,7 +1989,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
                             B
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -2009,7 +2009,7 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -2027,17 +2027,17 @@ exports[`FlexItem demo examples Snapshots: box-props 1`] = `
                             C
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
               </div>
             </Styled(div)>
-          </FlexItem>
+          </Box>
         </Flex>
       </Component>
     </WithTheme(Component)>
-  </FlexItem>
+  </Flex>
 </Styled(Flex)>
 `;
 
@@ -2534,7 +2534,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
   gutterWidth="md"
   justifyContent="start"
 >
-  <FlexItem
+  <Flex
     alignItems="stretch"
     className="emotion-33"
     direction="row"
@@ -2563,7 +2563,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
           gutterWidth="md"
           justifyContent="start"
         >
-          <FlexItem
+          <Box
             alignItems="stretch"
             className="emotion-31"
             direction="row"
@@ -2609,7 +2609,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Flex
                         alignItems="center"
                         className="emotion-13"
                         direction="row"
@@ -2654,7 +2654,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                               marginEnd="1em"
                               shrink={1}
                             >
-                              <FlexItem
+                              <Box
                                 alignItems="center"
                                 className="emotion-11"
                                 direction="row"
@@ -2700,7 +2700,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                                           marginEnd="1em"
                                           shrink={1}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             element="div"
                                             grow={0}
@@ -2720,7 +2720,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                                                 A
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
                                       </FlexItem>
                                     </Styled(FlexItem)>
@@ -2740,7 +2740,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                                           grow={0}
                                           shrink={1}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             element="div"
                                             grow={0}
@@ -2758,17 +2758,17 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                                                 B
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
                                       </FlexItem>
                                     </Styled(FlexItem)>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </Flex>
                           </Component>
                         </WithTheme(Component)>
-                      </FlexItem>
+                      </Flex>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -2788,7 +2788,7 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -2803,10 +2803,10 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                           <div
                             className="emotion-5"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-20"
                                 element="div"
                               >
@@ -2820,12 +2820,12 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                                     C
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
-                            <Styled(Flex)
+                              </Box>
+                            </Styled(Box)>
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-20"
                                 element="div"
                               >
@@ -2839,21 +2839,21 @@ exports[`FlexItem demo examples Snapshots: flex-props 1`] = `
                                     D
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
               </div>
             </Styled(div)>
-          </FlexItem>
+          </Box>
         </Flex>
       </Component>
     </WithTheme(Component)>
-  </FlexItem>
+  </Flex>
 </Styled(Flex)>
 `;
 
@@ -3370,7 +3370,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
               gutterWidth="md"
               justifyContent="start"
             >
-              <FlexItem
+              <Box
                 alignItems="stretch"
                 className="emotion-16"
                 direction="row"
@@ -3408,7 +3408,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-1"
                             element="div"
                             grow={1}
@@ -3428,7 +3428,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 1
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
@@ -3451,7 +3451,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-1"
                             element="div"
                             grow={1}
@@ -3471,7 +3471,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 1
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
@@ -3491,7 +3491,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           grow={1}
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-1"
                             element="div"
                             grow={1}
@@ -3509,13 +3509,13 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 1
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
                   </div>
                 </Styled(div)>
-              </FlexItem>
+              </Box>
             </Flex>
           </Component>
         </WithTheme(Component)>
@@ -3556,7 +3556,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
               gutterWidth="md"
               justifyContent="start"
             >
-              <FlexItem
+              <Box
                 alignItems="stretch"
                 className="emotion-16"
                 direction="row"
@@ -3594,7 +3594,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-1"
                             element="div"
                             grow={1}
@@ -3614,7 +3614,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 1
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
@@ -3637,7 +3637,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-28"
                             element="div"
                             grow={0}
@@ -3657,7 +3657,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 0
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
@@ -3677,7 +3677,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           grow={0}
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-28"
                             element="div"
                             grow={0}
@@ -3695,13 +3695,13 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 0
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
                   </div>
                 </Styled(div)>
-              </FlexItem>
+              </Box>
             </Flex>
           </Component>
         </WithTheme(Component)>
@@ -3742,7 +3742,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
               gutterWidth="md"
               justifyContent="start"
             >
-              <FlexItem
+              <Box
                 alignItems="stretch"
                 className="emotion-16"
                 direction="row"
@@ -3780,7 +3780,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-45"
                             element="div"
                             grow={3}
@@ -3800,7 +3800,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 3
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
@@ -3823,7 +3823,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-50"
                             element="div"
                             grow={2}
@@ -3843,7 +3843,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 2
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
@@ -3863,7 +3863,7 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                           grow={1}
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-1"
                             element="div"
                             grow={1}
@@ -3881,13 +3881,13 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
                                 1
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </Styled(FlexItem)>
                   </div>
                 </Styled(div)>
-              </FlexItem>
+              </Box>
             </Flex>
           </Component>
         </WithTheme(Component)>
@@ -4141,7 +4141,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
   gutterWidth="md"
   justifyContent="start"
 >
-  <FlexItem
+  <Flex
     alignItems="stretch"
     breakpoints={
       Array [
@@ -4190,7 +4190,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
           gutterWidth="md"
           justifyContent="start"
         >
-          <FlexItem
+          <Box
             alignItems="stretch"
             breakpoints={
               Array [
@@ -4253,7 +4253,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         breakpoints={
                           Array [
                             800,
@@ -4283,7 +4283,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
                             A
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -4321,7 +4321,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         breakpoints={
                           Array [
                             800,
@@ -4351,7 +4351,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
                             B
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -4404,7 +4404,7 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
                       }
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         breakpoints={
                           Array [
                             800,
@@ -4444,17 +4444,17 @@ exports[`FlexItem demo examples Snapshots: responsive 1`] = `
                             C
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
               </div>
             </Styled(div)>
-          </FlexItem>
+          </Box>
         </Flex>
       </Component>
     </WithTheme(Component)>
-  </FlexItem>
+  </Flex>
 </Styled(Flex)>
 `;
 
@@ -4794,7 +4794,7 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
           gutterWidth="md"
           justifyContent="start"
         >
-          <FlexItem
+          <Box
             alignItems="stretch"
             className="emotion-16"
             direction="row"
@@ -4835,7 +4835,7 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
                       shrink={3}
                       width="100%"
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-1"
                         element="div"
                         grow={0}
@@ -4855,7 +4855,7 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
                             3
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -4881,7 +4881,7 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
                       shrink={2}
                       width="100%"
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-6"
                         element="div"
                         grow={0}
@@ -4901,7 +4901,7 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
                             2
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
@@ -4924,7 +4924,7 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
                       shrink={1}
                       width="100%"
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-11"
                         element="div"
                         grow={0}
@@ -4942,13 +4942,13 @@ exports[`FlexItem demo examples Snapshots: shrink 1`] = `
                             1
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </Styled(FlexItem)>
               </div>
             </Styled(div)>
-          </FlexItem>
+          </Box>
         </Flex>
       </Component>
     </WithTheme(Component)>

--- a/src/library/Form/FormField.js
+++ b/src/library/Form/FormField.js
@@ -14,6 +14,8 @@ import type { FormFieldDefaultProps, FormFieldProps } from './types';
 const REGEX_GROUP = /(Checkbox|Radio|Group)/i;
 
 export default class FormField extends Component<FormFieldProps> {
+  static displayName = 'FormField';
+
   static defaultProps: FormFieldDefaultProps = {
     requiredText: 'Required'
   };

--- a/src/library/Form/FormFieldDivider.js
+++ b/src/library/Form/FormFieldDivider.js
@@ -9,6 +9,7 @@ const FormFieldDivider = (props: FormFieldDividerProps) => (
   <Root {...props} role="separator" />
 );
 
+FormFieldDivider.displayName = 'FormFieldDivider';
 FormFieldDivider.propTypes = formFieldDividerPropTypes;
 
 export default FormFieldDivider;

--- a/src/library/Form/FormFieldset.js
+++ b/src/library/Form/FormFieldset.js
@@ -15,6 +15,7 @@ const FormFieldset = (props: FormFieldsetProps) => {
   );
 };
 
+FormFieldset.displayName = 'FormFieldset';
 FormFieldset.propTypes = formFieldsetPropTypes;
 
 export default FormFieldset;

--- a/src/library/Form/__tests__/__snapshots__/FormField.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormField.spec.js.snap
@@ -389,7 +389,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-4"
                     control={[Function]}
                     controlProps={
@@ -483,7 +483,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -537,7 +537,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                   iconEnd={null}
                   size="large"
                 >
-                  <TextArea
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-13"
                     control={[Function]}
                     controlProps={
@@ -655,7 +655,7 @@ exports[`FormField demo examples Snapshots: basic 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextArea>
+                  </WithTheme(Themed(FauxControl))>
                 </TextArea>
               </TextArea>
             </label>
@@ -927,7 +927,7 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
             }
             size="large"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-4"
               control={[Function]}
               controlProps={
@@ -1023,13 +1023,14 @@ exports[`FormField demo examples Snapshots: caption 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
       </label>
       <Styled(div)
         caption="This is help text"
         id="formField-11-caption"
+        isGroup={false}
       >
         <div
           className="emotion-8"
@@ -1343,7 +1344,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-4"
                     control={[Function]}
                     controlProps={
@@ -1443,7 +1444,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -1499,7 +1500,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-4"
                     control={[Function]}
                     controlProps={
@@ -1599,7 +1600,7 @@ exports[`FormField demo examples Snapshots: hide-label 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -1889,7 +1890,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-5"
                     control={[Function]}
                     controlProps={
@@ -1987,7 +1988,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -2047,7 +2048,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-5"
                     control={[Function]}
                     controlProps={
@@ -2145,7 +2146,7 @@ exports[`FormField demo examples Snapshots: required 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -2445,7 +2446,7 @@ exports[`FormField demo examples Snapshots: rtl 1`] = `
                   iconStart={<IconBackspace />}
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-6"
                     control={[Function]}
                     controlProps={
@@ -2585,7 +2586,7 @@ exports[`FormField demo examples Snapshots: rtl 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -2865,7 +2866,7 @@ exports[`FormField demo examples Snapshots: secondaryText 1`] = `
             }
             size="large"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-5"
               control={[Function]}
               controlProps={
@@ -2959,7 +2960,7 @@ exports[`FormField demo examples Snapshots: secondaryText 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
       </label>
@@ -3377,7 +3378,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
                       }
                       size="large"
                     >
-                      <TextInput
+                      <WithTheme(Themed(FauxControl))
                         className="emotion-5"
                         control={[Function]}
                         controlProps={
@@ -3489,7 +3490,7 @@ exports[`FormField demo examples Snapshots: validation 1`] = `
                             </ThemeProvider>
                           </ThemeProvider>
                         </Themed(FauxControl)>
-                      </TextInput>
+                      </WithTheme(Themed(FauxControl))>
                     </TextInput>
                   </TextInput>
                 </label>
@@ -4168,7 +4169,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                   size="large"
                   variant="success"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-5"
                     control={[Function]}
                     controlProps={
@@ -4303,13 +4304,14 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
             <Styled(div)
               caption="This is help text"
               id="formField-13-caption"
+              isGroup={false}
               variant="success"
             >
               <div
@@ -4371,7 +4373,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                   size="large"
                   variant="warning"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-16"
                     control={[Function]}
                     controlProps={
@@ -4506,13 +4508,14 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
             <Styled(div)
               caption="This is help text"
               id="formField-15-caption"
+              isGroup={false}
               variant="warning"
             >
               <div
@@ -4574,7 +4577,7 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                   size="large"
                   variant="danger"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-27"
                     control={[Function]}
                     controlProps={
@@ -4709,13 +4712,14 @@ exports[`FormField demo examples Snapshots: variants 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
             <Styled(div)
               caption="This is help text"
               id="formField-17-caption"
+              isGroup={false}
               variant="danger"
             >
               <div

--- a/src/library/Form/__tests__/__snapshots__/FormFieldDivider.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormFieldDivider.spec.js.snap
@@ -268,7 +268,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-4"
                     control={[Function]}
                     controlProps={
@@ -362,7 +362,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -422,7 +422,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-4"
                     control={[Function]}
                     controlProps={
@@ -516,7 +516,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
@@ -566,7 +566,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                   }
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-4"
                     control={[Function]}
                     controlProps={
@@ -660,7 +660,7 @@ exports[`FormFieldDivider demo examples Snapshots: basic 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>

--- a/src/library/Form/__tests__/__snapshots__/FormFieldset.spec.js.snap
+++ b/src/library/Form/__tests__/__snapshots__/FormFieldset.spec.js.snap
@@ -301,7 +301,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
                         }
                         size="large"
                       >
-                        <TextInput
+                        <WithTheme(Themed(FauxControl))
                           className="emotion-4"
                           control={[Function]}
                           controlProps={
@@ -395,7 +395,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
                               </ThemeProvider>
                             </ThemeProvider>
                           </Themed(FauxControl)>
-                        </TextInput>
+                        </WithTheme(Themed(FauxControl))>
                       </TextInput>
                     </TextInput>
                   </label>
@@ -445,7 +445,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
                         }
                         size="large"
                       >
-                        <TextInput
+                        <WithTheme(Themed(FauxControl))
                           className="emotion-4"
                           control={[Function]}
                           controlProps={
@@ -539,7 +539,7 @@ exports[`FormFieldset demo examples Snapshots: basic 1`] = `
                               </ThemeProvider>
                             </ThemeProvider>
                           </Themed(FauxControl)>
-                        </TextInput>
+                        </WithTheme(Themed(FauxControl))>
                       </TextInput>
                     </TextInput>
                   </label>
@@ -852,7 +852,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
                         disabled={true}
                         size="large"
                       >
-                        <TextInput
+                        <WithTheme(Themed(FauxControl))
                           className="emotion-4"
                           control={[Function]}
                           controlProps={
@@ -954,7 +954,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
                               </ThemeProvider>
                             </ThemeProvider>
                           </Themed(FauxControl)>
-                        </TextInput>
+                        </WithTheme(Themed(FauxControl))>
                       </TextInput>
                     </TextInput>
                   </label>
@@ -1006,7 +1006,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
                         disabled={true}
                         size="large"
                       >
-                        <TextInput
+                        <WithTheme(Themed(FauxControl))
                           className="emotion-4"
                           control={[Function]}
                           controlProps={
@@ -1108,7 +1108,7 @@ exports[`FormFieldset demo examples Snapshots: disabled 1`] = `
                               </ThemeProvider>
                             </ThemeProvider>
                           </Themed(FauxControl)>
-                        </TextInput>
+                        </WithTheme(Themed(FauxControl))>
                       </TextInput>
                     </TextInput>
                   </label>
@@ -1432,7 +1432,7 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
                         iconStart={<IconBackspace />}
                         size="large"
                       >
-                        <TextInput
+                        <WithTheme(Themed(FauxControl))
                           className="emotion-5"
                           control={[Function]}
                           controlProps={
@@ -1568,7 +1568,7 @@ exports[`FormFieldset demo examples Snapshots: rtl 1`] = `
                               </ThemeProvider>
                             </ThemeProvider>
                           </Themed(FauxControl)>
-                        </TextInput>
+                        </WithTheme(Themed(FauxControl))>
                       </TextInput>
                     </TextInput>
                   </label>

--- a/src/library/Grid/Grid.js
+++ b/src/library/Grid/Grid.js
@@ -15,12 +15,12 @@ const Grid = (props: GridProps) => (
   <Root {...props}>{getGridItems(props)}</Root>
 );
 
+Grid.displayName = 'Grid';
 const defaultProps: GridDefaultProps = {
   alignItems: ALIGN_ITEMS.stretch, // Same as Flex
   columns: 12,
   gutterWidth: GUTTER_WIDTH.md // Same as Flex
 };
-
 Grid.defaultProps = defaultProps;
 Grid.propTypes = gridPropTypes;
 

--- a/src/library/Grid/GridItem.js
+++ b/src/library/Grid/GridItem.js
@@ -7,6 +7,7 @@ import type { GridItemProps } from './types';
 
 const GridItem = (props: GridItemProps) => <Root {...props} />;
 
+GridItem.displayName = 'GridItem';
 GridItem.propTypes = gridItemPropTypes;
 
 export default GridItem;

--- a/src/library/Grid/__tests__/__snapshots__/Grid.spec.js.snap
+++ b/src/library/Grid/__tests__/__snapshots__/Grid.spec.js.snap
@@ -534,7 +534,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <Grid
+                <Flex
                   alignItems="stretch"
                   className="emotion-27"
                   columns={12}
@@ -571,7 +571,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                         justifyContent="start"
                         wrap={true}
                       >
-                        <FlexItem
+                        <Box
                           alignItems="stretch"
                           className="emotion-25"
                           columns={12}
@@ -620,7 +620,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -637,7 +637,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -661,9 +661,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 A
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -694,7 +694,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -711,7 +711,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -735,9 +735,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 B
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -764,7 +764,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -779,7 +779,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           gutterWidth="md"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -801,20 +801,20 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 C
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
                               </Styled(GridItem)>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </Flex>
                     </Component>
                   </WithTheme(Component)>
-                </Grid>
+                </Flex>
               </Grid>
             </withProps(Grid)>
           </Grid>
@@ -846,7 +846,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <Grid
+                <Flex
                   alignItems="start"
                   className="emotion-27"
                   columns={12}
@@ -883,7 +883,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                         justifyContent="start"
                         wrap={true}
                       >
-                        <FlexItem
+                        <Box
                           alignItems="start"
                           className="emotion-59"
                           columns={12}
@@ -932,7 +932,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -949,7 +949,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -973,9 +973,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 A
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -1006,7 +1006,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1023,7 +1023,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1047,9 +1047,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 B
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -1076,7 +1076,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1091,7 +1091,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           gutterWidth="md"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1113,20 +1113,20 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 C
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
                               </Styled(GridItem)>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </Flex>
                     </Component>
                   </WithTheme(Component)>
-                </Grid>
+                </Flex>
               </Grid>
             </withProps(Grid)>
           </Grid>
@@ -1158,7 +1158,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <Grid
+                <Flex
                   alignItems="center"
                   className="emotion-27"
                   columns={12}
@@ -1195,7 +1195,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                         justifyContent="start"
                         wrap={true}
                       >
-                        <FlexItem
+                        <Box
                           alignItems="center"
                           className="emotion-93"
                           columns={12}
@@ -1244,7 +1244,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1261,7 +1261,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1285,9 +1285,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 A
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -1318,7 +1318,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1335,7 +1335,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1359,9 +1359,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 B
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -1388,7 +1388,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1403,7 +1403,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           gutterWidth="md"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1425,20 +1425,20 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 C
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
                               </Styled(GridItem)>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </Flex>
                     </Component>
                   </WithTheme(Component)>
-                </Grid>
+                </Flex>
               </Grid>
             </withProps(Grid)>
           </Grid>
@@ -1470,7 +1470,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <Grid
+                <Flex
                   alignItems="end"
                   className="emotion-27"
                   columns={12}
@@ -1507,7 +1507,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                         justifyContent="start"
                         wrap={true}
                       >
-                        <FlexItem
+                        <Box
                           alignItems="end"
                           className="emotion-127"
                           columns={12}
@@ -1556,7 +1556,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1573,7 +1573,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1597,9 +1597,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 A
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -1630,7 +1630,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1647,7 +1647,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           marginEnd="1em"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1671,9 +1671,9 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 B
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
@@ -1700,7 +1700,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <GridItem
+                                      <FlexItem
                                         className="emotion-3"
                                         columns={12}
                                         grow={0}
@@ -1715,7 +1715,7 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                           gutterWidth="md"
                                           shrink={0}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-1"
                                             columns={12}
                                             element="div"
@@ -1737,20 +1737,20 @@ exports[`Grid demo examples Snapshots: align-items 1`] = `
                                                 C
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
-                                      </GridItem>
+                                      </FlexItem>
                                     </GridItem>
                                   </withProps(GridItem)>
                                 </GridItem>
                               </Styled(GridItem)>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </Flex>
                     </Component>
                   </WithTheme(Component)>
-                </Grid>
+                </Flex>
               </Grid>
             </withProps(Grid)>
           </Grid>
@@ -2059,7 +2059,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
         justifyContent="start"
         wrap={true}
       >
-        <Grid
+        <Flex
           alignItems="stretch"
           className="emotion-27"
           columns={12}
@@ -2096,7 +2096,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-25"
                   columns={12}
@@ -2145,7 +2145,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                               marginEnd="1em"
                               shrink={0}
                             >
-                              <GridItem
+                              <FlexItem
                                 className="emotion-3"
                                 columns={12}
                                 grow={0}
@@ -2162,7 +2162,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     columns={12}
                                     element="div"
@@ -2186,9 +2186,9 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                                         A
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
@@ -2219,7 +2219,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                               marginEnd="1em"
                               shrink={0}
                             >
-                              <GridItem
+                              <FlexItem
                                 className="emotion-3"
                                 columns={12}
                                 grow={0}
@@ -2236,7 +2236,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     columns={12}
                                     element="div"
@@ -2260,9 +2260,9 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                                         B
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
@@ -2289,7 +2289,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                               gutterWidth="md"
                               shrink={0}
                             >
-                              <GridItem
+                              <FlexItem
                                 className="emotion-3"
                                 columns={12}
                                 grow={0}
@@ -2304,7 +2304,7 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     columns={12}
                                     element="div"
@@ -2326,20 +2326,20 @@ exports[`Grid demo examples Snapshots: basic 1`] = `
                                         C
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
                       </Styled(GridItem)>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
-        </Grid>
+        </Flex>
       </Grid>
     </withProps(Grid)>
   </Grid>
@@ -2658,7 +2658,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
           width={0.5}
           wrap={true}
         >
-          <Grid
+          <Flex
             alignItems="stretch"
             className="emotion-27"
             columns={12}
@@ -2703,7 +2703,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                   width={0.5}
                   wrap={true}
                 >
-                  <FlexItem
+                  <Box
                     alignItems="stretch"
                     className="emotion-25"
                     columns={12}
@@ -2756,7 +2756,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                 marginEnd="1em"
                                 shrink={0}
                               >
-                                <GridItem
+                                <FlexItem
                                   className="emotion-3"
                                   columns={12}
                                   grow={0}
@@ -2773,7 +2773,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                     marginEnd="1em"
                                     shrink={0}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       columns={12}
                                       element="div"
@@ -2797,9 +2797,9 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                           A
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
-                                </GridItem>
+                                </FlexItem>
                               </GridItem>
                             </withProps(GridItem)>
                           </GridItem>
@@ -2830,7 +2830,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                 marginEnd="1em"
                                 shrink={0}
                               >
-                                <GridItem
+                                <FlexItem
                                   className="emotion-3"
                                   columns={12}
                                   grow={0}
@@ -2847,7 +2847,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                     marginEnd="1em"
                                     shrink={0}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       columns={12}
                                       element="div"
@@ -2871,9 +2871,9 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                           B
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
-                                </GridItem>
+                                </FlexItem>
                               </GridItem>
                             </withProps(GridItem)>
                           </GridItem>
@@ -2900,7 +2900,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                 gutterWidth="md"
                                 shrink={0}
                               >
-                                <GridItem
+                                <FlexItem
                                   className="emotion-3"
                                   columns={12}
                                   grow={0}
@@ -2915,7 +2915,7 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                     gutterWidth="md"
                                     shrink={0}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       columns={12}
                                       element="div"
@@ -2937,20 +2937,20 @@ exports[`Grid demo examples Snapshots: box-props 1`] = `
                                           C
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
-                                </GridItem>
+                                </FlexItem>
                               </GridItem>
                             </withProps(GridItem)>
                           </GridItem>
                         </Styled(GridItem)>
                       </div>
                     </Styled(div)>
-                  </FlexItem>
+                  </Box>
                 </Flex>
               </Component>
             </WithTheme(Component)>
-          </Grid>
+          </Flex>
         </Grid>
       </withProps(Grid)>
     </Grid>
@@ -3504,7 +3504,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-27"
               columns={15}
@@ -3541,7 +3541,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-25"
                       columns={15}
@@ -3590,7 +3590,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -3607,7 +3607,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -3631,9 +3631,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -3668,7 +3668,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   shrink={0}
                                   span={7}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-11"
                                     columns={15}
                                     grow={0}
@@ -3687,7 +3687,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       shrink={0}
                                       span={7}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-9"
                                         columns={15}
                                         element="div"
@@ -3713,9 +3713,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             7
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -3742,7 +3742,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -3757,7 +3757,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -3779,20 +3779,20 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -3823,7 +3823,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-27"
               columns={15}
@@ -3860,7 +3860,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-25"
                       columns={15}
@@ -3909,7 +3909,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -3926,7 +3926,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -3950,9 +3950,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             1
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -3983,7 +3983,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4000,7 +4000,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4024,9 +4024,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             2
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4057,7 +4057,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4074,7 +4074,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4098,9 +4098,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             3
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4131,7 +4131,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4148,7 +4148,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4172,9 +4172,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             4
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4205,7 +4205,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4222,7 +4222,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4246,9 +4246,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             5
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4279,7 +4279,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4296,7 +4296,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4320,9 +4320,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             6
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4353,7 +4353,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4370,7 +4370,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4394,9 +4394,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             7
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4427,7 +4427,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4444,7 +4444,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4468,9 +4468,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             8
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4501,7 +4501,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4518,7 +4518,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4542,9 +4542,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             9
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4575,7 +4575,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4592,7 +4592,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4616,9 +4616,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             10
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4649,7 +4649,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4666,7 +4666,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4690,9 +4690,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             11
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4723,7 +4723,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4740,7 +4740,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4764,9 +4764,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             12
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4797,7 +4797,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4814,7 +4814,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4838,9 +4838,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             13
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4871,7 +4871,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4888,7 +4888,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4912,9 +4912,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             14
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -4941,7 +4941,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={15}
                                     grow={0}
@@ -4956,7 +4956,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={15}
                                         element="div"
@@ -4978,20 +4978,20 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             15
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -5023,7 +5023,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-27"
               columns={12}
@@ -5060,7 +5060,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-25"
                       columns={12}
@@ -5109,7 +5109,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5126,7 +5126,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5150,9 +5150,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5187,7 +5187,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   shrink={0}
                                   span={7}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-175"
                                     columns={12}
                                     grow={0}
@@ -5206,7 +5206,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       shrink={0}
                                       span={7}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-173"
                                         columns={12}
                                         element="div"
@@ -5232,9 +5232,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             7
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5261,7 +5261,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5276,7 +5276,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5298,20 +5298,20 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -5342,7 +5342,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-27"
               columns={12}
@@ -5379,7 +5379,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-25"
                       columns={12}
@@ -5428,7 +5428,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5445,7 +5445,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5469,9 +5469,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             1
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5502,7 +5502,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5519,7 +5519,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5543,9 +5543,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             2
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5576,7 +5576,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5593,7 +5593,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5617,9 +5617,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             3
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5650,7 +5650,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5667,7 +5667,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5691,9 +5691,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             4
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5724,7 +5724,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5741,7 +5741,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5765,9 +5765,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             5
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5798,7 +5798,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5815,7 +5815,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5839,9 +5839,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             6
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5872,7 +5872,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5889,7 +5889,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5913,9 +5913,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             7
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -5946,7 +5946,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -5963,7 +5963,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -5987,9 +5987,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             8
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6020,7 +6020,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -6037,7 +6037,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -6061,9 +6061,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             9
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6094,7 +6094,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -6111,7 +6111,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -6135,9 +6135,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             10
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6168,7 +6168,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -6185,7 +6185,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -6209,9 +6209,9 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             11
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6238,7 +6238,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -6253,7 +6253,7 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -6275,20 +6275,20 @@ exports[`Grid demo examples Snapshots: columns 1`] = `
                                             12
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -6770,7 +6770,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <Grid
+              <Flex
                 alignItems="stretch"
                 className="emotion-27"
                 columns={12}
@@ -6807,7 +6807,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                       justifyContent="start"
                       wrap={true}
                     >
-                      <FlexItem
+                      <Box
                         alignItems="stretch"
                         className="emotion-25"
                         columns={12}
@@ -6856,7 +6856,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="1em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -6873,7 +6873,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="1em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -6897,9 +6897,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               A
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -6930,7 +6930,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="1em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -6947,7 +6947,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="1em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -6971,9 +6971,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               B
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7000,7 +7000,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth="md"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7015,7 +7015,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth="md"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7037,20 +7037,20 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               C
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
                             </Styled(GridItem)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </Flex>
                   </Component>
                 </WithTheme(Component)>
-              </Grid>
+              </Flex>
             </Grid>
           </withProps(Grid)>
         </Grid>
@@ -7082,7 +7082,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <Grid
+              <Flex
                 alignItems="stretch"
                 className="emotion-27"
                 columns={12}
@@ -7119,7 +7119,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                       justifyContent="start"
                       wrap={true}
                     >
-                      <FlexItem
+                      <Box
                         alignItems="stretch"
                         className="emotion-25"
                         columns={12}
@@ -7168,7 +7168,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="2em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7185,7 +7185,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="2em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7209,9 +7209,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               A
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7242,7 +7242,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="2em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7259,7 +7259,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="2em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7283,9 +7283,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               B
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7312,7 +7312,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth="xl"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7327,7 +7327,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth="xl"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7349,20 +7349,20 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               C
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
                             </Styled(GridItem)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </Flex>
                   </Component>
                 </WithTheme(Component)>
-              </Grid>
+              </Flex>
             </Grid>
           </withProps(Grid)>
         </Grid>
@@ -7394,7 +7394,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <Grid
+              <Flex
                 alignItems="stretch"
                 className="emotion-27"
                 columns={12}
@@ -7431,7 +7431,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                       justifyContent="start"
                       wrap={true}
                     >
-                      <FlexItem
+                      <Box
                         alignItems="stretch"
                         className="emotion-25"
                         columns={12}
@@ -7480,7 +7480,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="2.5em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7497,7 +7497,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="2.5em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7521,9 +7521,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               A
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7554,7 +7554,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="2.5em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7571,7 +7571,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="2.5em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7595,9 +7595,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               B
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7624,7 +7624,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth="2.5em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7639,7 +7639,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth="2.5em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7661,20 +7661,20 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               C
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
                             </Styled(GridItem)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </Flex>
                   </Component>
                 </WithTheme(Component)>
-              </Grid>
+              </Flex>
             </Grid>
           </withProps(Grid)>
         </Grid>
@@ -7706,7 +7706,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <Grid
+              <Flex
                 alignItems="stretch"
                 className="emotion-27"
                 columns={12}
@@ -7743,7 +7743,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                       justifyContent="start"
                       wrap={true}
                     >
-                      <FlexItem
+                      <Box
                         alignItems="stretch"
                         className="emotion-25"
                         columns={12}
@@ -7792,7 +7792,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="3.125em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7809,7 +7809,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="3.125em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7833,9 +7833,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               A
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7866,7 +7866,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     marginEnd="3.125em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7883,7 +7883,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         marginEnd="3.125em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7907,9 +7907,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               B
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -7936,7 +7936,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth={50}
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -7951,7 +7951,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth={50}
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -7973,20 +7973,20 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               C
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
                             </Styled(GridItem)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </Flex>
                   </Component>
                 </WithTheme(Component)>
-              </Grid>
+              </Flex>
             </Grid>
           </withProps(Grid)>
         </Grid>
@@ -8018,7 +8018,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <Grid
+              <Flex
                 alignItems="stretch"
                 className="emotion-27"
                 columns={12}
@@ -8055,7 +8055,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                       justifyContent="start"
                       wrap={true}
                     >
-                      <FlexItem
+                      <Box
                         alignItems="stretch"
                         className="emotion-25"
                         columns={12}
@@ -8100,7 +8100,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth={0}
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -8115,7 +8115,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth={0}
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -8137,9 +8137,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               A
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -8166,7 +8166,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth={0}
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -8181,7 +8181,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth={0}
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -8203,9 +8203,9 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               B
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -8232,7 +8232,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                     gutterWidth={0}
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -8247,7 +8247,7 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                         gutterWidth={0}
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -8269,20 +8269,20 @@ exports[`Grid demo examples Snapshots: gutters 1`] = `
                                               C
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
                             </Styled(GridItem)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </Flex>
                   </Component>
                 </WithTheme(Component)>
-              </Grid>
+              </Flex>
             </Grid>
           </withProps(Grid)>
         </Grid>
@@ -8595,7 +8595,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <Grid
+              <Flex
                 alignItems="stretch"
                 className="emotion-27"
                 columns={12}
@@ -8632,7 +8632,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                       justifyContent="start"
                       wrap={true}
                     >
-                      <FlexItem
+                      <Box
                         alignItems="stretch"
                         className="emotion-25"
                         columns={12}
@@ -8681,7 +8681,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                     marginEnd="1em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -8698,7 +8698,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                         marginEnd="1em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -8722,9 +8722,9 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                               ا
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -8755,7 +8755,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                     marginEnd="1em"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -8772,7 +8772,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                         marginEnd="1em"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -8796,9 +8796,9 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                               ب
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
@@ -8825,7 +8825,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                     gutterWidth="md"
                                     shrink={0}
                                   >
-                                    <GridItem
+                                    <FlexItem
                                       className="emotion-3"
                                       columns={12}
                                       grow={0}
@@ -8840,7 +8840,7 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                         gutterWidth="md"
                                         shrink={0}
                                       >
-                                        <FlexItem
+                                        <Box
                                           className="emotion-1"
                                           columns={12}
                                           element="div"
@@ -8862,20 +8862,20 @@ exports[`Grid demo examples Snapshots: rtl 1`] = `
                                               د
                                             </div>
                                           </Styled(div)>
-                                        </FlexItem>
+                                        </Box>
                                       </FlexItem>
-                                    </GridItem>
+                                    </FlexItem>
                                   </GridItem>
                                 </withProps(GridItem)>
                               </GridItem>
                             </Styled(GridItem)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </Flex>
                   </Component>
                 </WithTheme(Component)>
-              </Grid>
+              </Flex>
             </Grid>
           </withProps(Grid)>
         </Grid>

--- a/src/library/Grid/__tests__/__snapshots__/GridItem.spec.js.snap
+++ b/src/library/Grid/__tests__/__snapshots__/GridItem.spec.js.snap
@@ -312,7 +312,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -349,7 +349,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -398,7 +398,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -415,7 +415,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -439,9 +439,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             A
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -468,7 +468,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -483,7 +483,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -505,20 +505,20 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             B
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -549,7 +549,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -586,7 +586,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -635,7 +635,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -652,7 +652,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -676,9 +676,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             A
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -709,7 +709,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -726,7 +726,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -750,9 +750,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             B
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -779,7 +779,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -794,7 +794,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -816,20 +816,20 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             C
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -860,7 +860,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -897,7 +897,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -946,7 +946,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -963,7 +963,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -987,9 +987,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             A
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1020,7 +1020,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1037,7 +1037,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1061,9 +1061,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             B
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1094,7 +1094,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1111,7 +1111,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1135,9 +1135,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             C
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1164,7 +1164,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1179,7 +1179,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1201,20 +1201,20 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             D
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -1245,7 +1245,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -1282,7 +1282,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -1331,7 +1331,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1348,7 +1348,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1372,9 +1372,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             1
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1405,7 +1405,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1422,7 +1422,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1446,9 +1446,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             2
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1479,7 +1479,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1496,7 +1496,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1520,9 +1520,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             3
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1553,7 +1553,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1570,7 +1570,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1594,9 +1594,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             4
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1627,7 +1627,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1644,7 +1644,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1668,9 +1668,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             5
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1701,7 +1701,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1718,7 +1718,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1742,9 +1742,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             6
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1775,7 +1775,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1792,7 +1792,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1816,9 +1816,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             7
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1849,7 +1849,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1866,7 +1866,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1890,9 +1890,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             8
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1923,7 +1923,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -1940,7 +1940,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -1964,9 +1964,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             9
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -1997,7 +1997,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2014,7 +2014,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2038,9 +2038,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             10
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -2071,7 +2071,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2088,7 +2088,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2112,9 +2112,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             11
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -2141,7 +2141,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2156,7 +2156,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2178,20 +2178,20 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             12
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -2223,7 +2223,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -2260,7 +2260,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -2309,7 +2309,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2326,7 +2326,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2350,9 +2350,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             A
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -2383,7 +2383,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2400,7 +2400,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2424,9 +2424,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             B
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -2457,7 +2457,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2474,7 +2474,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2498,9 +2498,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             C
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -2531,7 +2531,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2548,7 +2548,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2572,9 +2572,9 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             D
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -2601,7 +2601,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -2616,7 +2616,7 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -2638,20 +2638,20 @@ exports[`GridItem demo examples Snapshots: basic 1`] = `
                                             E
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -3146,7 +3146,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
         justifyContent="start"
         wrap={true}
       >
-        <Grid
+        <Flex
           alignItems="stretch"
           className="emotion-27"
           columns={12}
@@ -3183,7 +3183,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-25"
                   columns={12}
@@ -3232,7 +3232,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                               marginEnd="1em"
                               shrink={0}
                             >
-                              <GridItem
+                              <FlexItem
                                 className="emotion-3"
                                 columns={12}
                                 grow={0}
@@ -3249,7 +3249,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     columns={12}
                                     element="div"
@@ -3273,9 +3273,9 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                                         A
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
@@ -3310,7 +3310,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                               padding="lg"
                               shrink={0}
                             >
-                              <GridItem
+                              <FlexItem
                                 className="emotion-11"
                                 columns={12}
                                 grow={0}
@@ -3329,7 +3329,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                                   padding="lg"
                                   shrink={0}
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-9"
                                     columns={12}
                                     element="div"
@@ -3355,9 +3355,9 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                                         B
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
@@ -3384,7 +3384,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                               gutterWidth="md"
                               shrink={0}
                             >
-                              <GridItem
+                              <FlexItem
                                 className="emotion-3"
                                 columns={12}
                                 grow={0}
@@ -3399,7 +3399,7 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     columns={12}
                                     element="div"
@@ -3421,20 +3421,20 @@ exports[`GridItem demo examples Snapshots: box-props 1`] = `
                                         C
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
                       </Styled(GridItem)>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
-        </Grid>
+        </Flex>
       </Grid>
     </withProps(Grid)>
   </Grid>
@@ -4078,7 +4078,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
         justifyContent="start"
         wrap={true}
       >
-        <Grid
+        <Flex
           alignItems="stretch"
           breakpoints={
             Array [
@@ -4135,7 +4135,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                 justifyContent="start"
                 wrap={true}
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   breakpoints={
                     Array [
@@ -4238,7 +4238,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                 ]
                               }
                             >
-                              <GridItem
+                              <FlexItem
                                 breakpoints={
                                   Array [
                                     800,
@@ -4277,7 +4277,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                     ]
                                   }
                                 >
-                                  <FlexItem
+                                  <Box
                                     breakpoints={
                                       Array [
                                         800,
@@ -4323,9 +4323,9 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                         A
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
@@ -4400,7 +4400,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                 ]
                               }
                             >
-                              <GridItem
+                              <FlexItem
                                 breakpoints={
                                   Array [
                                     800,
@@ -4439,7 +4439,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                     ]
                                   }
                                 >
-                                  <FlexItem
+                                  <Box
                                     breakpoints={
                                       Array [
                                         800,
@@ -4485,9 +4485,9 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                         B
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
@@ -4558,7 +4558,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                 ]
                               }
                             >
-                              <GridItem
+                              <FlexItem
                                 breakpoints={
                                   Array [
                                     800,
@@ -4595,7 +4595,7 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                     ]
                                   }
                                 >
-                                  <FlexItem
+                                  <Box
                                     breakpoints={
                                       Array [
                                         800,
@@ -4639,20 +4639,20 @@ exports[`GridItem demo examples Snapshots: responsive 1`] = `
                                         C
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
+                                  </Box>
                                 </FlexItem>
-                              </GridItem>
+                              </FlexItem>
                             </GridItem>
                           </withProps(GridItem)>
                         </GridItem>
                       </Styled(GridItem)>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
-        </Grid>
+        </Flex>
       </Grid>
     </withProps(Grid)>
   </Grid>
@@ -6253,7 +6253,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -6290,7 +6290,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -6343,7 +6343,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={1}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-3"
                                     columns={12}
                                     grow={0}
@@ -6362,7 +6362,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={1}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-1"
                                         columns={12}
                                         element="div"
@@ -6388,9 +6388,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             1
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6421,7 +6421,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={11}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-11"
                                     columns={12}
                                     grow={0}
@@ -6438,7 +6438,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={11}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-9"
                                         columns={12}
                                         element="div"
@@ -6462,20 +6462,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             11
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -6506,7 +6506,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -6543,7 +6543,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -6596,7 +6596,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={2}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-29"
                                     columns={12}
                                     grow={0}
@@ -6615,7 +6615,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={2}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-27"
                                         columns={12}
                                         element="div"
@@ -6641,9 +6641,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             2
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6674,7 +6674,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={10}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-37"
                                     columns={12}
                                     grow={0}
@@ -6691,7 +6691,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={10}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-35"
                                         columns={12}
                                         element="div"
@@ -6715,20 +6715,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             10
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -6759,7 +6759,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -6796,7 +6796,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -6849,7 +6849,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={3}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-55"
                                     columns={12}
                                     grow={0}
@@ -6868,7 +6868,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={3}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-53"
                                         columns={12}
                                         element="div"
@@ -6894,9 +6894,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             3
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -6927,7 +6927,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={9}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-63"
                                     columns={12}
                                     grow={0}
@@ -6944,7 +6944,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={9}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-61"
                                         columns={12}
                                         element="div"
@@ -6968,20 +6968,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             9
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -7012,7 +7012,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -7049,7 +7049,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -7102,7 +7102,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={4}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-81"
                                     columns={12}
                                     grow={0}
@@ -7121,7 +7121,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={4}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-79"
                                         columns={12}
                                         element="div"
@@ -7147,9 +7147,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             4
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -7180,7 +7180,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={8}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-89"
                                     columns={12}
                                     grow={0}
@@ -7197,7 +7197,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={8}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-87"
                                         columns={12}
                                         element="div"
@@ -7221,20 +7221,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             8
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -7265,7 +7265,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -7302,7 +7302,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -7355,7 +7355,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={5}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-107"
                                     columns={12}
                                     grow={0}
@@ -7374,7 +7374,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={5}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-105"
                                         columns={12}
                                         element="div"
@@ -7400,9 +7400,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             5
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -7433,7 +7433,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={7}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-115"
                                     columns={12}
                                     grow={0}
@@ -7450,7 +7450,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={7}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-113"
                                         columns={12}
                                         element="div"
@@ -7474,20 +7474,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             7
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -7518,7 +7518,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -7555,7 +7555,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -7604,7 +7604,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-133"
                                     columns={12}
                                     grow={0}
@@ -7621,7 +7621,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-131"
                                         columns={12}
                                         element="div"
@@ -7645,9 +7645,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -7678,7 +7678,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-133"
                                     columns={12}
                                     grow={0}
@@ -7695,7 +7695,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-131"
                                         columns={12}
                                         element="div"
@@ -7719,9 +7719,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -7756,7 +7756,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={6}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-149"
                                     columns={12}
                                     grow={0}
@@ -7775,7 +7775,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={6}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-147"
                                         columns={12}
                                         element="div"
@@ -7801,9 +7801,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             6
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -7830,7 +7830,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-133"
                                     columns={12}
                                     grow={0}
@@ -7845,7 +7845,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-131"
                                         columns={12}
                                         element="div"
@@ -7867,20 +7867,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>
@@ -7912,7 +7912,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
             justifyContent="start"
             wrap={true}
           >
-            <Grid
+            <Flex
               alignItems="stretch"
               className="emotion-19"
               columns={12}
@@ -7949,7 +7949,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                     justifyContent="start"
                     wrap={true}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       className="emotion-17"
                       columns={12}
@@ -7998,7 +7998,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-133"
                                     columns={12}
                                     grow={0}
@@ -8015,7 +8015,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-131"
                                         columns={12}
                                         element="div"
@@ -8039,9 +8039,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -8072,7 +8072,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   marginEnd="1em"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-133"
                                     columns={12}
                                     grow={0}
@@ -8089,7 +8089,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       marginEnd="1em"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-131"
                                         columns={12}
                                         element="div"
@@ -8113,9 +8113,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -8150,7 +8150,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   shrink={0}
                                   span={4}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-81"
                                     columns={12}
                                     grow={0}
@@ -8169,7 +8169,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       shrink={0}
                                       span={4}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-79"
                                         columns={12}
                                         element="div"
@@ -8195,9 +8195,9 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             4
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
@@ -8224,7 +8224,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                   gutterWidth="md"
                                   shrink={0}
                                 >
-                                  <GridItem
+                                  <FlexItem
                                     className="emotion-133"
                                     columns={12}
                                     grow={0}
@@ -8239,7 +8239,7 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                       gutterWidth="md"
                                       shrink={0}
                                     >
-                                      <FlexItem
+                                      <Box
                                         className="emotion-131"
                                         columns={12}
                                         element="div"
@@ -8261,20 +8261,20 @@ exports[`GridItem demo examples Snapshots: span 1`] = `
                                             Auto
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </FlexItem>
-                                  </GridItem>
+                                  </FlexItem>
                                 </GridItem>
                               </withProps(GridItem)>
                             </GridItem>
                           </Styled(GridItem)>
                         </div>
                       </Styled(div)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </Grid>
+            </Flex>
           </Grid>
         </withProps(Grid)>
       </Grid>

--- a/src/library/Link/Link.js
+++ b/src/library/Link/Link.js
@@ -7,6 +7,8 @@ import { linkPropTypes } from './propTypes';
 import type { LinkProps } from './types';
 
 export default class Link extends Component<LinkProps> {
+  static displayName = 'Link';
+
   static defaultProps = {
     element: 'a'
   };

--- a/src/library/Menu/Menu.js
+++ b/src/library/Menu/Menu.js
@@ -34,6 +34,8 @@ export const getItems = (data: MenuItems | MenuItemGroups) => {
 };
 
 export default class Menu extends PureComponent<MenuProps> {
+  static displayName = 'Menu';
+
   static propTypes = menuPropTypes;
 
   render() {

--- a/src/library/Menu/MenuDivider.js
+++ b/src/library/Menu/MenuDivider.js
@@ -9,6 +9,7 @@ const MenuDivider = (props: MenuDividerProps) => (
   <Root {...props} role="separator" />
 );
 
+MenuDivider.displayName = 'MenuDivider';
 MenuDivider.propTypes = menuDividerPropTypes;
 
 export default MenuDivider;

--- a/src/library/Menu/MenuGroup.js
+++ b/src/library/Menu/MenuGroup.js
@@ -16,6 +16,7 @@ const MenuGroup = (props: MenuGroupProps) => {
   );
 };
 
+MenuGroup.displayName = 'MenuGroup';
 MenuGroup.propTypes = menuGroupPropTypes;
 
 export default MenuGroup;

--- a/src/library/Menu/MenuGroupTitle.js
+++ b/src/library/Menu/MenuGroupTitle.js
@@ -7,6 +7,7 @@ import type { MenuGroupTitleProps } from './types';
 
 const MenuGroupTitle = (props: MenuGroupTitleProps) => <Root {...props} />;
 
+MenuGroupTitle.displayName = 'MenuGroupTitle';
 MenuGroupTitle.propTypes = menuGroupTitlePropTypes;
 
 export default MenuGroupTitle;

--- a/src/library/Menu/MenuItem.js
+++ b/src/library/Menu/MenuItem.js
@@ -22,6 +22,8 @@ const variantIcons = {
 };
 
 export default class MenuItem extends PureComponent<MenuItemProps> {
+  static displayName = 'MenuItem';
+
   static propTypes = menuItemPropTypes;
 
   render() {

--- a/src/library/OverflowContainer/OverflowContainer.js
+++ b/src/library/OverflowContainer/OverflowContainer.js
@@ -10,6 +10,8 @@ export default class OverflowContainer extends Component<
   OverflowContainerProps,
   OverflowContainerState
 > {
+  static displayName = 'OverflowContainer';
+
   state = {
     scrollable: false
   };

--- a/src/library/OverflowContainer/OverflowContainerWithShadows.js
+++ b/src/library/OverflowContainer/OverflowContainerWithShadows.js
@@ -13,6 +13,8 @@ export default class OverflowContainerWithShadows extends Component<
   OverflowContainerWithShadowsProps,
   OverflowContainerWithShadowsState
 > {
+  static displayName = 'OverflowContainerWithShadows';
+
   container: ?HTMLElement;
 
   setContainerRef = (node: HTMLElement) => {

--- a/src/library/OverflowContainer/__tests__/__snapshots__/OverflowContainerWithShadows.spec.js.snap
+++ b/src/library/OverflowContainer/__tests__/__snapshots__/OverflowContainerWithShadows.spec.js.snap
@@ -62,7 +62,7 @@ exports[`OverflowContainerWithShadows applies shadow when scrollable 1`] = `
         scrollX={true}
         tabIndex={0}
       >
-        <Scroller
+        <WithTheme(Themed(OverflowContainer))
           className="emotion-1"
           containerRef={[Function]}
           onScroll={[Function]}
@@ -115,7 +115,7 @@ exports[`OverflowContainerWithShadows applies shadow when scrollable 1`] = `
               </ThemeProvider>
             </ThemeProvider>
           </Themed(OverflowContainer)>
-        </Scroller>
+        </WithTheme(Themed(OverflowContainer))>
       </Scroller>
     </div>
   </OverflowContainerWithShadows>
@@ -164,7 +164,7 @@ exports[`OverflowContainerWithShadows does not apply shadow when not scrollable 
         onScroll={[Function]}
         scrollX={true}
       >
-        <Scroller
+        <WithTheme(Themed(OverflowContainer))
           className="emotion-1"
           containerRef={[Function]}
           onScroll={[Function]}
@@ -212,7 +212,7 @@ exports[`OverflowContainerWithShadows does not apply shadow when not scrollable 
               </ThemeProvider>
             </ThemeProvider>
           </Themed(OverflowContainer)>
-        </Scroller>
+        </WithTheme(Themed(OverflowContainer))>
       </Scroller>
     </div>
   </OverflowContainerWithShadows>

--- a/src/library/Pagination/PageJumper.js
+++ b/src/library/Pagination/PageJumper.js
@@ -9,6 +9,8 @@ import {
 import type { PageJumperProps } from './types';
 
 export default class PageJumper extends PureComponent<PageJumperProps> {
+  static displayName = 'PageJumper';
+
   render() {
     const { inputRef, messages, size, ...restProps } = this.props;
     const rootProps = {

--- a/src/library/Pagination/PageSizer.js
+++ b/src/library/Pagination/PageSizer.js
@@ -7,6 +7,8 @@ import Select from '../Select';
 import type { PageSizerProps } from './types';
 
 export default class PageSizer extends PureComponent<PageSizerProps> {
+  static displayName = 'PageSizer';
+
   render() {
     const {
       currentPage,

--- a/src/library/Pagination/Pages.js
+++ b/src/library/Pagination/Pages.js
@@ -93,6 +93,7 @@ const getPageButtons = ({
     .filter((page) => !!page);
 };
 
+// eslint-disable-next-line react/display-name
 const IncrementButton = ({
   currentPage,
   direction,
@@ -132,6 +133,8 @@ const IncrementButton = ({
 };
 
 export default class Pages extends PureComponent<PagesProps> {
+  static displayName = 'Pages';
+
   previousButton: ?HTMLButtonElement;
 
   nextButton: ?HTMLButtonElement;

--- a/src/library/Pagination/__tests__/Pagination.spec.js
+++ b/src/library/Pagination/__tests__/Pagination.spec.js
@@ -51,6 +51,7 @@ const mountApp = (props = {}) => {
   return mount(<App {...appProps} />);
 };
 
+// eslint-disable-next-line react/display-name
 class App extends Component<*, *> {
   state = {
     currentPage: this.props.currentPage,

--- a/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
+++ b/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
@@ -694,7 +694,7 @@ exports[`Pagination demo examples Snapshots: basic 1`] = `
             showPageNumbers={true}
             visibleRange={5}
           >
-            <FlexItem
+            <Flex
               alignItems="stretch"
               aria-label="Pagination"
               className="emotion-46"
@@ -742,7 +742,7 @@ exports[`Pagination demo examples Snapshots: basic 1`] = `
                     showPageNumbers={true}
                     visibleRange={5}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       aria-label="Pagination"
                       className="emotion-44"
@@ -780,7 +780,7 @@ exports[`Pagination demo examples Snapshots: basic 1`] = `
                               grow={0}
                               shrink={1}
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-41"
                                 element="div"
                                 grow={0}
@@ -869,7 +869,7 @@ exports[`Pagination demo examples Snapshots: basic 1`] = `
                                             totalPages={10}
                                             visibleRange={5}
                                           >
-                                            <FlexItem
+                                            <Box
                                               className="emotion-36"
                                               currentPage={1}
                                               element="div"
@@ -1508,23 +1508,23 @@ exports[`Pagination demo examples Snapshots: basic 1`] = `
                                                   </IncrementButton>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </FlexItem>
                                         </FlexItem>
                                       </Styled(FlexItem)>
                                     </Pages>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </FlexItem>
                           </FlexItem>
                         </nav>
                       </Styled(nav)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </FlexItem>
+            </Flex>
           </Styled(Flex)>
         </withProps(Styled(Flex))>
       </Pagination>
@@ -4000,7 +4000,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-97"
@@ -4052,7 +4052,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-95"
@@ -4099,7 +4099,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     marginEnd="0.5em"
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Flex
                                       alignItems="stretch"
                                       className="emotion-53"
                                       direction="row"
@@ -4144,7 +4144,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                             marginEnd="0.5em"
                                             shrink={1}
                                           >
-                                            <FlexItem
+                                            <Box
                                               alignItems="stretch"
                                               className="emotion-51"
                                               direction="row"
@@ -4183,7 +4183,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginEnd="1em"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -4237,7 +4237,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                   onPageSizeChange={[Function]}
                                                                   shrink={1}
                                                                 >
-                                                                  <FlexItem
+                                                                  <Box
                                                                     className="emotion-25"
                                                                     element="div"
                                                                     grow={0}
@@ -4380,7 +4380,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                     placement="bottom-start"
                                                                                     size="small"
                                                                                   >
-                                                                                    <Select
+                                                                                    <WithTheme(Themed(Dropdown))
                                                                                       aria-describedby="formField-64-caption"
                                                                                       className="emotion-17"
                                                                                       data={
@@ -4577,7 +4577,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                   tag="span"
                                                                                                   triggerRef={[Function]}
                                                                                                 >
-                                                                                                  <Popover
+                                                                                                  <Manager
                                                                                                     aria-describedby="formField-64-caption"
                                                                                                     className="emotion-15"
                                                                                                     id="select-65"
@@ -4615,7 +4615,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                         <PopoverTrigger
                                                                                                           component="span"
                                                                                                         >
-                                                                                                          <PopoverTrigger
+                                                                                                          <Target
                                                                                                             className="emotion-13"
                                                                                                             component="span"
                                                                                                           >
@@ -4680,7 +4680,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                   size="small"
                                                                                                                   tabIndex={0}
                                                                                                                 >
-                                                                                                                  <SelectTrigger
+                                                                                                                  <WithTheme(Themed(FauxControl))
                                                                                                                     afterItems={
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -4908,28 +4908,29 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         </ThemeProvider>
                                                                                                                       </ThemeProvider>
                                                                                                                     </Themed(FauxControl)>
-                                                                                                                  </SelectTrigger>
+                                                                                                                  </WithTheme(Themed(FauxControl))>
                                                                                                                 </SelectTrigger>
                                                                                                               </SelectTrigger>
                                                                                                             </span>
-                                                                                                          </PopoverTrigger>
+                                                                                                          </Target>
                                                                                                         </PopoverTrigger>
                                                                                                       </PopoverTrigger>
                                                                                                     </span>
-                                                                                                  </Popover>
+                                                                                                  </Manager>
                                                                                                 </Popover>
                                                                                               </Popover>
                                                                                             </Dropdown>
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(Dropdown)>
-                                                                                    </Select>
+                                                                                    </WithTheme(Themed(Dropdown))>
                                                                                   </Select>
                                                                                 </Select>
                                                                               </label>
                                                                               <Styled(div)
                                                                                 caption="1–2 of 14 rows"
                                                                                 id="formField-64-caption"
+                                                                                isGroup={false}
                                                                               >
                                                                                 <div
                                                                                   className="emotion-22"
@@ -4943,13 +4944,13 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                         </FormField>
                                                                       </div>
                                                                     </Styled(div)>
-                                                                  </FlexItem>
+                                                                  </Box>
                                                                 </FlexItem>
                                                               </FlexItem>
                                                             </PageSizer>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                   <FlexItem
@@ -4964,7 +4965,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginStart="auto"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -5023,7 +5024,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                     totalPages={7}
                                                                     width="4.65em"
                                                                   >
-                                                                    <FlexItem
+                                                                    <Box
                                                                       className="emotion-43"
                                                                       currentPage={1}
                                                                       element="div"
@@ -5120,7 +5121,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                         }
                                                                                         size="small"
                                                                                       >
-                                                                                        <TextInput
+                                                                                        <WithTheme(Themed(FauxControl))
                                                                                           className="emotion-34"
                                                                                           control={[Function]}
                                                                                           controlProps={
@@ -5242,7 +5243,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                               </ThemeProvider>
                                                                                             </ThemeProvider>
                                                                                           </Themed(FauxControl)>
-                                                                                        </TextInput>
+                                                                                        </WithTheme(Themed(FauxControl))>
                                                                                       </TextInput>
                                                                                     </TextInput>
                                                                                   </Styled(TextInput)>
@@ -5264,23 +5265,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                           </FormField>
                                                                         </div>
                                                                       </Styled(div)>
-                                                                    </FlexItem>
+                                                                    </Box>
                                                                   </FlexItem>
                                                                 </FlexItem>
                                                               </Styled(FlexItem)>
                                                             </PageJumper>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </Flex>
                                         </Component>
                                       </WithTheme(Component)>
-                                    </FlexItem>
+                                    </Flex>
                                   </FlexItem>
                                 </FlexItem>
                                 <FlexItem
@@ -5293,7 +5294,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-25"
                                       element="div"
                                       grow={0}
@@ -5386,7 +5387,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                   totalPages={7}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-87"
                                                     currentPage={1}
                                                     element="div"
@@ -5937,23 +5938,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -6039,7 +6040,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-97"
@@ -6091,7 +6092,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-95"
@@ -6138,7 +6139,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     marginEnd="0.5em"
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Flex
                                       alignItems="stretch"
                                       className="emotion-53"
                                       direction="row"
@@ -6183,7 +6184,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                             marginEnd="0.5em"
                                             shrink={1}
                                           >
-                                            <FlexItem
+                                            <Box
                                               alignItems="stretch"
                                               className="emotion-51"
                                               direction="row"
@@ -6222,7 +6223,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginEnd="1em"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -6276,7 +6277,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                   onPageSizeChange={[Function]}
                                                                   shrink={1}
                                                                 >
-                                                                  <FlexItem
+                                                                  <Box
                                                                     className="emotion-25"
                                                                     element="div"
                                                                     grow={0}
@@ -6419,7 +6420,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                     placement="bottom-start"
                                                                                     size="medium"
                                                                                   >
-                                                                                    <Select
+                                                                                    <WithTheme(Themed(Dropdown))
                                                                                       aria-describedby="formField-70-caption"
                                                                                       className="emotion-17"
                                                                                       data={
@@ -6616,7 +6617,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                   tag="span"
                                                                                                   triggerRef={[Function]}
                                                                                                 >
-                                                                                                  <Popover
+                                                                                                  <Manager
                                                                                                     aria-describedby="formField-70-caption"
                                                                                                     className="emotion-15"
                                                                                                     id="select-71"
@@ -6654,7 +6655,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                         <PopoverTrigger
                                                                                                           component="span"
                                                                                                         >
-                                                                                                          <PopoverTrigger
+                                                                                                          <Target
                                                                                                             className="emotion-13"
                                                                                                             component="span"
                                                                                                           >
@@ -6719,7 +6720,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                   size="medium"
                                                                                                                   tabIndex={0}
                                                                                                                 >
-                                                                                                                  <SelectTrigger
+                                                                                                                  <WithTheme(Themed(FauxControl))
                                                                                                                     afterItems={
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -6947,28 +6948,29 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         </ThemeProvider>
                                                                                                                       </ThemeProvider>
                                                                                                                     </Themed(FauxControl)>
-                                                                                                                  </SelectTrigger>
+                                                                                                                  </WithTheme(Themed(FauxControl))>
                                                                                                                 </SelectTrigger>
                                                                                                               </SelectTrigger>
                                                                                                             </span>
-                                                                                                          </PopoverTrigger>
+                                                                                                          </Target>
                                                                                                         </PopoverTrigger>
                                                                                                       </PopoverTrigger>
                                                                                                     </span>
-                                                                                                  </Popover>
+                                                                                                  </Manager>
                                                                                                 </Popover>
                                                                                               </Popover>
                                                                                             </Dropdown>
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(Dropdown)>
-                                                                                    </Select>
+                                                                                    </WithTheme(Themed(Dropdown))>
                                                                                   </Select>
                                                                                 </Select>
                                                                               </label>
                                                                               <Styled(div)
                                                                                 caption="1–2 of 14 rows"
                                                                                 id="formField-70-caption"
+                                                                                isGroup={false}
                                                                               >
                                                                                 <div
                                                                                   className="emotion-22"
@@ -6982,13 +6984,13 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                         </FormField>
                                                                       </div>
                                                                     </Styled(div)>
-                                                                  </FlexItem>
+                                                                  </Box>
                                                                 </FlexItem>
                                                               </FlexItem>
                                                             </PageSizer>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                   <FlexItem
@@ -7003,7 +7005,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginStart="auto"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -7062,7 +7064,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                     totalPages={7}
                                                                     width="4.65em"
                                                                   >
-                                                                    <FlexItem
+                                                                    <Box
                                                                       className="emotion-43"
                                                                       currentPage={1}
                                                                       element="div"
@@ -7159,7 +7161,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                         }
                                                                                         size="medium"
                                                                                       >
-                                                                                        <TextInput
+                                                                                        <WithTheme(Themed(FauxControl))
                                                                                           className="emotion-34"
                                                                                           control={[Function]}
                                                                                           controlProps={
@@ -7281,7 +7283,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                               </ThemeProvider>
                                                                                             </ThemeProvider>
                                                                                           </Themed(FauxControl)>
-                                                                                        </TextInput>
+                                                                                        </WithTheme(Themed(FauxControl))>
                                                                                       </TextInput>
                                                                                     </TextInput>
                                                                                   </Styled(TextInput)>
@@ -7303,23 +7305,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                           </FormField>
                                                                         </div>
                                                                       </Styled(div)>
-                                                                    </FlexItem>
+                                                                    </Box>
                                                                   </FlexItem>
                                                                 </FlexItem>
                                                               </Styled(FlexItem)>
                                                             </PageJumper>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </Flex>
                                         </Component>
                                       </WithTheme(Component)>
-                                    </FlexItem>
+                                    </Flex>
                                   </FlexItem>
                                 </FlexItem>
                                 <FlexItem
@@ -7332,7 +7334,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-25"
                                       element="div"
                                       grow={0}
@@ -7425,7 +7427,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                   totalPages={7}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-87"
                                                     currentPage={1}
                                                     element="div"
@@ -7976,23 +7978,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -8078,7 +8080,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-97"
@@ -8130,7 +8132,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-95"
@@ -8177,7 +8179,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     marginEnd="0.5em"
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Flex
                                       alignItems="stretch"
                                       className="emotion-53"
                                       direction="row"
@@ -8222,7 +8224,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                             marginEnd="0.5em"
                                             shrink={1}
                                           >
-                                            <FlexItem
+                                            <Box
                                               alignItems="stretch"
                                               className="emotion-51"
                                               direction="row"
@@ -8261,7 +8263,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginEnd="1em"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -8315,7 +8317,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                   onPageSizeChange={[Function]}
                                                                   shrink={1}
                                                                 >
-                                                                  <FlexItem
+                                                                  <Box
                                                                     className="emotion-25"
                                                                     element="div"
                                                                     grow={0}
@@ -8458,7 +8460,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                     placement="bottom-start"
                                                                                     size="large"
                                                                                   >
-                                                                                    <Select
+                                                                                    <WithTheme(Themed(Dropdown))
                                                                                       aria-describedby="formField-76-caption"
                                                                                       className="emotion-17"
                                                                                       data={
@@ -8655,7 +8657,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                   tag="span"
                                                                                                   triggerRef={[Function]}
                                                                                                 >
-                                                                                                  <Popover
+                                                                                                  <Manager
                                                                                                     aria-describedby="formField-76-caption"
                                                                                                     className="emotion-15"
                                                                                                     id="select-77"
@@ -8693,7 +8695,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                         <PopoverTrigger
                                                                                                           component="span"
                                                                                                         >
-                                                                                                          <PopoverTrigger
+                                                                                                          <Target
                                                                                                             className="emotion-13"
                                                                                                             component="span"
                                                                                                           >
@@ -8758,7 +8760,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                   size="large"
                                                                                                                   tabIndex={0}
                                                                                                                 >
-                                                                                                                  <SelectTrigger
+                                                                                                                  <WithTheme(Themed(FauxControl))
                                                                                                                     afterItems={
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -8986,28 +8988,29 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         </ThemeProvider>
                                                                                                                       </ThemeProvider>
                                                                                                                     </Themed(FauxControl)>
-                                                                                                                  </SelectTrigger>
+                                                                                                                  </WithTheme(Themed(FauxControl))>
                                                                                                                 </SelectTrigger>
                                                                                                               </SelectTrigger>
                                                                                                             </span>
-                                                                                                          </PopoverTrigger>
+                                                                                                          </Target>
                                                                                                         </PopoverTrigger>
                                                                                                       </PopoverTrigger>
                                                                                                     </span>
-                                                                                                  </Popover>
+                                                                                                  </Manager>
                                                                                                 </Popover>
                                                                                               </Popover>
                                                                                             </Dropdown>
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(Dropdown)>
-                                                                                    </Select>
+                                                                                    </WithTheme(Themed(Dropdown))>
                                                                                   </Select>
                                                                                 </Select>
                                                                               </label>
                                                                               <Styled(div)
                                                                                 caption="1–2 of 14 rows"
                                                                                 id="formField-76-caption"
+                                                                                isGroup={false}
                                                                               >
                                                                                 <div
                                                                                   className="emotion-22"
@@ -9021,13 +9024,13 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                         </FormField>
                                                                       </div>
                                                                     </Styled(div)>
-                                                                  </FlexItem>
+                                                                  </Box>
                                                                 </FlexItem>
                                                               </FlexItem>
                                                             </PageSizer>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                   <FlexItem
@@ -9042,7 +9045,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginStart="auto"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -9101,7 +9104,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                     totalPages={7}
                                                                     width="4.65em"
                                                                   >
-                                                                    <FlexItem
+                                                                    <Box
                                                                       className="emotion-43"
                                                                       currentPage={1}
                                                                       element="div"
@@ -9198,7 +9201,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                         }
                                                                                         size="large"
                                                                                       >
-                                                                                        <TextInput
+                                                                                        <WithTheme(Themed(FauxControl))
                                                                                           className="emotion-34"
                                                                                           control={[Function]}
                                                                                           controlProps={
@@ -9320,7 +9323,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                               </ThemeProvider>
                                                                                             </ThemeProvider>
                                                                                           </Themed(FauxControl)>
-                                                                                        </TextInput>
+                                                                                        </WithTheme(Themed(FauxControl))>
                                                                                       </TextInput>
                                                                                     </TextInput>
                                                                                   </Styled(TextInput)>
@@ -9342,23 +9345,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                           </FormField>
                                                                         </div>
                                                                       </Styled(div)>
-                                                                    </FlexItem>
+                                                                    </Box>
                                                                   </FlexItem>
                                                                 </FlexItem>
                                                               </Styled(FlexItem)>
                                                             </PageJumper>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </Flex>
                                         </Component>
                                       </WithTheme(Component)>
-                                    </FlexItem>
+                                    </Flex>
                                   </FlexItem>
                                 </FlexItem>
                                 <FlexItem
@@ -9371,7 +9374,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-25"
                                       element="div"
                                       grow={0}
@@ -9464,7 +9467,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                   totalPages={7}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-87"
                                                     currentPage={1}
                                                     element="div"
@@ -10015,23 +10018,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -10117,7 +10120,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-97"
@@ -10169,7 +10172,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-95"
@@ -10216,7 +10219,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     marginEnd="0.5em"
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Flex
                                       alignItems="stretch"
                                       className="emotion-53"
                                       direction="row"
@@ -10261,7 +10264,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                             marginEnd="0.5em"
                                             shrink={1}
                                           >
-                                            <FlexItem
+                                            <Box
                                               alignItems="stretch"
                                               className="emotion-51"
                                               direction="row"
@@ -10300,7 +10303,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginEnd="1em"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -10354,7 +10357,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                   onPageSizeChange={[Function]}
                                                                   shrink={1}
                                                                 >
-                                                                  <FlexItem
+                                                                  <Box
                                                                     className="emotion-25"
                                                                     element="div"
                                                                     grow={0}
@@ -10497,7 +10500,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                     placement="bottom-start"
                                                                                     size="jumbo"
                                                                                   >
-                                                                                    <Select
+                                                                                    <WithTheme(Themed(Dropdown))
                                                                                       aria-describedby="formField-82-caption"
                                                                                       className="emotion-17"
                                                                                       data={
@@ -10694,7 +10697,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                   tag="span"
                                                                                                   triggerRef={[Function]}
                                                                                                 >
-                                                                                                  <Popover
+                                                                                                  <Manager
                                                                                                     aria-describedby="formField-82-caption"
                                                                                                     className="emotion-15"
                                                                                                     id="select-83"
@@ -10732,7 +10735,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                         <PopoverTrigger
                                                                                                           component="span"
                                                                                                         >
-                                                                                                          <PopoverTrigger
+                                                                                                          <Target
                                                                                                             className="emotion-13"
                                                                                                             component="span"
                                                                                                           >
@@ -10797,7 +10800,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                   size="jumbo"
                                                                                                                   tabIndex={0}
                                                                                                                 >
-                                                                                                                  <SelectTrigger
+                                                                                                                  <WithTheme(Themed(FauxControl))
                                                                                                                     afterItems={
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -11025,28 +11028,29 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         </ThemeProvider>
                                                                                                                       </ThemeProvider>
                                                                                                                     </Themed(FauxControl)>
-                                                                                                                  </SelectTrigger>
+                                                                                                                  </WithTheme(Themed(FauxControl))>
                                                                                                                 </SelectTrigger>
                                                                                                               </SelectTrigger>
                                                                                                             </span>
-                                                                                                          </PopoverTrigger>
+                                                                                                          </Target>
                                                                                                         </PopoverTrigger>
                                                                                                       </PopoverTrigger>
                                                                                                     </span>
-                                                                                                  </Popover>
+                                                                                                  </Manager>
                                                                                                 </Popover>
                                                                                               </Popover>
                                                                                             </Dropdown>
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(Dropdown)>
-                                                                                    </Select>
+                                                                                    </WithTheme(Themed(Dropdown))>
                                                                                   </Select>
                                                                                 </Select>
                                                                               </label>
                                                                               <Styled(div)
                                                                                 caption="1–2 of 14 rows"
                                                                                 id="formField-82-caption"
+                                                                                isGroup={false}
                                                                               >
                                                                                 <div
                                                                                   className="emotion-22"
@@ -11060,13 +11064,13 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                         </FormField>
                                                                       </div>
                                                                     </Styled(div)>
-                                                                  </FlexItem>
+                                                                  </Box>
                                                                 </FlexItem>
                                                               </FlexItem>
                                                             </PageSizer>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                   <FlexItem
@@ -11081,7 +11085,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                       marginStart="auto"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-25"
                                                         element="div"
                                                         grow={0}
@@ -11140,7 +11144,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                     totalPages={7}
                                                                     width="4.65em"
                                                                   >
-                                                                    <FlexItem
+                                                                    <Box
                                                                       className="emotion-43"
                                                                       currentPage={1}
                                                                       element="div"
@@ -11237,7 +11241,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                         }
                                                                                         size="jumbo"
                                                                                       >
-                                                                                        <TextInput
+                                                                                        <WithTheme(Themed(FauxControl))
                                                                                           className="emotion-34"
                                                                                           control={[Function]}
                                                                                           controlProps={
@@ -11359,7 +11363,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                               </ThemeProvider>
                                                                                             </ThemeProvider>
                                                                                           </Themed(FauxControl)>
-                                                                                        </TextInput>
+                                                                                        </WithTheme(Themed(FauxControl))>
                                                                                       </TextInput>
                                                                                     </TextInput>
                                                                                   </Styled(TextInput)>
@@ -11381,23 +11385,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                           </FormField>
                                                                         </div>
                                                                       </Styled(div)>
-                                                                    </FlexItem>
+                                                                    </Box>
                                                                   </FlexItem>
                                                                 </FlexItem>
                                                               </Styled(FlexItem)>
                                                             </PageJumper>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </Flex>
                                         </Component>
                                       </WithTheme(Component)>
-                                    </FlexItem>
+                                    </Flex>
                                   </FlexItem>
                                 </FlexItem>
                                 <FlexItem
@@ -11410,7 +11414,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-25"
                                       element="div"
                                       grow={0}
@@ -11503,7 +11507,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                   totalPages={7}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-87"
                                                     currentPage={1}
                                                     element="div"
@@ -12054,23 +12058,23 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -13134,7 +13138,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
             showPageNumbers={true}
             visibleRange={5}
           >
-            <FlexItem
+            <Flex
               alignItems="stretch"
               aria-label="Pagination"
               className="emotion-73"
@@ -13182,7 +13186,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                     showPageNumbers={true}
                     visibleRange={5}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       aria-label="Pagination"
                       className="emotion-71"
@@ -13227,7 +13231,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                               marginEnd="0.5em"
                               shrink={1}
                             >
-                              <FlexItem
+                              <Flex
                                 alignItems="stretch"
                                 className="emotion-23"
                                 direction="row"
@@ -13272,7 +13276,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                       marginEnd="0.5em"
                                       shrink={1}
                                     >
-                                      <FlexItem
+                                      <Box
                                         alignItems="stretch"
                                         className="emotion-21"
                                         direction="row"
@@ -13311,7 +13315,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                 marginStart="auto"
                                                 shrink={1}
                                               >
-                                                <FlexItem
+                                                <Box
                                                   className="emotion-18"
                                                   element="div"
                                                   grow={0}
@@ -13370,7 +13374,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                               totalPages={10}
                                                               width="4.65em"
                                                             >
-                                                              <FlexItem
+                                                              <Box
                                                                 className="emotion-13"
                                                                 currentPage={1}
                                                                 element="div"
@@ -13467,7 +13471,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                                                   }
                                                                                   size="medium"
                                                                                 >
-                                                                                  <TextInput
+                                                                                  <WithTheme(Themed(FauxControl))
                                                                                     className="emotion-4"
                                                                                     control={[Function]}
                                                                                     controlProps={
@@ -13589,7 +13593,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                                                         </ThemeProvider>
                                                                                       </ThemeProvider>
                                                                                     </Themed(FauxControl)>
-                                                                                  </TextInput>
+                                                                                  </WithTheme(Themed(FauxControl))>
                                                                                 </TextInput>
                                                                               </TextInput>
                                                                             </Styled(TextInput)>
@@ -13611,23 +13615,23 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                                     </FormField>
                                                                   </div>
                                                                 </Styled(div)>
-                                                              </FlexItem>
+                                                              </Box>
                                                             </FlexItem>
                                                           </FlexItem>
                                                         </Styled(FlexItem)>
                                                       </PageJumper>
                                                     </div>
                                                   </Styled(div)>
-                                                </FlexItem>
+                                                </Box>
                                               </FlexItem>
                                             </FlexItem>
                                           </div>
                                         </Styled(div)>
-                                      </FlexItem>
+                                      </Box>
                                     </Flex>
                                   </Component>
                                 </WithTheme(Component)>
-                              </FlexItem>
+                              </Flex>
                             </FlexItem>
                           </FlexItem>
                           <FlexItem
@@ -13640,7 +13644,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                               grow={0}
                               shrink={1}
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-18"
                                 element="div"
                                 grow={0}
@@ -13729,7 +13733,7 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                             totalPages={10}
                                             visibleRange={5}
                                           >
-                                            <FlexItem
+                                            <Box
                                               className="emotion-63"
                                               currentPage={1}
                                               element="div"
@@ -14368,23 +14372,23 @@ exports[`Pagination demo examples Snapshots: page-jumper 1`] = `
                                                   </IncrementButton>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </FlexItem>
                                         </FlexItem>
                                       </Styled(FlexItem)>
                                     </Pages>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </FlexItem>
                           </FlexItem>
                         </nav>
                       </Styled(nav)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </FlexItem>
+            </Flex>
           </Styled(Flex)>
         </withProps(Styled(Flex))>
       </Pagination>
@@ -15797,7 +15801,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                             <tr
                                               className="emotion-27"
                                             >
-                                              <TableSortableHeaderCell
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="name"
                                                 label="Mineral"
@@ -15848,7 +15852,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Mineral"
                                                       className="emotion-3"
                                                       element="th"
@@ -15886,11 +15890,11 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="color"
                                                 label="Color"
@@ -15941,7 +15945,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Color"
                                                       className="emotion-3"
                                                       element="th"
@@ -15979,11 +15983,11 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="luster"
                                                 label="Luster"
@@ -16034,7 +16038,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Luster"
                                                       className="emotion-3"
                                                       element="th"
@@ -16072,11 +16076,11 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="crystalSystem"
                                                 label="Crystal System"
@@ -16127,7 +16131,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Crystal System"
                                                       className="emotion-3"
                                                       element="th"
@@ -16165,11 +16169,11 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="crystalHabit"
                                                 label="Crystal Habit"
@@ -16220,7 +16224,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Crystal Habit"
                                                       className="emotion-3"
                                                       element="th"
@@ -16258,10 +16262,10 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
+                                              </TableHeaderCell>
                                             </tr>
                                           </TableRow>
                                         </TableRow>
@@ -16699,7 +16703,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-121"
@@ -16751,7 +16755,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-119"
@@ -16798,7 +16802,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                     marginEnd="0.5em"
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Flex
                                       alignItems="stretch"
                                       className="emotion-77"
                                       direction="row"
@@ -16843,7 +16847,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                             marginEnd="0.5em"
                                             shrink={1}
                                           >
-                                            <FlexItem
+                                            <Box
                                               alignItems="stretch"
                                               className="emotion-75"
                                               direction="row"
@@ -16882,7 +16886,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                       marginEnd="1em"
                                                       shrink={1}
                                                     >
-                                                      <FlexItem
+                                                      <Box
                                                         className="emotion-69"
                                                         element="div"
                                                         grow={0}
@@ -16936,7 +16940,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                   onPageSizeChange={[Function]}
                                                                   shrink={1}
                                                                 >
-                                                                  <FlexItem
+                                                                  <Box
                                                                     className="emotion-69"
                                                                     element="div"
                                                                     grow={0}
@@ -17079,7 +17083,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                     placement="bottom-start"
                                                                                     size="medium"
                                                                                   >
-                                                                                    <Select
+                                                                                    <WithTheme(Themed(Dropdown))
                                                                                       aria-describedby="formField-39-caption"
                                                                                       className="emotion-61"
                                                                                       data={
@@ -17276,7 +17280,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                   tag="span"
                                                                                                   triggerRef={[Function]}
                                                                                                 >
-                                                                                                  <Popover
+                                                                                                  <Manager
                                                                                                     aria-describedby="formField-39-caption"
                                                                                                     className="emotion-59"
                                                                                                     id="select-40"
@@ -17314,7 +17318,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                         <PopoverTrigger
                                                                                                           component="span"
                                                                                                         >
-                                                                                                          <PopoverTrigger
+                                                                                                          <Target
                                                                                                             className="emotion-57"
                                                                                                             component="span"
                                                                                                           >
@@ -17379,7 +17383,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                   size="medium"
                                                                                                                   tabIndex={0}
                                                                                                                 >
-                                                                                                                  <SelectTrigger
+                                                                                                                  <WithTheme(Themed(FauxControl))
                                                                                                                     afterItems={
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -17607,28 +17611,29 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                         </ThemeProvider>
                                                                                                                       </ThemeProvider>
                                                                                                                     </Themed(FauxControl)>
-                                                                                                                  </SelectTrigger>
+                                                                                                                  </WithTheme(Themed(FauxControl))>
                                                                                                                 </SelectTrigger>
                                                                                                               </SelectTrigger>
                                                                                                             </span>
-                                                                                                          </PopoverTrigger>
+                                                                                                          </Target>
                                                                                                         </PopoverTrigger>
                                                                                                       </PopoverTrigger>
                                                                                                     </span>
-                                                                                                  </Popover>
+                                                                                                  </Manager>
                                                                                                 </Popover>
                                                                                               </Popover>
                                                                                             </Dropdown>
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(Dropdown)>
-                                                                                    </Select>
+                                                                                    </WithTheme(Themed(Dropdown))>
                                                                                   </Select>
                                                                                 </Select>
                                                                               </label>
                                                                               <Styled(div)
                                                                                 caption="1–2 of 14 minerals"
                                                                                 id="formField-39-caption"
+                                                                                isGroup={false}
                                                                               >
                                                                                 <div
                                                                                   className="emotion-66"
@@ -17642,22 +17647,22 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                         </FormField>
                                                                       </div>
                                                                     </Styled(div)>
-                                                                  </FlexItem>
+                                                                  </Box>
                                                                 </FlexItem>
                                                               </FlexItem>
                                                             </PageSizer>
                                                           </div>
                                                         </Styled(div)>
-                                                      </FlexItem>
+                                                      </Box>
                                                     </FlexItem>
                                                   </FlexItem>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </Flex>
                                         </Component>
                                       </WithTheme(Component)>
-                                    </FlexItem>
+                                    </Flex>
                                   </FlexItem>
                                 </FlexItem>
                                 <FlexItem
@@ -17670,7 +17675,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-69"
                                       element="div"
                                       grow={0}
@@ -17763,7 +17768,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                   totalPages={7}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-111"
                                                     currentPage={1}
                                                     element="div"
@@ -18314,23 +18319,23 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -18818,7 +18823,7 @@ exports[`Pagination demo examples Snapshots: previous-next 1`] = `
             showPageNumbers={false}
             visibleRange={5}
           >
-            <FlexItem
+            <Flex
               alignItems="stretch"
               aria-label="Pagination"
               className="emotion-19"
@@ -18866,7 +18871,7 @@ exports[`Pagination demo examples Snapshots: previous-next 1`] = `
                     showPageNumbers={false}
                     visibleRange={5}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       aria-label="Pagination"
                       className="emotion-17"
@@ -18904,7 +18909,7 @@ exports[`Pagination demo examples Snapshots: previous-next 1`] = `
                               grow={0}
                               shrink={1}
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-14"
                                 element="div"
                                 grow={0}
@@ -18993,7 +18998,7 @@ exports[`Pagination demo examples Snapshots: previous-next 1`] = `
                                             totalPages={10}
                                             visibleRange={5}
                                           >
-                                            <FlexItem
+                                            <Box
                                               className="emotion-9"
                                               currentPage={1}
                                               element="div"
@@ -19240,23 +19245,23 @@ exports[`Pagination demo examples Snapshots: previous-next 1`] = `
                                                   </IncrementButton>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </FlexItem>
                                         </FlexItem>
                                       </Styled(FlexItem)>
                                     </Pages>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </FlexItem>
                           </FlexItem>
                         </nav>
                       </Styled(nav)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </FlexItem>
+            </Flex>
           </Styled(Flex)>
         </withProps(Styled(Flex))>
       </Pagination>
@@ -20951,7 +20956,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                   <tr
                                                     className="emotion-27"
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       element="th"
                                                       key="اسم"
                                                       label="معدني"
@@ -21002,7 +21007,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                           }
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="معدني"
                                                             className="emotion-3"
                                                             element="th"
@@ -21040,11 +21045,11 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
-                                                    <TableSortableHeaderCell
+                                                    </TableHeaderCell>
+                                                    <TableHeaderCell
                                                       element="th"
                                                       key="اللون"
                                                       label="اللون"
@@ -21095,7 +21100,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                           }
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="اللون"
                                                             className="emotion-3"
                                                             element="th"
@@ -21133,11 +21138,11 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
-                                                    <TableSortableHeaderCell
+                                                    </TableHeaderCell>
+                                                    <TableHeaderCell
                                                       element="th"
                                                       key="بريق"
                                                       label="بريق"
@@ -21188,7 +21193,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                           }
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="بريق"
                                                             className="emotion-3"
                                                             element="th"
@@ -21226,11 +21231,11 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
-                                                    <TableSortableHeaderCell
+                                                    </TableHeaderCell>
+                                                    <TableHeaderCell
                                                       element="th"
                                                       key="النظام"
                                                       label="نظام الكريستال"
@@ -21281,7 +21286,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                           }
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="نظام الكريستال"
                                                             className="emotion-3"
                                                             element="th"
@@ -21319,11 +21324,11 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
-                                                    <TableSortableHeaderCell
+                                                    </TableHeaderCell>
+                                                    <TableHeaderCell
                                                       element="th"
                                                       key="عادة"
                                                       label="الكريستال العادة"
@@ -21374,7 +21379,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                           }
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="الكريستال العادة"
                                                             className="emotion-3"
                                                             element="th"
@@ -21412,10 +21417,10 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </tr>
                                                 </TableRow>
                                               </TableRow>
@@ -22056,7 +22061,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                         showPageNumbers={true}
                         visibleRange={5}
                       >
-                        <FlexItem
+                        <Flex
                           alignItems="stretch"
                           aria-label="ترقيم الصفحات"
                           className="emotion-141"
@@ -22112,7 +22117,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                 showPageNumbers={true}
                                 visibleRange={5}
                               >
-                                <FlexItem
+                                <Box
                                   alignItems="stretch"
                                   aria-label="ترقيم الصفحات"
                                   className="emotion-139"
@@ -22161,7 +22166,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                           marginEnd="0.5em"
                                           shrink={1}
                                         >
-                                          <FlexItem
+                                          <Flex
                                             alignItems="stretch"
                                             className="emotion-103"
                                             direction="row"
@@ -22206,7 +22211,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                   marginEnd="0.5em"
                                                   shrink={1}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     alignItems="stretch"
                                                     className="emotion-101"
                                                     direction="row"
@@ -22245,7 +22250,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                             marginEnd="1em"
                                                             shrink={1}
                                                           >
-                                                            <FlexItem
+                                                            <Box
                                                               className="emotion-75"
                                                               element="div"
                                                               grow={0}
@@ -22299,7 +22304,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                         onPageSizeChange={[Function]}
                                                                         shrink={1}
                                                                       >
-                                                                        <FlexItem
+                                                                        <Box
                                                                           className="emotion-75"
                                                                           element="div"
                                                                           grow={0}
@@ -22442,7 +22447,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                           placement="bottom-start"
                                                                                           size="medium"
                                                                                         >
-                                                                                          <Select
+                                                                                          <WithTheme(Themed(Dropdown))
                                                                                             aria-describedby="formField-51-caption"
                                                                                             className="emotion-67"
                                                                                             data={
@@ -22639,7 +22644,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                         tag="span"
                                                                                                         triggerRef={[Function]}
                                                                                                       >
-                                                                                                        <Popover
+                                                                                                        <Manager
                                                                                                           aria-describedby="formField-51-caption"
                                                                                                           className="emotion-65"
                                                                                                           id="select-52"
@@ -22677,7 +22682,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                               <PopoverTrigger
                                                                                                                 component="span"
                                                                                                               >
-                                                                                                                <PopoverTrigger
+                                                                                                                <Target
                                                                                                                   className="emotion-63"
                                                                                                                   component="span"
                                                                                                                 >
@@ -22742,7 +22747,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                         size="medium"
                                                                                                                         tabIndex={0}
                                                                                                                       >
-                                                                                                                        <SelectTrigger
+                                                                                                                        <WithTheme(Themed(FauxControl))
                                                                                                                           afterItems={
                                                                                                                             Array [
                                                                                                                               <withProps(Styled(IconArrowDropdownDown)) />,
@@ -22970,28 +22975,29 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                               </ThemeProvider>
                                                                                                                             </ThemeProvider>
                                                                                                                           </Themed(FauxControl)>
-                                                                                                                        </SelectTrigger>
+                                                                                                                        </WithTheme(Themed(FauxControl))>
                                                                                                                       </SelectTrigger>
                                                                                                                     </SelectTrigger>
                                                                                                                   </span>
-                                                                                                                </PopoverTrigger>
+                                                                                                                </Target>
                                                                                                               </PopoverTrigger>
                                                                                                             </PopoverTrigger>
                                                                                                           </span>
-                                                                                                        </Popover>
+                                                                                                        </Manager>
                                                                                                       </Popover>
                                                                                                     </Popover>
                                                                                                   </Dropdown>
                                                                                                 </ThemeProvider>
                                                                                               </ThemeProvider>
                                                                                             </Themed(Dropdown)>
-                                                                                          </Select>
+                                                                                          </WithTheme(Themed(Dropdown))>
                                                                                         </Select>
                                                                                       </Select>
                                                                                     </label>
                                                                                     <Styled(div)
                                                                                       caption="1–3 من 14 المعادن"
                                                                                       id="formField-51-caption"
+                                                                                      isGroup={false}
                                                                                     >
                                                                                       <div
                                                                                         className="emotion-72"
@@ -23005,13 +23011,13 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                               </FormField>
                                                                             </div>
                                                                           </Styled(div)>
-                                                                        </FlexItem>
+                                                                        </Box>
                                                                       </FlexItem>
                                                                     </FlexItem>
                                                                   </PageSizer>
                                                                 </div>
                                                               </Styled(div)>
-                                                            </FlexItem>
+                                                            </Box>
                                                           </FlexItem>
                                                         </FlexItem>
                                                         <FlexItem
@@ -23026,7 +23032,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                             marginStart="auto"
                                                             shrink={1}
                                                           >
-                                                            <FlexItem
+                                                            <Box
                                                               className="emotion-75"
                                                               element="div"
                                                               grow={0}
@@ -23085,7 +23091,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                           totalPages={5}
                                                                           width="4.65em"
                                                                         >
-                                                                          <FlexItem
+                                                                          <Box
                                                                             className="emotion-93"
                                                                             currentPage={1}
                                                                             element="div"
@@ -23182,7 +23188,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                               }
                                                                                               size="medium"
                                                                                             >
-                                                                                              <TextInput
+                                                                                              <WithTheme(Themed(FauxControl))
                                                                                                 className="emotion-84"
                                                                                                 control={[Function]}
                                                                                                 controlProps={
@@ -23304,7 +23310,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                     </ThemeProvider>
                                                                                                   </ThemeProvider>
                                                                                                 </Themed(FauxControl)>
-                                                                                              </TextInput>
+                                                                                              </WithTheme(Themed(FauxControl))>
                                                                                             </TextInput>
                                                                                           </TextInput>
                                                                                         </Styled(TextInput)>
@@ -23326,23 +23332,23 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                 </FormField>
                                                                               </div>
                                                                             </Styled(div)>
-                                                                          </FlexItem>
+                                                                          </Box>
                                                                         </FlexItem>
                                                                       </FlexItem>
                                                                     </Styled(FlexItem)>
                                                                   </PageJumper>
                                                                 </div>
                                                               </Styled(div)>
-                                                            </FlexItem>
+                                                            </Box>
                                                           </FlexItem>
                                                         </FlexItem>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </Flex>
                                               </Component>
                                             </WithTheme(Component)>
-                                          </FlexItem>
+                                          </Flex>
                                         </FlexItem>
                                       </FlexItem>
                                       <FlexItem
@@ -23355,7 +23361,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                           grow={0}
                                           shrink={1}
                                         >
-                                          <FlexItem
+                                          <Box
                                             className="emotion-75"
                                             element="div"
                                             grow={0}
@@ -23452,7 +23458,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                         totalPages={5}
                                                         visibleRange={5}
                                                       >
-                                                        <FlexItem
+                                                        <Box
                                                           className="emotion-131"
                                                           currentPage={1}
                                                           element="div"
@@ -23929,23 +23935,23 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                               </IncrementButton>
                                                             </div>
                                                           </Styled(div)>
-                                                        </FlexItem>
+                                                        </Box>
                                                       </FlexItem>
                                                     </FlexItem>
                                                   </Styled(FlexItem)>
                                                 </Pages>
                                               </div>
                                             </Styled(div)>
-                                          </FlexItem>
+                                          </Box>
                                         </FlexItem>
                                       </FlexItem>
                                     </nav>
                                   </Styled(nav)>
-                                </FlexItem>
+                                </Box>
                               </Flex>
                             </Component>
                           </WithTheme(Component)>
-                        </FlexItem>
+                        </Flex>
                       </Styled(Flex)>
                     </withProps(Styled(Flex))>
                   </Pagination>
@@ -25385,7 +25391,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-46"
@@ -25433,7 +25439,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-44"
@@ -25471,7 +25477,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-41"
                                       element="div"
                                       grow={0}
@@ -25560,7 +25566,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                   totalPages={10}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-36"
                                                     currentPage={1}
                                                     element="div"
@@ -26199,23 +26205,23 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -26286,7 +26292,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-46"
@@ -26334,7 +26340,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-44"
@@ -26372,7 +26378,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-41"
                                       element="div"
                                       grow={0}
@@ -26461,7 +26467,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                   totalPages={10}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-36"
                                                     currentPage={1}
                                                     element="div"
@@ -27100,23 +27106,23 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -27187,7 +27193,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-46"
@@ -27235,7 +27241,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-44"
@@ -27273,7 +27279,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-41"
                                       element="div"
                                       grow={0}
@@ -27362,7 +27368,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                   totalPages={10}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-36"
                                                     currentPage={1}
                                                     element="div"
@@ -28001,23 +28007,23 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -28088,7 +28094,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <FlexItem
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-46"
@@ -28136,7 +28142,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-44"
@@ -28174,7 +28180,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-41"
                                       element="div"
                                       grow={0}
@@ -28263,7 +28269,7 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                   totalPages={10}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-36"
                                                     currentPage={1}
                                                     element="div"
@@ -28902,23 +28908,23 @@ exports[`Pagination demo examples Snapshots: sizes 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
                                               </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
                                 </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </FlexItem>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -29487,7 +29493,7 @@ exports[`Pagination demo examples Snapshots: visible-range 1`] = `
             showPageNumbers={true}
             visibleRange={3}
           >
-            <FlexItem
+            <Flex
               alignItems="stretch"
               aria-label="Pagination"
               className="emotion-40"
@@ -29535,7 +29541,7 @@ exports[`Pagination demo examples Snapshots: visible-range 1`] = `
                     showPageNumbers={true}
                     visibleRange={3}
                   >
-                    <FlexItem
+                    <Box
                       alignItems="stretch"
                       aria-label="Pagination"
                       className="emotion-38"
@@ -29573,7 +29579,7 @@ exports[`Pagination demo examples Snapshots: visible-range 1`] = `
                               grow={0}
                               shrink={1}
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-35"
                                 element="div"
                                 grow={0}
@@ -29662,7 +29668,7 @@ exports[`Pagination demo examples Snapshots: visible-range 1`] = `
                                             totalPages={10}
                                             visibleRange={3}
                                           >
-                                            <FlexItem
+                                            <Box
                                               className="emotion-30"
                                               currentPage={5}
                                               element="div"
@@ -30233,23 +30239,23 @@ exports[`Pagination demo examples Snapshots: visible-range 1`] = `
                                                   </IncrementButton>
                                                 </div>
                                               </Styled(div)>
-                                            </FlexItem>
+                                            </Box>
                                           </FlexItem>
                                         </FlexItem>
                                       </Styled(FlexItem)>
                                     </Pages>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </FlexItem>
                           </FlexItem>
                         </nav>
                       </Styled(nav)>
-                    </FlexItem>
+                    </Box>
                   </Flex>
                 </Component>
               </WithTheme(Component)>
-            </FlexItem>
+            </Flex>
           </Styled(Flex)>
         </withProps(Styled(Flex))>
       </Pagination>

--- a/src/library/Popover/Popover.js
+++ b/src/library/Popover/Popover.js
@@ -21,6 +21,8 @@ import type {
 } from './types';
 
 export default class Popover extends Component<PopoverProps, PopoverState> {
+  static displayName = 'Popover';
+
   static defaultProps: PopoverDefaultProps = {
     focusTriggerOnClose: true,
     hasArrow: true,

--- a/src/library/Popover/PopoverArrow.js
+++ b/src/library/Popover/PopoverArrow.js
@@ -11,3 +11,5 @@ export default function PopoverArrow(props: PopoverArrowProps) {
     </Root>
   );
 }
+
+PopoverArrow.displayName = 'PopoverArrow';

--- a/src/library/Popover/PopoverContent.js
+++ b/src/library/Popover/PopoverContent.js
@@ -11,6 +11,8 @@ import { ARROW_SIZE } from './constants';
 import type { PopoverContentProps } from './types';
 
 export default class PopoverContent extends Component<PopoverContentProps> {
+  static displayName = 'PopoverContent';
+
   render() {
     const {
       children,

--- a/src/library/Popover/PopoverTrigger.js
+++ b/src/library/Popover/PopoverTrigger.js
@@ -5,6 +5,8 @@ import { PopoverTriggerRoot as Root } from './styled';
 import type { PopoverTriggerProps } from './types';
 
 export default class PopoverTrigger extends Component<PopoverTriggerProps> {
+  static displayName = 'PopoverTrigger';
+
   render() {
     const { children, cursor, ...restProps } = this.props;
     const rootProps = {

--- a/src/library/Popover/RtlPopper.js
+++ b/src/library/Popover/RtlPopper.js
@@ -19,6 +19,7 @@ const getRtlPlacement = (placement: string) => {
   return placement;
 };
 
+// eslint-disable-next-line react/display-name
 function RtlPopper({ placement, theme, ...restProps }: RtlPopperProps) {
   const rootProps = {
     placement:

--- a/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -143,7 +143,7 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
     placement="bottom"
     tag="span"
   >
-    <Popover
+    <Manager
       className="emotion-5"
       tag="span"
     >
@@ -164,7 +164,7 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
           <PopoverTrigger
             component="span"
           >
-            <PopoverTrigger
+            <Target
               className="emotion-3"
               component="span"
             >
@@ -223,11 +223,11 @@ exports[`Popover demo examples Snapshots: basic 1`] = `
                   </Button>
                 </Button>
               </span>
-            </PopoverTrigger>
+            </Target>
           </PopoverTrigger>
         </PopoverTrigger>
       </span>
-    </Popover>
+    </Manager>
   </Popover>
 </Popover>
 `;
@@ -400,7 +400,7 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
           placement="bottom"
           tag="span"
         >
-          <Popover
+          <Manager
             className="emotion-5"
             tag="span"
           >
@@ -421,7 +421,7 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
                 <PopoverTrigger
                   component="span"
                 >
-                  <PopoverTrigger
+                  <Target
                     className="emotion-3"
                     component="span"
                   >
@@ -480,11 +480,11 @@ exports[`Popover demo examples Snapshots: controlled 1`] = `
                         </Button>
                       </Button>
                     </span>
-                  </PopoverTrigger>
+                  </Target>
                 </PopoverTrigger>
               </PopoverTrigger>
             </span>
-          </Popover>
+          </Manager>
         </Popover>
       </Popover>
       <Button
@@ -672,7 +672,7 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
       placement="bottom"
       tag="span"
     >
-      <Popover
+      <Manager
         className="emotion-5"
         tag="span"
       >
@@ -693,7 +693,7 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
             <PopoverTrigger
               component="span"
             >
-              <PopoverTrigger
+              <Target
                 className="emotion-3"
                 component="span"
               >
@@ -752,11 +752,11 @@ exports[`Popover demo examples Snapshots: custom-content 1`] = `
                     </Button>
                   </Button>
                 </span>
-              </PopoverTrigger>
+              </Target>
             </PopoverTrigger>
           </PopoverTrigger>
         </span>
-      </Popover>
+      </Manager>
     </Popover>
   </Popover>
 </Component>
@@ -781,14 +781,14 @@ exports[`Popover demo examples Snapshots: custom-trigger 1`] = `
       placement="bottom"
       tag="span"
     >
-      <Popover
+      <Manager
         className="emotion-2"
         tag="span"
       >
         <span
           className="emotion-2"
         >
-          <Styled(PopoverTrigger)
+          <Styled(Target)
             aria-describedby="popover-24-content"
             aria-expanded={false}
             aria-owns="popover-24-content"
@@ -796,7 +796,7 @@ exports[`Popover demo examples Snapshots: custom-trigger 1`] = `
             onBlur={[Function]}
             onClick={[Function]}
           >
-            <PopoverTrigger
+            <Target
               aria-describedby="popover-24-content"
               aria-expanded={false}
               aria-owns="popover-24-content"
@@ -821,10 +821,10 @@ exports[`Popover demo examples Snapshots: custom-trigger 1`] = `
                   ▼
                 </span>
               </button>
-            </PopoverTrigger>
-          </Styled(PopoverTrigger)>
+            </Target>
+          </Styled(Target)>
         </span>
-      </Popover>
+      </Manager>
     </Popover>
   </Popover>
 </Component>
@@ -970,7 +970,7 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
     placement="bottom"
     tag="span"
   >
-    <Popover
+    <Manager
       className="emotion-5"
       tag="span"
     >
@@ -992,7 +992,7 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
           <PopoverTrigger
             component="span"
           >
-            <PopoverTrigger
+            <Target
               className="emotion-3"
               component="span"
             >
@@ -1054,11 +1054,11 @@ exports[`Popover demo examples Snapshots: disabled 1`] = `
                   </Button>
                 </Button>
               </span>
-            </PopoverTrigger>
+            </Target>
           </PopoverTrigger>
         </PopoverTrigger>
       </span>
-    </Popover>
+    </Manager>
   </Popover>
 </Popover>
 `;
@@ -1211,7 +1211,7 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
       placement="bottom"
       tag="span"
     >
-      <Popover
+      <Manager
         className="emotion-5"
         tag="span"
       >
@@ -1232,7 +1232,7 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
             <PopoverTrigger
               component="span"
             >
-              <PopoverTrigger
+              <Target
                 className="emotion-3"
                 component="span"
               >
@@ -1291,11 +1291,11 @@ exports[`Popover demo examples Snapshots: on-open-close 1`] = `
                     </Button>
                   </Button>
                 </span>
-              </PopoverTrigger>
+              </Target>
             </PopoverTrigger>
           </PopoverTrigger>
         </span>
-      </Popover>
+      </Manager>
     </Popover>
   </Popover>
 </Component>
@@ -1532,7 +1532,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
         placement="right"
         tag="span"
       >
-        <Popover
+        <Manager
           className="emotion-14"
           tag="span"
         >
@@ -1553,7 +1553,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -1612,7 +1612,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
             <PopoverContent
@@ -1628,7 +1628,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
                 placement="right"
                 tabIndex={0}
               >
-                <PopoverContent
+                <WithTheme(RtlPopper)
                   className="emotion-10"
                   id="popover-8-content"
                   onBlur={[Function]}
@@ -1704,7 +1704,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
                             aria-hidden={true}
                             size="8px"
                           >
-                            <PopoverArrow
+                            <Arrow
                               aria-hidden={true}
                               className="emotion-8"
                             >
@@ -1715,13 +1715,13 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
                               >
                                 ▼
                               </span>
-                            </PopoverArrow>
+                            </Arrow>
                           </PopoverArrow>
                         </PopoverArrow>
                       </div>
                     </Popper>
                   </RtlPopper>
-                </PopoverContent>
+                </WithTheme(RtlPopper)>
               </PopoverContent>
             </PopoverContent>
             <EventListener
@@ -1743,7 +1743,7 @@ exports[`Popover demo examples Snapshots: overflow 1`] = `
               }
             />
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </div>
@@ -1991,7 +1991,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
         placement="bottom"
         tag="span"
       >
-        <Popover
+        <Manager
           className="emotion-14"
           tag="span"
         >
@@ -2012,7 +2012,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -2071,7 +2071,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
             <PopoverContent
@@ -2087,7 +2087,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
                 placement="bottom"
                 tabIndex={0}
               >
-                <PopoverContent
+                <WithTheme(RtlPopper)
                   className="emotion-10"
                   id="popover-6-content"
                   onBlur={[Function]}
@@ -2163,7 +2163,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
                             aria-hidden={true}
                             size="8px"
                           >
-                            <PopoverArrow
+                            <Arrow
                               aria-hidden={true}
                               className="emotion-8"
                             >
@@ -2174,13 +2174,13 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
                               >
                                 ▼
                               </span>
-                            </PopoverArrow>
+                            </Arrow>
                           </PopoverArrow>
                         </PopoverArrow>
                       </div>
                     </Popper>
                   </RtlPopper>
-                </PopoverContent>
+                </WithTheme(RtlPopper)>
               </PopoverContent>
             </PopoverContent>
             <EventListener
@@ -2202,7 +2202,7 @@ exports[`Popover demo examples Snapshots: placement 1`] = `
               }
             />
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </div>
@@ -2519,7 +2519,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                   tag="span"
                   usePortal={true}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-5"
                     tag="span"
                   >
@@ -2540,7 +2540,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-3"
                             component="span"
                           >
@@ -2599,7 +2599,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                                 </Button>
                               </Button>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                       <Portal />
@@ -2622,7 +2622,7 @@ exports[`Popover demo examples Snapshots: portal 1`] = `
                         }
                       />
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </div>
@@ -2916,7 +2916,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
             placement="bottom-start"
             tag="span"
           >
-            <Popover
+            <Manager
               className="emotion-14"
               tag="span"
             >
@@ -2937,7 +2937,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                   <PopoverTrigger
                     component="span"
                   >
-                    <PopoverTrigger
+                    <Target
                       className="emotion-3"
                       component="span"
                     >
@@ -2996,7 +2996,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                           </Button>
                         </Button>
                       </span>
-                    </PopoverTrigger>
+                    </Target>
                   </PopoverTrigger>
                 </PopoverTrigger>
                 <PopoverContent
@@ -3012,7 +3012,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                     placement="bottom-start"
                     tabIndex={0}
                   >
-                    <PopoverContent
+                    <WithTheme(RtlPopper)
                       className="emotion-10"
                       id="popover-20-content"
                       onBlur={[Function]}
@@ -3088,7 +3088,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                                 aria-hidden={true}
                                 size="8px"
                               >
-                                <PopoverArrow
+                                <Arrow
                                   aria-hidden={true}
                                   className="emotion-8"
                                 >
@@ -3099,13 +3099,13 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                                   >
                                     ▼
                                   </span>
-                                </PopoverArrow>
+                                </Arrow>
                               </PopoverArrow>
                             </PopoverArrow>
                           </div>
                         </Popper>
                       </RtlPopper>
-                    </PopoverContent>
+                    </WithTheme(RtlPopper)>
                   </PopoverContent>
                 </PopoverContent>
                 <EventListener
@@ -3127,7 +3127,7 @@ exports[`Popover demo examples Snapshots: rtl 1`] = `
                   }
                 />
               </span>
-            </Popover>
+            </Manager>
           </Popover>
         </Popover>
       </ThemeProvider>
@@ -3506,7 +3506,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                   placement="left"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     tag="span"
                   >
@@ -3527,7 +3527,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-3"
                             component="span"
                           >
@@ -3586,7 +3586,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                                 </Button>
                               </Button>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                       <PopoverContent
@@ -3602,7 +3602,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                           placement="left"
                           tabIndex={0}
                         >
-                          <PopoverContent
+                          <WithTheme(RtlPopper)
                             className="emotion-10"
                             id="popover-10-content"
                             onBlur={[Function]}
@@ -3678,7 +3678,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                                       aria-hidden={true}
                                       size="8px"
                                     >
-                                      <PopoverArrow
+                                      <Arrow
                                         aria-hidden={true}
                                         className="emotion-8"
                                       >
@@ -3689,13 +3689,13 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                                         >
                                           ▼
                                         </span>
-                                      </PopoverArrow>
+                                      </Arrow>
                                     </PopoverArrow>
                                   </PopoverArrow>
                                 </div>
                               </Popper>
                             </RtlPopper>
-                          </PopoverContent>
+                          </WithTheme(RtlPopper)>
                         </PopoverContent>
                       </PopoverContent>
                       <EventListener
@@ -3717,7 +3717,7 @@ exports[`Popover demo examples Snapshots: scrolling-container 1`] = `
                         }
                       />
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </div>
@@ -4062,7 +4062,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
         tag="span"
         title="Title"
       >
-        <Popover
+        <Manager
           className="emotion-19"
           tag="span"
           title="Title"
@@ -4085,7 +4085,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
               <PopoverTrigger
                 component="span"
               >
-                <PopoverTrigger
+                <Target
                   className="emotion-3"
                   component="span"
                 >
@@ -4144,7 +4144,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
                       </Button>
                     </Button>
                   </span>
-                </PopoverTrigger>
+                </Target>
               </PopoverTrigger>
             </PopoverTrigger>
             <PopoverContent
@@ -4162,7 +4162,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
                 placement="right"
                 tabIndex={0}
               >
-                <PopoverContent
+                <WithTheme(RtlPopper)
                   className="emotion-15"
                   id="popover-4-content"
                   onBlur={[Function]}
@@ -4286,7 +4286,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
                             aria-hidden={true}
                             size="8px"
                           >
-                            <PopoverArrow
+                            <Arrow
                               aria-hidden={true}
                               className="emotion-13"
                             >
@@ -4297,13 +4297,13 @@ exports[`Popover demo examples Snapshots: title 1`] = `
                               >
                                 ▼
                               </span>
-                            </PopoverArrow>
+                            </Arrow>
                           </PopoverArrow>
                         </PopoverArrow>
                       </div>
                     </Popper>
                   </RtlPopper>
-                </PopoverContent>
+                </WithTheme(RtlPopper)>
               </PopoverContent>
             </PopoverContent>
             <EventListener
@@ -4325,7 +4325,7 @@ exports[`Popover demo examples Snapshots: title 1`] = `
               }
             />
           </span>
-        </Popover>
+        </Manager>
       </Popover>
     </Popover>
   </div>

--- a/src/library/Portal/Portal.js
+++ b/src/library/Portal/Portal.js
@@ -9,6 +9,8 @@ import {
 import type { PortalProps } from './types';
 
 export default class Portal extends Component<PortalProps> {
+  static displayName = 'Portal';
+
   content: React$Element<*>;
 
   node: ?HTMLElement;

--- a/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
+++ b/src/library/Radio/__tests__/__snapshots__/Radio.spec.js.snap
@@ -4248,7 +4248,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="small"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -4344,7 +4344,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -4530,7 +4530,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="medium"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -4626,7 +4626,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -4812,7 +4812,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -4908,7 +4908,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -5094,7 +5094,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="jumbo"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-8"
                 control={[Function]}
                 controlProps={
@@ -5190,7 +5190,7 @@ exports[`Radio demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button

--- a/src/library/Select/Select.js
+++ b/src/library/Select/Select.js
@@ -25,6 +25,8 @@ import type {
 } from './types';
 
 export default class Select extends Component<SelectProps, SelectState> {
+  static displayName = 'Select';
+
   static defaultProps: SelectDefaultProps = {
     itemKey: 'value',
     placeholder: 'Select...',

--- a/src/library/Select/SelectTrigger.js
+++ b/src/library/Select/SelectTrigger.js
@@ -25,6 +25,8 @@ const iconMarginMap = {
 };
 
 export default class SelectTrigger extends Component<SelectTriggerProps> {
+  static displayName = 'SelectTrigger';
+
   render() {
     const {
       disabled,

--- a/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
@@ -288,7 +288,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
         placement="bottom-start"
         size="large"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-16"
           data={
             Array [
@@ -450,7 +450,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-14"
                         id="select-6"
                         onChange={[Function]}
@@ -480,7 +480,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -533,7 +533,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -737,22 +737,22 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
   </MyForm>
@@ -1058,7 +1058,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
       placement="bottom-start"
       size="large"
     >
-      <Select
+      <WithTheme(Themed(Dropdown))
         className="emotion-16"
         data={
           Array [
@@ -1236,7 +1236,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                     tag="span"
                     triggerRef={[Function]}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-14"
                       id="select-98"
                       tag="span"
@@ -1264,7 +1264,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-12"
                               component="span"
                             >
@@ -1317,7 +1317,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <SelectTrigger
+                                    <WithTheme(Themed(FauxControl))
                                       afterItems={
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
@@ -1521,22 +1521,22 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                           </ThemeProvider>
                                         </ThemeProvider>
                                       </Themed(FauxControl)>
-                                    </SelectTrigger>
+                                    </WithTheme(Themed(FauxControl))>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </Dropdown>
             </ThemeProvider>
           </ThemeProvider>
         </Themed(Dropdown)>
-      </Select>
+      </WithTheme(Themed(Dropdown))>
     </Select>
   </Select>
 </Component>
@@ -1828,7 +1828,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
       placement="bottom-start"
       size="large"
     >
-      <Select
+      <WithTheme(Themed(Dropdown))
         className="emotion-16"
         data={
           Array [
@@ -1985,7 +1985,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                     tag="span"
                     triggerRef={[Function]}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-14"
                       id="select-102"
                       tag="span"
@@ -2013,7 +2013,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-12"
                               component="span"
                             >
@@ -2066,7 +2066,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <SelectTrigger
+                                    <WithTheme(Themed(FauxControl))
                                       afterItems={
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
@@ -2270,22 +2270,22 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                           </ThemeProvider>
                                         </ThemeProvider>
                                       </Themed(FauxControl)>
-                                    </SelectTrigger>
+                                    </WithTheme(Themed(FauxControl))>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </Dropdown>
             </ThemeProvider>
           </ThemeProvider>
         </Themed(Dropdown)>
-      </Select>
+      </WithTheme(Themed(Dropdown))>
     </Select>
   </Select>
 </Component>
@@ -2368,7 +2368,7 @@ exports[`Select demo examples Snapshots: custom-trigger 1`] = `
       placement="bottom-start"
       size="large"
     >
-      <Select
+      <WithTheme(Themed(Dropdown))
         className="emotion-4"
         data={
           Array [
@@ -2525,7 +2525,7 @@ exports[`Select demo examples Snapshots: custom-trigger 1`] = `
                     tag="span"
                     triggerRef={[Function]}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-2"
                       id="select-106"
                       tag="span"
@@ -2534,7 +2534,7 @@ exports[`Select demo examples Snapshots: custom-trigger 1`] = `
                         className="emotion-2"
                         id="select-106"
                       >
-                        <Styled(PopoverTrigger)
+                        <Styled(Target)
                           aria-describedby="select-106-content"
                           aria-expanded={false}
                           aria-haspopup="listbox"
@@ -2549,7 +2549,7 @@ exports[`Select demo examples Snapshots: custom-trigger 1`] = `
                           size="large"
                           tabIndex={0}
                         >
-                          <PopoverTrigger
+                          <Target
                             aria-describedby="select-106-content"
                             aria-expanded={false}
                             aria-haspopup="listbox"
@@ -2587,17 +2587,17 @@ exports[`Select demo examples Snapshots: custom-trigger 1`] = `
                                 ▼
                               </span>
                             </button>
-                          </PopoverTrigger>
-                        </Styled(PopoverTrigger)>
+                          </Target>
+                        </Styled(Target)>
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </Dropdown>
             </ThemeProvider>
           </ThemeProvider>
         </Themed(Dropdown)>
-      </Select>
+      </WithTheme(Themed(Dropdown))>
     </Select>
   </Select>
 </Component>
@@ -2922,7 +2922,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
       placement="bottom-start"
       size="large"
     >
-      <Select
+      <WithTheme(Themed(Dropdown))
         className="emotion-16"
         data={
           Array [
@@ -3130,7 +3130,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                     tag="span"
                     triggerRef={[Function]}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-14"
                       id="select-10"
                       tag="span"
@@ -3158,7 +3158,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-12"
                               component="span"
                             >
@@ -3211,7 +3211,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                     size="large"
                                     tabIndex={0}
                                   >
-                                    <SelectTrigger
+                                    <WithTheme(Themed(FauxControl))
                                       afterItems={
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
@@ -3415,22 +3415,22 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                           </ThemeProvider>
                                         </ThemeProvider>
                                       </Themed(FauxControl)>
-                                    </SelectTrigger>
+                                    </WithTheme(Themed(FauxControl))>
                                   </SelectTrigger>
                                 </SelectTrigger>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </Dropdown>
             </ThemeProvider>
           </ThemeProvider>
         </Themed(Dropdown)>
-      </Select>
+      </WithTheme(Themed(Dropdown))>
     </Select>
   </Select>
 </Component>
@@ -3713,7 +3713,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
     placement="bottom-start"
     size="large"
   >
-    <Select
+    <WithTheme(Themed(Dropdown))
       className="emotion-16"
       data={
         Array [
@@ -3875,7 +3875,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                   tag="span"
                   triggerRef={[Function]}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     id="select-18"
                     tag="span"
@@ -3903,7 +3903,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-12"
                             component="span"
                           >
@@ -3956,7 +3956,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                   role="button"
                                   size="large"
                                 >
-                                  <SelectTrigger
+                                  <WithTheme(Themed(FauxControl))
                                     afterItems={
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -4162,22 +4162,22 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(FauxControl)>
-                                  </SelectTrigger>
+                                  </WithTheme(Themed(FauxControl))>
                                 </SelectTrigger>
                               </SelectTrigger>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </Dropdown>
           </ThemeProvider>
         </ThemeProvider>
       </Themed(Dropdown)>
-    </Select>
+    </WithTheme(Themed(Dropdown))>
   </Select>
 </Select>
 `;
@@ -5146,7 +5146,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                 required={true}
                 size="large"
               >
-                <Select
+                <WithTheme(Themed(Dropdown))
                   aria-describedby="formField-108-caption"
                   className="emotion-18"
                   data={
@@ -5882,7 +5882,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                               tag="span"
                               triggerRef={[Function]}
                             >
-                              <Popover
+                              <Manager
                                 aria-describedby="formField-108-caption"
                                 className="emotion-16"
                                 id="select-109"
@@ -5914,7 +5914,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                     <PopoverTrigger
                                       component="span"
                                     >
-                                      <PopoverTrigger
+                                      <Target
                                         className="emotion-14"
                                         component="span"
                                       >
@@ -5971,7 +5971,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                               size="large"
                                               tabIndex={0}
                                             >
-                                              <SelectTrigger
+                                              <WithTheme(Themed(FauxControl))
                                                 afterItems={
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
@@ -6184,28 +6184,29 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                     </ThemeProvider>
                                                   </ThemeProvider>
                                                 </Themed(FauxControl)>
-                                              </SelectTrigger>
+                                              </WithTheme(Themed(FauxControl))>
                                             </SelectTrigger>
                                           </SelectTrigger>
                                         </span>
-                                      </PopoverTrigger>
+                                      </Target>
                                     </PopoverTrigger>
                                   </PopoverTrigger>
                                 </span>
-                              </Popover>
+                              </Manager>
                             </Popover>
                           </Popover>
                         </Dropdown>
                       </ThemeProvider>
                     </ThemeProvider>
                   </Themed(Dropdown)>
-                </Select>
+                </WithTheme(Themed(Dropdown))>
               </Select>
             </Select>
           </label>
           <Styled(div)
             caption="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
             id="formField-108-caption"
+            isGroup={false}
           >
             <div
               className="emotion-23"
@@ -6507,7 +6508,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
     placement="bottom-start"
     size="large"
   >
-    <Select
+    <WithTheme(Themed(Dropdown))
       className="emotion-16"
       data={
         Array [
@@ -6669,7 +6670,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                   tag="span"
                   triggerRef={[Function]}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     id="select-30"
                     tag="span"
@@ -6698,7 +6699,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-12"
                             component="span"
                           >
@@ -6753,7 +6754,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                   size="large"
                                   tabIndex={0}
                                 >
-                                  <SelectTrigger
+                                  <WithTheme(Themed(FauxControl))
                                     afterItems={
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -6962,22 +6963,22 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(FauxControl)>
-                                  </SelectTrigger>
+                                  </WithTheme(Themed(FauxControl))>
                                 </SelectTrigger>
                               </SelectTrigger>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </Dropdown>
           </ThemeProvider>
         </ThemeProvider>
       </Themed(Dropdown)>
-    </Select>
+    </WithTheme(Themed(Dropdown))>
   </Select>
 </Select>
 `;
@@ -7440,7 +7441,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
         placement="bottom-start"
         size="large"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-34"
           data={
             Array [
@@ -7597,7 +7598,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-32"
                         id="select-72"
                         tag="span"
@@ -7626,7 +7627,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -7681,7 +7682,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownUp)) />,
@@ -7890,11 +7891,11 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                           <DropdownContent
@@ -7925,7 +7926,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                               onBlur={[Function]}
                               placement="bottom-start"
                             >
-                              <DropdownContent
+                              <WithTheme(RtlPopper)
                                 className="emotion-28"
                                 id="select-72-content"
                                 modifiers={
@@ -8277,7 +8278,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                     </div>
                                   </Popper>
                                 </RtlPopper>
-                              </DropdownContent>
+                              </WithTheme(RtlPopper)>
                             </DropdownContent>
                           </DropdownContent>
                           <EventListener
@@ -8299,14 +8300,14 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                             }
                           />
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
   </div>
@@ -8973,7 +8974,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
     placement="bottom-start"
     size="large"
   >
-    <Select
+    <WithTheme(Themed(Dropdown))
       className="emotion-16"
       data={
         Array [
@@ -9694,7 +9695,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                   tag="span"
                   triggerRef={[Function]}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     id="select-14"
                     tag="span"
@@ -9722,7 +9723,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-12"
                             component="span"
                           >
@@ -9775,7 +9776,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                   size="large"
                                   tabIndex={0}
                                 >
-                                  <SelectTrigger
+                                  <WithTheme(Themed(FauxControl))
                                     afterItems={
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -9979,22 +9980,22 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(FauxControl)>
-                                  </SelectTrigger>
+                                  </WithTheme(Themed(FauxControl))>
                                 </SelectTrigger>
                               </SelectTrigger>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </Dropdown>
           </ThemeProvider>
         </ThemeProvider>
       </Themed(Dropdown)>
-    </Select>
+    </WithTheme(Themed(Dropdown))>
   </Select>
 </Select>
 `;
@@ -10466,7 +10467,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
         placement="bottom-start"
         size="large"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-34"
           data={
             Array [
@@ -10623,7 +10624,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-32"
                         id="select-68"
                         tag="span"
@@ -10652,7 +10653,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -10707,7 +10708,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownUp)) />,
@@ -10916,11 +10917,11 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                           <DropdownContent
@@ -10951,7 +10952,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                               onBlur={[Function]}
                               placement="bottom-start"
                             >
-                              <DropdownContent
+                              <WithTheme(RtlPopper)
                                 className="emotion-28"
                                 id="select-68-content"
                                 modifiers={
@@ -11303,7 +11304,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                     </div>
                                   </Popper>
                                 </RtlPopper>
-                              </DropdownContent>
+                              </WithTheme(RtlPopper)>
                             </DropdownContent>
                           </DropdownContent>
                           <EventListener
@@ -11325,14 +11326,14 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                             }
                           />
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
   </div>
@@ -11837,7 +11838,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                       size="large"
                       usePortal={true}
                     >
-                      <Select
+                      <WithTheme(Themed(Dropdown))
                         className="emotion-16"
                         data={
                           Array [
@@ -12014,7 +12015,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                     triggerRef={[Function]}
                                     usePortal={true}
                                   >
-                                    <Popover
+                                    <Manager
                                       className="emotion-14"
                                       id="select-80"
                                       tag="span"
@@ -12043,7 +12044,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                           <PopoverTrigger
                                             component="span"
                                           >
-                                            <PopoverTrigger
+                                            <Target
                                               className="emotion-12"
                                               component="span"
                                             >
@@ -12098,7 +12099,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                     size="large"
                                                     tabIndex={0}
                                                   >
-                                                    <SelectTrigger
+                                                    <WithTheme(Themed(FauxControl))
                                                       afterItems={
                                                         Array [
                                                           <withProps(Styled(IconArrowDropdownUp)) />,
@@ -12307,11 +12308,11 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(FauxControl)>
-                                                    </SelectTrigger>
+                                                    </WithTheme(Themed(FauxControl))>
                                                   </SelectTrigger>
                                                 </SelectTrigger>
                                               </span>
-                                            </PopoverTrigger>
+                                            </Target>
                                           </PopoverTrigger>
                                         </PopoverTrigger>
                                         <Portal />
@@ -12334,14 +12335,14 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                           }
                                         />
                                       </span>
-                                    </Popover>
+                                    </Manager>
                                   </Popover>
                                 </Popover>
                               </Dropdown>
                             </ThemeProvider>
                           </ThemeProvider>
                         </Themed(Dropdown)>
-                      </Select>
+                      </WithTheme(Themed(Dropdown))>
                     </Select>
                   </Select>
                 </div>
@@ -12700,7 +12701,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
     }
     size="large"
   >
-    <Select
+    <WithTheme(Themed(Dropdown))
       className="emotion-16"
       data={
         Array [
@@ -12892,7 +12893,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                   tag="span"
                   triggerRef={[Function]}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     id="select-22"
                     tag="span"
@@ -12928,7 +12929,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-12"
                             component="span"
                           >
@@ -12997,7 +12998,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                   size="large"
                                   tabIndex={0}
                                 >
-                                  <SelectTrigger
+                                  <WithTheme(Themed(FauxControl))
                                     afterItems={
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -13238,22 +13239,22 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(FauxControl)>
-                                  </SelectTrigger>
+                                  </WithTheme(Themed(FauxControl))>
                                 </SelectTrigger>
                               </SelectTrigger>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </Dropdown>
           </ThemeProvider>
         </ThemeProvider>
       </Themed(Dropdown)>
-    </Select>
+    </WithTheme(Themed(Dropdown))>
   </Select>
 </Select>
 `;
@@ -13544,7 +13545,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
     required={true}
     size="large"
   >
-    <Select
+    <WithTheme(Themed(Dropdown))
       className="emotion-16"
       data={
         Array [
@@ -13706,7 +13707,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                   tag="span"
                   triggerRef={[Function]}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     id="select-26"
                     tag="span"
@@ -13735,7 +13736,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-12"
                             component="span"
                           >
@@ -13790,7 +13791,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                   size="large"
                                   tabIndex={0}
                                 >
-                                  <SelectTrigger
+                                  <WithTheme(Themed(FauxControl))
                                     afterItems={
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -13999,22 +14000,22 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(FauxControl)>
-                                  </SelectTrigger>
+                                  </WithTheme(Themed(FauxControl))>
                                 </SelectTrigger>
                               </SelectTrigger>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </Dropdown>
           </ThemeProvider>
         </ThemeProvider>
       </Themed(Dropdown)>
-    </Select>
+    </WithTheme(Themed(Dropdown))>
   </Select>
 </Select>
 `;
@@ -14503,7 +14504,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
               placement="bottom-start"
               size="large"
             >
-              <Select
+              <WithTheme(Themed(Dropdown))
                 className="emotion-16"
                 data={
                   Array [
@@ -14660,7 +14661,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                             tag="span"
                             triggerRef={[Function]}
                           >
-                            <Popover
+                            <Manager
                               className="emotion-14"
                               id="select-88"
                               tag="span"
@@ -14688,7 +14689,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                   <PopoverTrigger
                                     component="span"
                                   >
-                                    <PopoverTrigger
+                                    <Target
                                       className="emotion-12"
                                       component="span"
                                     >
@@ -14741,7 +14742,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                             size="large"
                                             tabIndex={0}
                                           >
-                                            <SelectTrigger
+                                            <WithTheme(Themed(FauxControl))
                                               afterItems={
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
@@ -14945,22 +14946,22 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(FauxControl)>
-                                            </SelectTrigger>
+                                            </WithTheme(Themed(FauxControl))>
                                           </SelectTrigger>
                                         </SelectTrigger>
                                       </span>
-                                    </PopoverTrigger>
+                                    </Target>
                                   </PopoverTrigger>
                                 </PopoverTrigger>
                               </span>
-                            </Popover>
+                            </Manager>
                           </Popover>
                         </Popover>
                       </Dropdown>
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(Dropdown)>
-              </Select>
+              </WithTheme(Themed(Dropdown))>
             </Select>
           </Select>
           <Select
@@ -15022,7 +15023,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
               size="large"
               variant="success"
             >
-              <Select
+              <WithTheme(Themed(Dropdown))
                 className="emotion-16"
                 data={
                   Array [
@@ -15184,7 +15185,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                             triggerRef={[Function]}
                             variant="success"
                           >
-                            <Popover
+                            <Manager
                               className="emotion-14"
                               id="select-90"
                               tag="span"
@@ -15213,7 +15214,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                   <PopoverTrigger
                                     component="span"
                                   >
-                                    <PopoverTrigger
+                                    <Target
                                       className="emotion-12"
                                       component="span"
                                     >
@@ -15268,7 +15269,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                             tabIndex={0}
                                             variant="success"
                                           >
-                                            <SelectTrigger
+                                            <WithTheme(Themed(FauxControl))
                                               afterItems={
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
@@ -15511,22 +15512,22 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(FauxControl)>
-                                            </SelectTrigger>
+                                            </WithTheme(Themed(FauxControl))>
                                           </SelectTrigger>
                                         </SelectTrigger>
                                       </span>
-                                    </PopoverTrigger>
+                                    </Target>
                                   </PopoverTrigger>
                                 </PopoverTrigger>
                               </span>
-                            </Popover>
+                            </Manager>
                           </Popover>
                         </Popover>
                       </Dropdown>
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(Dropdown)>
-              </Select>
+              </WithTheme(Themed(Dropdown))>
             </Select>
           </Select>
         </div>
@@ -16176,7 +16177,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                       placement="bottom-start"
                       size="large"
                     >
-                      <Select
+                      <WithTheme(Themed(Dropdown))
                         className="emotion-34"
                         data={
                           Array [
@@ -16333,7 +16334,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                     tag="span"
                                     triggerRef={[Function]}
                                   >
-                                    <Popover
+                                    <Manager
                                       className="emotion-32"
                                       id="select-76"
                                       tag="span"
@@ -16362,7 +16363,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                           <PopoverTrigger
                                             component="span"
                                           >
-                                            <PopoverTrigger
+                                            <Target
                                               className="emotion-12"
                                               component="span"
                                             >
@@ -16417,7 +16418,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                     size="large"
                                                     tabIndex={0}
                                                   >
-                                                    <SelectTrigger
+                                                    <WithTheme(Themed(FauxControl))
                                                       afterItems={
                                                         Array [
                                                           <withProps(Styled(IconArrowDropdownUp)) />,
@@ -16626,11 +16627,11 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(FauxControl)>
-                                                    </SelectTrigger>
+                                                    </WithTheme(Themed(FauxControl))>
                                                   </SelectTrigger>
                                                 </SelectTrigger>
                                               </span>
-                                            </PopoverTrigger>
+                                            </Target>
                                           </PopoverTrigger>
                                         </PopoverTrigger>
                                         <DropdownContent
@@ -16661,7 +16662,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                             onBlur={[Function]}
                                             placement="bottom-start"
                                           >
-                                            <DropdownContent
+                                            <WithTheme(RtlPopper)
                                               className="emotion-28"
                                               id="select-76-content"
                                               modifiers={
@@ -17013,7 +17014,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                   </div>
                                                 </Popper>
                                               </RtlPopper>
-                                            </DropdownContent>
+                                            </WithTheme(RtlPopper)>
                                           </DropdownContent>
                                         </DropdownContent>
                                         <EventListener
@@ -17035,14 +17036,14 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                           }
                                         />
                                       </span>
-                                    </Popover>
+                                    </Manager>
                                   </Popover>
                                 </Popover>
                               </Dropdown>
                             </ThemeProvider>
                           </ThemeProvider>
                         </Themed(Dropdown)>
-                      </Select>
+                      </WithTheme(Themed(Dropdown))>
                     </Select>
                   </Select>
                 </div>
@@ -17632,7 +17633,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         placement="bottom-start"
         size="small"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-16"
           data={
             Array [
@@ -17789,7 +17790,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-14"
                         id="select-34"
                         tag="span"
@@ -17817,7 +17818,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -17870,7 +17871,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                       size="small"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -18074,22 +18075,22 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
     <Select
@@ -18149,7 +18150,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         placement="bottom-start"
         size="medium"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-16"
           data={
             Array [
@@ -18306,7 +18307,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-14"
                         id="select-36"
                         tag="span"
@@ -18334,7 +18335,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -18387,7 +18388,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                       size="medium"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -18591,22 +18592,22 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
     <Select
@@ -18666,7 +18667,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         placement="bottom-start"
         size="large"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-16"
           data={
             Array [
@@ -18823,7 +18824,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-14"
                         id="select-38"
                         tag="span"
@@ -18851,7 +18852,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -18904,7 +18905,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                       size="large"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -19108,22 +19109,22 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
     <Select
@@ -19183,7 +19184,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
         placement="bottom-start"
         size="jumbo"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-16"
           data={
             Array [
@@ -19340,7 +19341,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                       tag="span"
                       triggerRef={[Function]}
                     >
-                      <Popover
+                      <Manager
                         className="emotion-14"
                         id="select-40"
                         tag="span"
@@ -19368,7 +19369,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-12"
                                 component="span"
                               >
@@ -19421,7 +19422,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                       size="jumbo"
                                       tabIndex={0}
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -19625,22 +19626,22 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
   </div>
@@ -20064,7 +20065,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
             size="large"
             triggerRef={[Function]}
           >
-            <Select
+            <WithTheme(Themed(Dropdown))
               className="emotion-16"
               data={
                 Array [
@@ -20224,7 +20225,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                           tag="span"
                           triggerRef={[Function]}
                         >
-                          <Popover
+                          <Manager
                             className="emotion-14"
                             id="select-84"
                             tag="span"
@@ -20252,7 +20253,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                 <PopoverTrigger
                                   component="span"
                                 >
-                                  <PopoverTrigger
+                                  <Target
                                     className="emotion-12"
                                     component="span"
                                   >
@@ -20305,7 +20306,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                           size="large"
                                           tabIndex={0}
                                         >
-                                          <SelectTrigger
+                                          <WithTheme(Themed(FauxControl))
                                             afterItems={
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
@@ -20509,22 +20510,22 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(FauxControl)>
-                                          </SelectTrigger>
+                                          </WithTheme(Themed(FauxControl))>
                                         </SelectTrigger>
                                       </SelectTrigger>
                                     </span>
-                                  </PopoverTrigger>
+                                  </Target>
                                 </PopoverTrigger>
                               </PopoverTrigger>
                             </span>
-                          </Popover>
+                          </Manager>
                         </Popover>
                       </Popover>
                     </Dropdown>
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(Dropdown)>
-            </Select>
+            </WithTheme(Themed(Dropdown))>
           </Select>
         </Select>
         <Button
@@ -21242,7 +21243,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
     placement="bottom-start"
     size="large"
   >
-    <Select
+    <WithTheme(Themed(Dropdown))
       className="emotion-16"
       data={
         Array [
@@ -21998,7 +21999,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                   tag="span"
                   triggerRef={[Function]}
                 >
-                  <Popover
+                  <Manager
                     className="emotion-14"
                     id="select-2"
                     tag="span"
@@ -22033,7 +22034,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-12"
                             component="span"
                           >
@@ -22100,7 +22101,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                   size="large"
                                   tabIndex={0}
                                 >
-                                  <SelectTrigger
+                                  <WithTheme(Themed(FauxControl))
                                     afterItems={
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
@@ -22332,22 +22333,22 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(FauxControl)>
-                                  </SelectTrigger>
+                                  </WithTheme(Themed(FauxControl))>
                                 </SelectTrigger>
                               </SelectTrigger>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </Dropdown>
           </ThemeProvider>
         </ThemeProvider>
       </Themed(Dropdown)>
-    </Select>
+    </WithTheme(Themed(Dropdown))>
   </Select>
 </Select>
 `;
@@ -23013,7 +23014,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
         size="large"
         variant="danger"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-17"
           data={
             Array [
@@ -23175,7 +23176,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                       triggerRef={[Function]}
                       variant="danger"
                     >
-                      <Popover
+                      <Manager
                         className="emotion-15"
                         id="select-50"
                         tag="span"
@@ -23204,7 +23205,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-13"
                                 component="span"
                               >
@@ -23259,7 +23260,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                       tabIndex={0}
                                       variant="danger"
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -23502,22 +23503,22 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
     <Select
@@ -23579,7 +23580,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
         size="large"
         variant="success"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-17"
           data={
             Array [
@@ -23741,7 +23742,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                       triggerRef={[Function]}
                       variant="success"
                     >
-                      <Popover
+                      <Manager
                         className="emotion-15"
                         id="select-53"
                         tag="span"
@@ -23770,7 +23771,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-13"
                                 component="span"
                               >
@@ -23825,7 +23826,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                       tabIndex={0}
                                       variant="success"
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -24068,22 +24069,22 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
     <Select
@@ -24145,7 +24146,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
         size="large"
         variant="warning"
       >
-        <Select
+        <WithTheme(Themed(Dropdown))
           className="emotion-17"
           data={
             Array [
@@ -24307,7 +24308,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                       triggerRef={[Function]}
                       variant="warning"
                     >
-                      <Popover
+                      <Manager
                         className="emotion-15"
                         id="select-56"
                         tag="span"
@@ -24336,7 +24337,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                             <PopoverTrigger
                               component="span"
                             >
-                              <PopoverTrigger
+                              <Target
                                 className="emotion-13"
                                 component="span"
                               >
@@ -24391,7 +24392,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                       tabIndex={0}
                                       variant="warning"
                                     >
-                                      <SelectTrigger
+                                      <WithTheme(Themed(FauxControl))
                                         afterItems={
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
@@ -24634,22 +24635,22 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                             </ThemeProvider>
                                           </ThemeProvider>
                                         </Themed(FauxControl)>
-                                      </SelectTrigger>
+                                      </WithTheme(Themed(FauxControl))>
                                     </SelectTrigger>
                                   </SelectTrigger>
                                 </span>
-                              </PopoverTrigger>
+                              </Target>
                             </PopoverTrigger>
                           </PopoverTrigger>
                         </span>
-                      </Popover>
+                      </Manager>
                     </Popover>
                   </Popover>
                 </Dropdown>
               </ThemeProvider>
             </ThemeProvider>
           </Themed(Dropdown)>
-        </Select>
+        </WithTheme(Themed(Dropdown))>
       </Select>
     </Select>
   </div>

--- a/src/library/StartEnd/StartEnd.js
+++ b/src/library/StartEnd/StartEnd.js
@@ -39,3 +39,5 @@ export default function StartEnd(props: StartEndProps) {
   // $FlowFixMe - Reverse directions unsupported here but are supported on Flex
   return <Flex {...rootProps}>{flexItems}</Flex>;
 }
+
+StartEnd.displayName = 'StartEnd';

--- a/src/library/StartEnd/__tests__/__snapshots__/StartEnd.spec.js.snap
+++ b/src/library/StartEnd/__tests__/__snapshots__/StartEnd.spec.js.snap
@@ -410,7 +410,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                   gutterWidth="md"
                   justifyContent="between"
                 >
-                  <FlexItem
+                  <Box
                     alignItems="stretch"
                     className="emotion-13"
                     direction="row"
@@ -441,7 +441,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -458,10 +458,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-3"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -475,11 +475,11 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           Start
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                         <FlexItem
@@ -492,7 +492,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -507,10 +507,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-9"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -524,16 +524,16 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           End
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </div>
                     </Styled(div)>
-                  </FlexItem>
+                  </Box>
                 </Flex>
               </Component>
             </WithTheme(Component)>
@@ -577,7 +577,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                   gutterWidth="md"
                   justifyContent="between"
                 >
-                  <FlexItem
+                  <Box
                     alignItems="start"
                     className="emotion-33"
                     direction="row"
@@ -608,7 +608,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -625,10 +625,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-3"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -642,11 +642,11 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           Start
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                         <FlexItem
@@ -659,7 +659,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -674,10 +674,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-9"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -691,16 +691,16 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           End
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </div>
                     </Styled(div)>
-                  </FlexItem>
+                  </Box>
                 </Flex>
               </Component>
             </WithTheme(Component)>
@@ -744,7 +744,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                   gutterWidth="md"
                   justifyContent="between"
                 >
-                  <FlexItem
+                  <Box
                     alignItems="center"
                     className="emotion-53"
                     direction="row"
@@ -775,7 +775,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -792,10 +792,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-3"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -809,11 +809,11 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           Start
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                         <FlexItem
@@ -826,7 +826,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -841,10 +841,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-9"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -858,16 +858,16 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           End
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </div>
                     </Styled(div)>
-                  </FlexItem>
+                  </Box>
                 </Flex>
               </Component>
             </WithTheme(Component)>
@@ -911,7 +911,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                   gutterWidth="md"
                   justifyContent="between"
                 >
-                  <FlexItem
+                  <Box
                     alignItems="end"
                     className="emotion-73"
                     direction="row"
@@ -942,7 +942,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -959,10 +959,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-3"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -976,11 +976,11 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           Start
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                         <FlexItem
@@ -993,7 +993,7 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -1008,10 +1008,10 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                 <div
                                   className="emotion-9"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -1025,16 +1025,16 @@ exports[`StartEnd demo examples Snapshots: align-items 1`] = `
                                           End
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </div>
                     </Styled(div)>
-                  </FlexItem>
+                  </Box>
                 </Flex>
               </Component>
             </WithTheme(Component)>
@@ -1263,7 +1263,7 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
             gutterWidth="md"
             justifyContent="between"
           >
-            <FlexItem
+            <Box
               alignItems="stretch"
               className="emotion-13"
               direction="row"
@@ -1294,7 +1294,7 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
                       marginEnd="1em"
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-4"
                         element="div"
                         grow={0}
@@ -1311,10 +1311,10 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
                           <div
                             className="emotion-3"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-1"
                                 element="div"
                               >
@@ -1328,11 +1328,11 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
                                     Start
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                   <FlexItem
@@ -1345,7 +1345,7 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-4"
                         element="div"
                         grow={0}
@@ -1360,10 +1360,10 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
                           <div
                             className="emotion-9"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-1"
                                 element="div"
                               >
@@ -1377,16 +1377,16 @@ exports[`StartEnd demo examples Snapshots: basic 1`] = `
                                     End
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </div>
               </Styled(div)>
-            </FlexItem>
+            </Box>
           </Flex>
         </Component>
       </WithTheme(Component)>
@@ -1586,7 +1586,7 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
             gutterWidth="md"
             justifyContent="between"
           >
-            <FlexItem
+            <Box
               alignItems="stretch"
               className="emotion-13"
               direction="column"
@@ -1615,7 +1615,7 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-4"
                         element="div"
                         grow={0}
@@ -1630,10 +1630,10 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
                           <div
                             className="emotion-3"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-1"
                                 element="div"
                               >
@@ -1647,11 +1647,11 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
                                     Start
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                   <FlexItem
@@ -1664,7 +1664,7 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         className="emotion-4"
                         element="div"
                         grow={0}
@@ -1679,10 +1679,10 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
                           <div
                             className="emotion-3"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-1"
                                 element="div"
                               >
@@ -1696,16 +1696,16 @@ exports[`StartEnd demo examples Snapshots: direction 1`] = `
                                     End
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </div>
               </Styled(div)>
-            </FlexItem>
+            </Box>
           </Flex>
         </Component>
       </WithTheme(Component)>
@@ -2018,7 +2018,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                 gutterWidth="md"
                 justifyContent="between"
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-13"
                   direction="row"
@@ -2049,7 +2049,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-4"
                             element="div"
                             grow={1}
@@ -2066,10 +2066,10 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                               <div
                                 className="emotion-3"
                               >
-                                <Styled(Flex)
+                                <Styled(Box)
                                   element="div"
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     element="div"
                                   >
@@ -2083,11 +2083,11 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                                         Start
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
-                                </Styled(Flex)>
+                                  </Box>
+                                </Styled(Box)>
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                       <FlexItem
@@ -2100,7 +2100,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                           grow={0}
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-10"
                             element="div"
                             grow={0}
@@ -2115,10 +2115,10 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                               <div
                                 className="emotion-9"
                               >
-                                <Styled(Flex)
+                                <Styled(Box)
                                   element="div"
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     element="div"
                                   >
@@ -2132,16 +2132,16 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                                         End
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
-                                </Styled(Flex)>
+                                  </Box>
+                                </Styled(Box)>
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
@@ -2184,7 +2184,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                 gutterWidth="md"
                 justifyContent="between"
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-13"
                   direction="row"
@@ -2215,7 +2215,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-10"
                             element="div"
                             grow={0}
@@ -2232,10 +2232,10 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                               <div
                                 className="emotion-23"
                               >
-                                <Styled(Flex)
+                                <Styled(Box)
                                   element="div"
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     element="div"
                                   >
@@ -2249,11 +2249,11 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                                         Start
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
-                                </Styled(Flex)>
+                                  </Box>
+                                </Styled(Box)>
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                       <FlexItem
@@ -2266,7 +2266,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                           grow={1}
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-4"
                             element="div"
                             grow={1}
@@ -2281,10 +2281,10 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                               <div
                                 className="emotion-29"
                               >
-                                <Styled(Flex)
+                                <Styled(Box)
                                   element="div"
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     element="div"
                                   >
@@ -2298,16 +2298,16 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                                         End
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
-                                </Styled(Flex)>
+                                  </Box>
+                                </Styled(Box)>
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
@@ -2350,7 +2350,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                 gutterWidth="md"
                 justifyContent="between"
               >
-                <FlexItem
+                <Box
                   alignItems="stretch"
                   className="emotion-13"
                   direction="row"
@@ -2381,7 +2381,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                           marginEnd="1em"
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-4"
                             element="div"
                             grow={1}
@@ -2398,10 +2398,10 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                               <div
                                 className="emotion-3"
                               >
-                                <Styled(Flex)
+                                <Styled(Box)
                                   element="div"
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     element="div"
                                   >
@@ -2415,11 +2415,11 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                                         Start
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
-                                </Styled(Flex)>
+                                  </Box>
+                                </Styled(Box)>
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                       <FlexItem
@@ -2432,7 +2432,7 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                           grow={1}
                           shrink={1}
                         >
-                          <FlexItem
+                          <Box
                             className="emotion-4"
                             element="div"
                             grow={1}
@@ -2447,10 +2447,10 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                               <div
                                 className="emotion-29"
                               >
-                                <Styled(Flex)
+                                <Styled(Box)
                                   element="div"
                                 >
-                                  <FlexItem
+                                  <Box
                                     className="emotion-1"
                                     element="div"
                                   >
@@ -2464,16 +2464,16 @@ exports[`StartEnd demo examples Snapshots: priority 1`] = `
                                         End
                                       </div>
                                     </Styled(div)>
-                                  </FlexItem>
-                                </Styled(Flex)>
+                                  </Box>
+                                </Styled(Box)>
                               </div>
                             </Styled(div)>
-                          </FlexItem>
+                          </Box>
                         </FlexItem>
                       </FlexItem>
                     </div>
                   </Styled(div)>
-                </FlexItem>
+                </Box>
               </Flex>
             </Component>
           </WithTheme(Component)>
@@ -2808,7 +2808,7 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
             gutterWidth="md"
             justifyContent="between"
           >
-            <FlexItem
+            <Box
               alignItems="stretch"
               breakpoints={
                 Array [
@@ -2891,7 +2891,7 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
                       }
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         breakpoints={
                           Array [
                             800,
@@ -2940,10 +2940,10 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
                           <div
                             className="emotion-3"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-1"
                                 element="div"
                               >
@@ -2957,11 +2957,11 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
                                     Start
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                   <FlexItem
@@ -2984,7 +2984,7 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
                       grow={0}
                       shrink={1}
                     >
-                      <FlexItem
+                      <Box
                         breakpoints={
                           Array [
                             800,
@@ -3009,10 +3009,10 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
                           <div
                             className="emotion-9"
                           >
-                            <Styled(Flex)
+                            <Styled(Box)
                               element="div"
                             >
-                              <FlexItem
+                              <Box
                                 className="emotion-1"
                                 element="div"
                               >
@@ -3026,16 +3026,16 @@ exports[`StartEnd demo examples Snapshots: responsive 1`] = `
                                     End
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
-                            </Styled(Flex)>
+                              </Box>
+                            </Styled(Box)>
                           </div>
                         </Styled(div)>
-                      </FlexItem>
+                      </Box>
                     </FlexItem>
                   </FlexItem>
                 </div>
               </Styled(div)>
-            </FlexItem>
+            </Box>
           </Flex>
         </Component>
       </WithTheme(Component)>
@@ -3266,7 +3266,7 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                   gutterWidth="md"
                   justifyContent="between"
                 >
-                  <FlexItem
+                  <Box
                     alignItems="stretch"
                     className="emotion-13"
                     direction="row"
@@ -3297,7 +3297,7 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                             marginEnd="1em"
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -3314,10 +3314,10 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                                 <div
                                   className="emotion-3"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -3331,11 +3331,11 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                                           بداية
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                         <FlexItem
@@ -3348,7 +3348,7 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                             grow={0}
                             shrink={1}
                           >
-                            <FlexItem
+                            <Box
                               className="emotion-4"
                               element="div"
                               grow={0}
@@ -3363,10 +3363,10 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                                 <div
                                   className="emotion-9"
                                 >
-                                  <Styled(Flex)
+                                  <Styled(Box)
                                     element="div"
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-1"
                                       element="div"
                                     >
@@ -3380,16 +3380,16 @@ exports[`StartEnd demo examples Snapshots: rtl 1`] = `
                                           النهاية
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
-                                  </Styled(Flex)>
+                                    </Box>
+                                  </Styled(Box)>
                                 </div>
                               </Styled(div)>
-                            </FlexItem>
+                            </Box>
                           </FlexItem>
                         </FlexItem>
                       </div>
                     </Styled(div)>
-                  </FlexItem>
+                  </Box>
                 </Flex>
               </Component>
             </WithTheme(Component)>

--- a/src/library/Table/Selectable.js
+++ b/src/library/Table/Selectable.js
@@ -8,6 +8,8 @@ export default class Selectable extends Component<
   SelectableProps,
   SelectableState
 > {
+  static displayName = 'Selectable';
+
   state = {
     selected: this.props.defaultSelected || []
   };

--- a/src/library/Table/SelectableSortableTable.js
+++ b/src/library/Table/SelectableSortableTable.js
@@ -14,4 +14,6 @@ const SelectableSortableTable = (props: SelectableSortableTableProps) => {
   );
 };
 
+SelectableSortableTable.displayName = 'SelectableSortableTable';
+
 export default SelectableSortableTable;

--- a/src/library/Table/SelectableTable.js
+++ b/src/library/Table/SelectableTable.js
@@ -14,4 +14,6 @@ const SelectableTable = (props: SelectableTableProps) => {
   );
 };
 
+SelectableTable.displayName = 'SelectableTable';
+
 export default SelectableTable;

--- a/src/library/Table/Sortable.js
+++ b/src/library/Table/Sortable.js
@@ -24,6 +24,8 @@ export const defaultSortComparator: SortComparator = (a, b, key) => {
 };
 
 export default class Sortable extends Component<SortableProps, SortableState> {
+  static displayName = 'Sortable';
+
   static defaultProps = {
     sortComparator: defaultSortComparator
   };

--- a/src/library/Table/SortableTable.js
+++ b/src/library/Table/SortableTable.js
@@ -11,4 +11,6 @@ const SortableTable = (props: SortableTableProps) => (
   </Sortable>
 );
 
+SortableTable.displayName = 'SortableTable';
+
 export default SortableTable;

--- a/src/library/Table/Table.js
+++ b/src/library/Table/Table.js
@@ -54,6 +54,8 @@ const getSortable = ({ columns, defaultSort, sort, sortable }: TableProps) =>
   );
 
 class Table extends Component<TableProps> {
+  static displayName = 'Table';
+
   static defaultProps: TableDefaultProps = {
     density: DENSITY.compact,
     messages: {

--- a/src/library/Table/TableBase.js
+++ b/src/library/Table/TableBase.js
@@ -23,6 +23,8 @@ export default class TableBase extends Component<
   TableBaseProps,
   TableBaseState
 > {
+  static displayName = 'TableBase';
+
   static defaultProps: TableBaseDefaultProps = {
     density: DENSITY.compact,
     scrollable: true,

--- a/src/library/Table/TableCell.js
+++ b/src/library/Table/TableCell.js
@@ -8,6 +8,8 @@ import { createTableCellRootNode } from './styled';
 import type { TableCellDefaultProps, TableCellProps } from './types';
 
 export default class TableCell extends PureComponent<TableCellProps> {
+  static displayName = 'TableCell';
+
   static defaultProps: TableCellDefaultProps = {
     element: 'td'
   };

--- a/src/library/Table/TableDataRow.js
+++ b/src/library/Table/TableDataRow.js
@@ -8,6 +8,8 @@ import TableRow from './TableRow';
 import type { TableDataRowProps } from './types';
 
 export default class TableDataRow extends Component<TableDataRowProps> {
+  static displayName = 'TableDataRow';
+
   shouldComponentUpdate(nextProps: TableDataRowProps) {
     return !deepEqual(this.props, nextProps);
   }

--- a/src/library/Table/TableHeader.js
+++ b/src/library/Table/TableHeader.js
@@ -6,6 +6,8 @@ import { TableHeaderRoot as Root } from './styled';
 import type { TableHeaderProps } from './types';
 
 export default class TableHeader extends PureComponent<TableHeaderProps> {
+  static displayName = 'TableHeader';
+
   render() {
     return (
       <TableContext.Consumer>

--- a/src/library/Table/TableHeaderCell.js
+++ b/src/library/Table/TableHeaderCell.js
@@ -14,6 +14,8 @@ import type {
 export default class TableHeaderCell extends PureComponent<
   TableHeaderCellProps
 > {
+  static displayName = 'TableHeaderCell';
+
   static defaultProps: TableHeaderCellDefaultProps = {
     element: 'th',
     textAlign: COLUMN_ALIGN.start

--- a/src/library/Table/TableHeaderRow.js
+++ b/src/library/Table/TableHeaderRow.js
@@ -9,6 +9,8 @@ import TableRow from './TableRow';
 import type { TableHeaderRowProps } from './types';
 
 export default class TableHeaderRow extends Component<TableHeaderRowProps> {
+  static displayName = 'TableHeaderRow';
+
   shouldComponentUpdate(nextProps: TableHeaderRowProps) {
     return !deepEqual(this.props, nextProps);
   }

--- a/src/library/Table/TableRow.js
+++ b/src/library/Table/TableRow.js
@@ -7,6 +7,8 @@ import { TableRowRoot as Root } from './styled';
 import type { TableRowProps } from './types';
 
 export default class TableRow extends PureComponent<TableRowProps> {
+  static displayName = 'TableRow';
+
   render() {
     return (
       <TableContext.Consumer>

--- a/src/library/Table/TableSelectableCell.js
+++ b/src/library/Table/TableSelectableCell.js
@@ -10,6 +10,8 @@ import type { TableSelectableCellProps } from './types';
 export default class TableSelectableCell extends Component<
   TableSelectableCellProps
 > {
+  static displayName = 'TableSelectableCell';
+
   shouldComponentUpdate(nextProps: TableSelectableCellProps) {
     return (
       this.props.checked !== nextProps.checked ||

--- a/src/library/Table/TableSortableHeaderCell.js
+++ b/src/library/Table/TableSortableHeaderCell.js
@@ -26,6 +26,8 @@ const sortIcon = {
 export default class TableSortableHeaderCell extends Component<
   TableSortableHeaderCellProps
 > {
+  static displayName = 'TableSortableHeaderCell';
+
   render() {
     return (
       <TableContext.Consumer>

--- a/src/library/Table/TableTitle.js
+++ b/src/library/Table/TableTitle.js
@@ -12,6 +12,7 @@ const TableTitle = ({ hide, id, theme, ...restProps }: TableTitleProps) => {
     ...restProps
   };
 
+  // eslint-disable-next-line react/display-name
   const TitleContent = (props) => <Text align="start" id={id} {...props} />;
 
   const title = textWithThemeOverrides({
@@ -23,5 +24,7 @@ const TableTitle = ({ hide, id, theme, ...restProps }: TableTitleProps) => {
 
   return <Root {...rootProps}>{title}</Root>;
 };
+
+TableTitle.displayName = 'TableTitle';
 
 export default withTheme(TableTitle);

--- a/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
+++ b/src/library/Table/__tests__/__snapshots__/Table.spec.js.snap
@@ -1315,7 +1315,7 @@ button:focus > .emotion-4 {
                                                 role="columnheader"
                                                 textAlign="start"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Fruits"
                                                   aria-sort="none"
                                                   className="emotion-18"
@@ -1344,7 +1344,7 @@ button:focus > .emotion-4 {
                                                       role="columnheader"
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Fruits"
                                                         aria-sort="none"
                                                         className="emotion-14"
@@ -1389,17 +1389,17 @@ button:focus > .emotion-4 {
                                                                     className="emotion-13"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in ascending order"
                                                                       onClick={[Function]}
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in ascending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="start"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in ascending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -1422,7 +1422,7 @@ button:focus > .emotion-4 {
                                                                               onClick={[Function]}
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in ascending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -1514,22 +1514,22 @@ button:focus > .emotion-4 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -1602,7 +1602,7 @@ button:focus > .emotion-4 {
                                                 role="columnheader"
                                                 textAlign="end"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                                   aria-sort="ascending"
                                                   className="emotion-18"
@@ -1631,7 +1631,7 @@ button:focus > .emotion-4 {
                                                       role="columnheader"
                                                       textAlign="end"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Vegetables Are Good For You And You Should Eat Lots Of Them"
                                                         aria-sort="ascending"
                                                         className="emotion-14"
@@ -1676,18 +1676,18 @@ button:focus > .emotion-4 {
                                                                     className="emotion-32"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in descending order"
                                                                       onClick={[Function]}
                                                                       textAlign="end"
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in descending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="end"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in descending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -1710,7 +1710,7 @@ button:focus > .emotion-4 {
                                                                               onClick={[Function]}
                                                                               textAlign="end"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in descending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -1802,22 +1802,22 @@ button:focus > .emotion-4 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -1890,7 +1890,7 @@ button:focus > .emotion-4 {
                                                 role="columnheader"
                                                 textAlign="center"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Grains Make For Hearty Filler"
                                                   aria-sort="none"
                                                   className="emotion-18"
@@ -1919,7 +1919,7 @@ button:focus > .emotion-4 {
                                                       role="columnheader"
                                                       textAlign="center"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Grains Make For Hearty Filler"
                                                         aria-sort="none"
                                                         className="emotion-14"
@@ -1964,18 +1964,18 @@ button:focus > .emotion-4 {
                                                                     className="emotion-51"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in ascending order"
                                                                       onClick={[Function]}
                                                                       textAlign="center"
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in ascending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="center"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in ascending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -1998,7 +1998,7 @@ button:focus > .emotion-4 {
                                                                               onClick={[Function]}
                                                                               textAlign="center"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in ascending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -2090,22 +2090,22 @@ button:focus > .emotion-4 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -2178,7 +2178,7 @@ button:focus > .emotion-4 {
                                                 role="columnheader"
                                                 textAlign="justify"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Dairy"
                                                   aria-sort="none"
                                                   className="emotion-18"
@@ -2207,7 +2207,7 @@ button:focus > .emotion-4 {
                                                       role="columnheader"
                                                       textAlign="justify"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Dairy"
                                                         aria-sort="none"
                                                         className="emotion-14"
@@ -2252,18 +2252,18 @@ button:focus > .emotion-4 {
                                                                     className="emotion-70"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in ascending order"
                                                                       onClick={[Function]}
                                                                       textAlign="justify"
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in ascending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="justify"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in ascending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -2286,7 +2286,7 @@ button:focus > .emotion-4 {
                                                                               onClick={[Function]}
                                                                               textAlign="justify"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in ascending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -2378,22 +2378,22 @@ button:focus > .emotion-4 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -3453,7 +3453,7 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                     <tr
                                       className="emotion-27"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         key="Fruits"
                                         label="Fruits"
@@ -3504,7 +3504,7 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Fruits"
                                               className="emotion-3"
                                               element="th"
@@ -3542,11 +3542,11 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Vegetables"
                                         label="Vegetables"
@@ -3597,7 +3597,7 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Vegetables"
                                               className="emotion-3"
                                               element="th"
@@ -3635,11 +3635,11 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Grains"
                                         label="Grains"
@@ -3690,7 +3690,7 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Grains"
                                               className="emotion-3"
                                               element="th"
@@ -3728,11 +3728,11 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Dairy"
                                         label="Dairy"
@@ -3783,7 +3783,7 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Dairy"
                                               className="emotion-3"
                                               element="th"
@@ -3821,11 +3821,11 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Protein"
                                         label="Protein"
@@ -3876,7 +3876,7 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Protein"
                                               className="emotion-3"
                                               element="th"
@@ -3914,10 +3914,10 @@ exports[`Table demo examples Snapshots: basic 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -5181,7 +5181,7 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                     <tr
                                       className="emotion-27"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         key="Fruits"
                                         label="Fruits"
@@ -5232,7 +5232,7 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Fruits"
                                               className="emotion-3"
                                               element="th"
@@ -5270,11 +5270,11 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Vegetables"
                                         label="Vegetables"
@@ -5325,7 +5325,7 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                             }
                                             textAlign="end"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Vegetables"
                                               className="emotion-3"
                                               element="th"
@@ -5363,11 +5363,11 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Grains"
                                         label="Grains"
@@ -5418,7 +5418,7 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                             }
                                             textAlign="center"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Grains"
                                               className="emotion-3"
                                               element="th"
@@ -5456,11 +5456,11 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Dairy"
                                         label="Dairy"
@@ -5511,7 +5511,7 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                             }
                                             textAlign="justify"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Dairy"
                                               className="emotion-3"
                                               element="th"
@@ -5549,11 +5549,11 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Protein"
                                         label="Protein"
@@ -5604,7 +5604,7 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Protein"
                                               className="emotion-3"
                                               element="th"
@@ -5642,10 +5642,10 @@ exports[`Table demo examples Snapshots: column-align 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -6824,7 +6824,7 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                     <tr
                                       className="emotion-27"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         key="Fruits"
                                         label="Fresh Fruits"
@@ -6875,7 +6875,7 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Fresh Fruits"
                                               className="emotion-3"
                                               element="th"
@@ -6913,11 +6913,11 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Vegetables"
                                         label="Veritable Vegetables"
@@ -6968,7 +6968,7 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Veritable Vegetables"
                                               className="emotion-3"
                                               element="th"
@@ -7006,11 +7006,11 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Grains"
                                         label="Good Grains"
@@ -7061,7 +7061,7 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Good Grains"
                                               className="emotion-3"
                                               element="th"
@@ -7099,11 +7099,11 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Dairy"
                                         label="Delectable Dairy"
@@ -7154,7 +7154,7 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Delectable Dairy"
                                               className="emotion-3"
                                               element="th"
@@ -7192,11 +7192,11 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Protein"
                                         label="Powerful Protein"
@@ -7247,7 +7247,7 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Powerful Protein"
                                               className="emotion-3"
                                               element="th"
@@ -7285,10 +7285,10 @@ exports[`Table demo examples Snapshots: column-def 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -8503,7 +8503,7 @@ tr:hover > .emotion-35 {
                                     <tr
                                       className="emotion-27"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         key="Fruits"
                                         label="Fruits"
@@ -8554,7 +8554,7 @@ tr:hover > .emotion-35 {
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Fruits"
                                               className="emotion-3"
                                               element="th"
@@ -8592,11 +8592,11 @@ tr:hover > .emotion-35 {
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         cell={[Function]}
                                         element="th"
                                         key="Vegetables"
@@ -8650,7 +8650,7 @@ tr:hover > .emotion-35 {
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Vegetables"
                                               className="emotion-3"
                                               element="th"
@@ -8688,11 +8688,11 @@ tr:hover > .emotion-35 {
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Grains"
                                         label="Grains"
@@ -8743,7 +8743,7 @@ tr:hover > .emotion-35 {
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Grains"
                                               className="emotion-3"
                                               element="th"
@@ -8781,11 +8781,11 @@ tr:hover > .emotion-35 {
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Dairy"
                                         label="Dairy"
@@ -8836,7 +8836,7 @@ tr:hover > .emotion-35 {
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Dairy"
                                               className="emotion-3"
                                               element="th"
@@ -8874,11 +8874,11 @@ tr:hover > .emotion-35 {
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Protein"
                                         label="Protein"
@@ -8929,7 +8929,7 @@ tr:hover > .emotion-35 {
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Protein"
                                               className="emotion-3"
                                               element="th"
@@ -8967,10 +8967,10 @@ tr:hover > .emotion-35 {
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -9089,7 +9089,7 @@ tr:hover > .emotion-35 {
                                           <td
                                             className="emotion-35"
                                           >
-                                            <Grid
+                                            <Flex
                                               alignItems="stretch"
                                               direction="row"
                                               element="span"
@@ -9117,7 +9117,7 @@ tr:hover > .emotion-35 {
                                                     gutterWidth="md"
                                                     justifyContent="start"
                                                   >
-                                                    <FlexItem
+                                                    <Box
                                                       alignItems="stretch"
                                                       className="emotion-33"
                                                       direction="row"
@@ -9165,11 +9165,11 @@ tr:hover > .emotion-35 {
                                                           </Styled(span)>
                                                         </span>
                                                       </Styled(span)>
-                                                    </FlexItem>
+                                                    </Box>
                                                   </Flex>
                                                 </Component>
                                               </WithTheme(Component)>
-                                            </Grid>
+                                            </Flex>
                                           </td>
                                         </Styled(td)>
                                       </CustomCell>
@@ -9348,7 +9348,7 @@ tr:hover > .emotion-35 {
                                           <td
                                             className="emotion-35"
                                           >
-                                            <Grid
+                                            <Flex
                                               alignItems="stretch"
                                               direction="row"
                                               element="span"
@@ -9376,7 +9376,7 @@ tr:hover > .emotion-35 {
                                                     gutterWidth="md"
                                                     justifyContent="start"
                                                   >
-                                                    <FlexItem
+                                                    <Box
                                                       alignItems="stretch"
                                                       className="emotion-33"
                                                       direction="row"
@@ -9424,11 +9424,11 @@ tr:hover > .emotion-35 {
                                                           </Styled(span)>
                                                         </span>
                                                       </Styled(span)>
-                                                    </FlexItem>
+                                                    </Box>
                                                   </Flex>
                                                 </Component>
                                               </WithTheme(Component)>
-                                            </Grid>
+                                            </Flex>
                                           </td>
                                         </Styled(td)>
                                       </CustomCell>
@@ -9607,7 +9607,7 @@ tr:hover > .emotion-35 {
                                           <td
                                             className="emotion-35"
                                           >
-                                            <Grid
+                                            <Flex
                                               alignItems="stretch"
                                               direction="row"
                                               element="span"
@@ -9635,7 +9635,7 @@ tr:hover > .emotion-35 {
                                                     gutterWidth="md"
                                                     justifyContent="start"
                                                   >
-                                                    <FlexItem
+                                                    <Box
                                                       alignItems="stretch"
                                                       className="emotion-33"
                                                       direction="row"
@@ -9683,11 +9683,11 @@ tr:hover > .emotion-35 {
                                                           </Styled(span)>
                                                         </span>
                                                       </Styled(span)>
-                                                    </FlexItem>
+                                                    </Box>
                                                   </Flex>
                                                 </Component>
                                               </WithTheme(Component)>
-                                            </Grid>
+                                            </Flex>
                                           </td>
                                         </Styled(td)>
                                       </CustomCell>
@@ -9866,7 +9866,7 @@ tr:hover > .emotion-35 {
                                           <td
                                             className="emotion-35"
                                           >
-                                            <Grid
+                                            <Flex
                                               alignItems="stretch"
                                               direction="row"
                                               element="span"
@@ -9894,7 +9894,7 @@ tr:hover > .emotion-35 {
                                                     gutterWidth="md"
                                                     justifyContent="start"
                                                   >
-                                                    <FlexItem
+                                                    <Box
                                                       alignItems="stretch"
                                                       className="emotion-33"
                                                       direction="row"
@@ -9942,11 +9942,11 @@ tr:hover > .emotion-35 {
                                                           </Styled(span)>
                                                         </span>
                                                       </Styled(span)>
-                                                    </FlexItem>
+                                                    </Box>
                                                   </Flex>
                                                 </Component>
                                               </WithTheme(Component)>
-                                            </Grid>
+                                            </Flex>
                                           </td>
                                         </Styled(td)>
                                       </CustomCell>
@@ -10485,7 +10485,7 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                     <tr
                                       className="emotion-22"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         emoji="🍎"
                                         key="Fruits"
@@ -10576,8 +10576,8 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                             </th>
                                           </Styled(th)>
                                         </CustomHeaderCell>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         emoji="🥗"
                                         key="Vegetables"
@@ -10668,8 +10668,8 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                             </th>
                                           </Styled(th)>
                                         </CustomHeaderCell>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         emoji="🌾"
                                         key="Grains"
@@ -10760,8 +10760,8 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                             </th>
                                           </Styled(th)>
                                         </CustomHeaderCell>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         emoji="🥚"
                                         key="Dairy"
@@ -10852,8 +10852,8 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                             </th>
                                           </Styled(th)>
                                         </CustomHeaderCell>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         emoji="🍗"
                                         key="Protein"
@@ -10944,7 +10944,7 @@ exports[`Table demo examples Snapshots: custom-header-cell 1`] = `
                                             </th>
                                           </Styled(th)>
                                         </CustomHeaderCell>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -12203,7 +12203,7 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                     <tr
                                       className="emotion-27"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         key="Fruits"
                                         label="Fruits"
@@ -12254,7 +12254,7 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Fruits"
                                               className="emotion-3"
                                               element="th"
@@ -12292,11 +12292,11 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Vegetables"
                                         label="Vegetables"
@@ -12347,7 +12347,7 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Vegetables"
                                               className="emotion-3"
                                               element="th"
@@ -12385,11 +12385,11 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Grains"
                                         label="Grains"
@@ -12440,7 +12440,7 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Grains"
                                               className="emotion-3"
                                               element="th"
@@ -12478,11 +12478,11 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Dairy"
                                         label="Dairy"
@@ -12533,7 +12533,7 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Dairy"
                                               className="emotion-3"
                                               element="th"
@@ -12571,11 +12571,11 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Protein"
                                         label="Protein"
@@ -12626,7 +12626,7 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Protein"
                                               className="emotion-3"
                                               element="th"
@@ -12664,10 +12664,10 @@ exports[`Table demo examples Snapshots: custom-row 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -15103,7 +15103,7 @@ button:focus > .emotion-30 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableSortableHeaderCell
+                                                              <TableHeaderCell
                                                                 aria-label="Fruits"
                                                                 aria-sort="ascending"
                                                                 className="emotion-20"
@@ -15139,7 +15139,7 @@ button:focus > .emotion-30 {
                                                                     role="columnheader"
                                                                     textAlign="start"
                                                                   >
-                                                                    <TableHeaderCell
+                                                                    <WithTheme(Themed(TableCell))
                                                                       aria-label="Fruits"
                                                                       aria-sort="ascending"
                                                                       className="emotion-16"
@@ -15184,7 +15184,7 @@ button:focus > .emotion-30 {
                                                                                   className="emotion-15"
                                                                                   role="columnheader"
                                                                                 >
-                                                                                  <withProps(Styled(TableSortableHeaderCell))
+                                                                                  <withProps(Styled(TableHeaderCell))
                                                                                     aria-label="Fruits"
                                                                                     aria-sort="ascending"
                                                                                     className="emotion-13"
@@ -15194,7 +15194,7 @@ button:focus > .emotion-30 {
                                                                                     onClick={[Function]}
                                                                                     role="columnheader"
                                                                                   >
-                                                                                    <Styled(TableSortableHeaderCell)
+                                                                                    <Styled(TableHeaderCell)
                                                                                       aria-label="Fruits"
                                                                                       aria-sort="ascending"
                                                                                       className="emotion-13"
@@ -15206,7 +15206,7 @@ button:focus > .emotion-30 {
                                                                                       role="columnheader"
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableSortableHeaderCell
+                                                                                      <TableHeaderCell
                                                                                         aria-label="Fruits"
                                                                                         aria-sort="ascending"
                                                                                         className="emotion-10"
@@ -15242,7 +15242,7 @@ button:focus > .emotion-30 {
                                                                                             role="columnheader"
                                                                                             textAlign="start"
                                                                                           >
-                                                                                            <TableHeaderCell
+                                                                                            <WithTheme(Themed(TableCell))
                                                                                               aria-label="Fruits"
                                                                                               aria-sort="ascending"
                                                                                               className="emotion-6"
@@ -15344,22 +15344,22 @@ button:focus > .emotion-30 {
                                                                                                   </ThemeProvider>
                                                                                                 </ThemeProvider>
                                                                                               </Themed(TableCell)>
-                                                                                            </TableHeaderCell>
+                                                                                            </WithTheme(Themed(TableCell))>
                                                                                           </TableHeaderCell>
                                                                                         </withProps(TableHeaderCell)>
-                                                                                      </TableSortableHeaderCell>
-                                                                                    </Styled(TableSortableHeaderCell)>
-                                                                                  </withProps(Styled(TableSortableHeaderCell))>
+                                                                                      </TableHeaderCell>
+                                                                                    </Styled(TableHeaderCell)>
+                                                                                  </withProps(Styled(TableHeaderCell))>
                                                                                 </th>
                                                                               </TableCell>
                                                                             </TableCell>
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(TableCell)>
-                                                                    </TableHeaderCell>
+                                                                    </WithTheme(Themed(TableCell))>
                                                                   </TableHeaderCell>
                                                                 </withProps(TableHeaderCell)>
-                                                              </TableSortableHeaderCell>
+                                                              </TableHeaderCell>
                                                             </TableSortableHeaderCell>
                                                           </withProps(TableSortableHeaderCell)>
                                                         </TableSortableHeaderCell>
@@ -15758,7 +15758,7 @@ button:focus > .emotion-30 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableSortableHeaderCell
+                                                              <TableHeaderCell
                                                                 aria-label="Vegetables"
                                                                 aria-sort="none"
                                                                 className="emotion-46"
@@ -15794,7 +15794,7 @@ button:focus > .emotion-30 {
                                                                     role="columnheader"
                                                                     textAlign="start"
                                                                   >
-                                                                    <TableHeaderCell
+                                                                    <WithTheme(Themed(TableCell))
                                                                       aria-label="Vegetables"
                                                                       aria-sort="none"
                                                                       className="emotion-42"
@@ -15839,7 +15839,7 @@ button:focus > .emotion-30 {
                                                                                   className="emotion-41"
                                                                                   role="columnheader"
                                                                                 >
-                                                                                  <withProps(Styled(TableSortableHeaderCell))
+                                                                                  <withProps(Styled(TableHeaderCell))
                                                                                     aria-label="Vegetables"
                                                                                     aria-sort="none"
                                                                                     className="emotion-39"
@@ -15849,7 +15849,7 @@ button:focus > .emotion-30 {
                                                                                     onClick={[Function]}
                                                                                     role="columnheader"
                                                                                   >
-                                                                                    <Styled(TableSortableHeaderCell)
+                                                                                    <Styled(TableHeaderCell)
                                                                                       aria-label="Vegetables"
                                                                                       aria-sort="none"
                                                                                       className="emotion-39"
@@ -15861,7 +15861,7 @@ button:focus > .emotion-30 {
                                                                                       role="columnheader"
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableSortableHeaderCell
+                                                                                      <TableHeaderCell
                                                                                         aria-label="Vegetables"
                                                                                         aria-sort="none"
                                                                                         className="emotion-36"
@@ -15897,7 +15897,7 @@ button:focus > .emotion-30 {
                                                                                             role="columnheader"
                                                                                             textAlign="start"
                                                                                           >
-                                                                                            <TableHeaderCell
+                                                                                            <WithTheme(Themed(TableCell))
                                                                                               aria-label="Vegetables"
                                                                                               aria-sort="none"
                                                                                               className="emotion-32"
@@ -15999,22 +15999,22 @@ button:focus > .emotion-30 {
                                                                                                   </ThemeProvider>
                                                                                                 </ThemeProvider>
                                                                                               </Themed(TableCell)>
-                                                                                            </TableHeaderCell>
+                                                                                            </WithTheme(Themed(TableCell))>
                                                                                           </TableHeaderCell>
                                                                                         </withProps(TableHeaderCell)>
-                                                                                      </TableSortableHeaderCell>
-                                                                                    </Styled(TableSortableHeaderCell)>
-                                                                                  </withProps(Styled(TableSortableHeaderCell))>
+                                                                                      </TableHeaderCell>
+                                                                                    </Styled(TableHeaderCell)>
+                                                                                  </withProps(Styled(TableHeaderCell))>
                                                                                 </th>
                                                                               </TableCell>
                                                                             </TableCell>
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(TableCell)>
-                                                                    </TableHeaderCell>
+                                                                    </WithTheme(Themed(TableCell))>
                                                                   </TableHeaderCell>
                                                                 </withProps(TableHeaderCell)>
-                                                              </TableSortableHeaderCell>
+                                                              </TableHeaderCell>
                                                             </TableSortableHeaderCell>
                                                           </withProps(TableSortableHeaderCell)>
                                                         </TableSortableHeaderCell>
@@ -16413,7 +16413,7 @@ button:focus > .emotion-30 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableSortableHeaderCell
+                                                              <TableHeaderCell
                                                                 aria-label="Grains"
                                                                 aria-sort="none"
                                                                 className="emotion-46"
@@ -16449,7 +16449,7 @@ button:focus > .emotion-30 {
                                                                     role="columnheader"
                                                                     textAlign="start"
                                                                   >
-                                                                    <TableHeaderCell
+                                                                    <WithTheme(Themed(TableCell))
                                                                       aria-label="Grains"
                                                                       aria-sort="none"
                                                                       className="emotion-42"
@@ -16494,7 +16494,7 @@ button:focus > .emotion-30 {
                                                                                   className="emotion-41"
                                                                                   role="columnheader"
                                                                                 >
-                                                                                  <withProps(Styled(TableSortableHeaderCell))
+                                                                                  <withProps(Styled(TableHeaderCell))
                                                                                     aria-label="Grains"
                                                                                     aria-sort="none"
                                                                                     className="emotion-39"
@@ -16504,7 +16504,7 @@ button:focus > .emotion-30 {
                                                                                     onClick={[Function]}
                                                                                     role="columnheader"
                                                                                   >
-                                                                                    <Styled(TableSortableHeaderCell)
+                                                                                    <Styled(TableHeaderCell)
                                                                                       aria-label="Grains"
                                                                                       aria-sort="none"
                                                                                       className="emotion-39"
@@ -16516,7 +16516,7 @@ button:focus > .emotion-30 {
                                                                                       role="columnheader"
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableSortableHeaderCell
+                                                                                      <TableHeaderCell
                                                                                         aria-label="Grains"
                                                                                         aria-sort="none"
                                                                                         className="emotion-36"
@@ -16552,7 +16552,7 @@ button:focus > .emotion-30 {
                                                                                             role="columnheader"
                                                                                             textAlign="start"
                                                                                           >
-                                                                                            <TableHeaderCell
+                                                                                            <WithTheme(Themed(TableCell))
                                                                                               aria-label="Grains"
                                                                                               aria-sort="none"
                                                                                               className="emotion-32"
@@ -16654,22 +16654,22 @@ button:focus > .emotion-30 {
                                                                                                   </ThemeProvider>
                                                                                                 </ThemeProvider>
                                                                                               </Themed(TableCell)>
-                                                                                            </TableHeaderCell>
+                                                                                            </WithTheme(Themed(TableCell))>
                                                                                           </TableHeaderCell>
                                                                                         </withProps(TableHeaderCell)>
-                                                                                      </TableSortableHeaderCell>
-                                                                                    </Styled(TableSortableHeaderCell)>
-                                                                                  </withProps(Styled(TableSortableHeaderCell))>
+                                                                                      </TableHeaderCell>
+                                                                                    </Styled(TableHeaderCell)>
+                                                                                  </withProps(Styled(TableHeaderCell))>
                                                                                 </th>
                                                                               </TableCell>
                                                                             </TableCell>
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(TableCell)>
-                                                                    </TableHeaderCell>
+                                                                    </WithTheme(Themed(TableCell))>
                                                                   </TableHeaderCell>
                                                                 </withProps(TableHeaderCell)>
-                                                              </TableSortableHeaderCell>
+                                                              </TableHeaderCell>
                                                             </TableSortableHeaderCell>
                                                           </withProps(TableSortableHeaderCell)>
                                                         </TableSortableHeaderCell>
@@ -17068,7 +17068,7 @@ button:focus > .emotion-30 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableSortableHeaderCell
+                                                              <TableHeaderCell
                                                                 aria-label="Dairy"
                                                                 aria-sort="none"
                                                                 className="emotion-46"
@@ -17104,7 +17104,7 @@ button:focus > .emotion-30 {
                                                                     role="columnheader"
                                                                     textAlign="start"
                                                                   >
-                                                                    <TableHeaderCell
+                                                                    <WithTheme(Themed(TableCell))
                                                                       aria-label="Dairy"
                                                                       aria-sort="none"
                                                                       className="emotion-42"
@@ -17149,7 +17149,7 @@ button:focus > .emotion-30 {
                                                                                   className="emotion-41"
                                                                                   role="columnheader"
                                                                                 >
-                                                                                  <withProps(Styled(TableSortableHeaderCell))
+                                                                                  <withProps(Styled(TableHeaderCell))
                                                                                     aria-label="Dairy"
                                                                                     aria-sort="none"
                                                                                     className="emotion-39"
@@ -17159,7 +17159,7 @@ button:focus > .emotion-30 {
                                                                                     onClick={[Function]}
                                                                                     role="columnheader"
                                                                                   >
-                                                                                    <Styled(TableSortableHeaderCell)
+                                                                                    <Styled(TableHeaderCell)
                                                                                       aria-label="Dairy"
                                                                                       aria-sort="none"
                                                                                       className="emotion-39"
@@ -17171,7 +17171,7 @@ button:focus > .emotion-30 {
                                                                                       role="columnheader"
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableSortableHeaderCell
+                                                                                      <TableHeaderCell
                                                                                         aria-label="Dairy"
                                                                                         aria-sort="none"
                                                                                         className="emotion-36"
@@ -17207,7 +17207,7 @@ button:focus > .emotion-30 {
                                                                                             role="columnheader"
                                                                                             textAlign="start"
                                                                                           >
-                                                                                            <TableHeaderCell
+                                                                                            <WithTheme(Themed(TableCell))
                                                                                               aria-label="Dairy"
                                                                                               aria-sort="none"
                                                                                               className="emotion-32"
@@ -17309,22 +17309,22 @@ button:focus > .emotion-30 {
                                                                                                   </ThemeProvider>
                                                                                                 </ThemeProvider>
                                                                                               </Themed(TableCell)>
-                                                                                            </TableHeaderCell>
+                                                                                            </WithTheme(Themed(TableCell))>
                                                                                           </TableHeaderCell>
                                                                                         </withProps(TableHeaderCell)>
-                                                                                      </TableSortableHeaderCell>
-                                                                                    </Styled(TableSortableHeaderCell)>
-                                                                                  </withProps(Styled(TableSortableHeaderCell))>
+                                                                                      </TableHeaderCell>
+                                                                                    </Styled(TableHeaderCell)>
+                                                                                  </withProps(Styled(TableHeaderCell))>
                                                                                 </th>
                                                                               </TableCell>
                                                                             </TableCell>
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(TableCell)>
-                                                                    </TableHeaderCell>
+                                                                    </WithTheme(Themed(TableCell))>
                                                                   </TableHeaderCell>
                                                                 </withProps(TableHeaderCell)>
-                                                              </TableSortableHeaderCell>
+                                                              </TableHeaderCell>
                                                             </TableSortableHeaderCell>
                                                           </withProps(TableSortableHeaderCell)>
                                                         </TableSortableHeaderCell>
@@ -17723,7 +17723,7 @@ button:focus > .emotion-30 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableSortableHeaderCell
+                                                              <TableHeaderCell
                                                                 aria-label="Protein"
                                                                 aria-sort="none"
                                                                 className="emotion-46"
@@ -17759,7 +17759,7 @@ button:focus > .emotion-30 {
                                                                     role="columnheader"
                                                                     textAlign="start"
                                                                   >
-                                                                    <TableHeaderCell
+                                                                    <WithTheme(Themed(TableCell))
                                                                       aria-label="Protein"
                                                                       aria-sort="none"
                                                                       className="emotion-42"
@@ -17804,7 +17804,7 @@ button:focus > .emotion-30 {
                                                                                   className="emotion-41"
                                                                                   role="columnheader"
                                                                                 >
-                                                                                  <withProps(Styled(TableSortableHeaderCell))
+                                                                                  <withProps(Styled(TableHeaderCell))
                                                                                     aria-label="Protein"
                                                                                     aria-sort="none"
                                                                                     className="emotion-39"
@@ -17814,7 +17814,7 @@ button:focus > .emotion-30 {
                                                                                     onClick={[Function]}
                                                                                     role="columnheader"
                                                                                   >
-                                                                                    <Styled(TableSortableHeaderCell)
+                                                                                    <Styled(TableHeaderCell)
                                                                                       aria-label="Protein"
                                                                                       aria-sort="none"
                                                                                       className="emotion-39"
@@ -17826,7 +17826,7 @@ button:focus > .emotion-30 {
                                                                                       role="columnheader"
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableSortableHeaderCell
+                                                                                      <TableHeaderCell
                                                                                         aria-label="Protein"
                                                                                         aria-sort="none"
                                                                                         className="emotion-36"
@@ -17862,7 +17862,7 @@ button:focus > .emotion-30 {
                                                                                             role="columnheader"
                                                                                             textAlign="start"
                                                                                           >
-                                                                                            <TableHeaderCell
+                                                                                            <WithTheme(Themed(TableCell))
                                                                                               aria-label="Protein"
                                                                                               aria-sort="none"
                                                                                               className="emotion-32"
@@ -17964,22 +17964,22 @@ button:focus > .emotion-30 {
                                                                                                   </ThemeProvider>
                                                                                                 </ThemeProvider>
                                                                                               </Themed(TableCell)>
-                                                                                            </TableHeaderCell>
+                                                                                            </WithTheme(Themed(TableCell))>
                                                                                           </TableHeaderCell>
                                                                                         </withProps(TableHeaderCell)>
-                                                                                      </TableSortableHeaderCell>
-                                                                                    </Styled(TableSortableHeaderCell)>
-                                                                                  </withProps(Styled(TableSortableHeaderCell))>
+                                                                                      </TableHeaderCell>
+                                                                                    </Styled(TableHeaderCell)>
+                                                                                  </withProps(Styled(TableHeaderCell))>
                                                                                 </th>
                                                                               </TableCell>
                                                                             </TableCell>
                                                                           </ThemeProvider>
                                                                         </ThemeProvider>
                                                                       </Themed(TableCell)>
-                                                                    </TableHeaderCell>
+                                                                    </WithTheme(Themed(TableCell))>
                                                                   </TableHeaderCell>
                                                                 </withProps(TableHeaderCell)>
-                                                              </TableSortableHeaderCell>
+                                                              </TableHeaderCell>
                                                             </TableSortableHeaderCell>
                                                           </withProps(TableSortableHeaderCell)>
                                                         </TableSortableHeaderCell>
@@ -19169,7 +19169,7 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                   <tr
                                     className="emotion-27"
                                   >
-                                    <TableSortableHeaderCell
+                                    <TableHeaderCell
                                       element="th"
                                       key="Fruits"
                                       label="Fruits"
@@ -19220,7 +19220,7 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Fruits"
                                             className="emotion-3"
                                             element="th"
@@ -19258,11 +19258,11 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Vegetables"
                                       label="Vegetables"
@@ -19313,7 +19313,7 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Vegetables"
                                             className="emotion-3"
                                             element="th"
@@ -19351,11 +19351,11 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Grains"
                                       label="Grains"
@@ -19406,7 +19406,7 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Grains"
                                             className="emotion-3"
                                             element="th"
@@ -19444,11 +19444,11 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Dairy"
                                       label="Dairy"
@@ -19499,7 +19499,7 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Dairy"
                                             className="emotion-3"
                                             element="th"
@@ -19537,11 +19537,11 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Protein"
                                       label="Protein"
@@ -19592,7 +19592,7 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Protein"
                                             className="emotion-3"
                                             element="th"
@@ -19630,10 +19630,10 @@ exports[`Table demo examples Snapshots: density 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
+                                    </TableHeaderCell>
                                   </tr>
                                 </TableRow>
                               </TableRow>
@@ -20755,7 +20755,7 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                   <tr
                                     className="emotion-27"
                                   >
-                                    <TableSortableHeaderCell
+                                    <TableHeaderCell
                                       element="th"
                                       key="Fruits"
                                       label="Fruits"
@@ -20808,7 +20808,7 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Fruits"
                                             className="emotion-3"
                                             element="th"
@@ -20847,11 +20847,11 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Vegetables"
                                       label="Vegetables"
@@ -20904,7 +20904,7 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Vegetables"
                                             className="emotion-3"
                                             element="th"
@@ -20943,11 +20943,11 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Grains"
                                       label="Grains"
@@ -21000,7 +21000,7 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Grains"
                                             className="emotion-3"
                                             element="th"
@@ -21039,11 +21039,11 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Dairy"
                                       label="Dairy"
@@ -21096,7 +21096,7 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Dairy"
                                             className="emotion-3"
                                             element="th"
@@ -21135,11 +21135,11 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Protein"
                                       label="Protein"
@@ -21192,7 +21192,7 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                           }
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Protein"
                                             className="emotion-3"
                                             element="th"
@@ -21231,10 +21231,10 @@ exports[`Table demo examples Snapshots: high-contrast 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
+                                    </TableHeaderCell>
                                   </tr>
                                 </TableRow>
                               </TableRow>
@@ -22994,7 +22994,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                             <tr
                                               className="emotion-27"
                                             >
-                                              <TableSortableHeaderCell
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="name"
                                                 label="Mineral"
@@ -23045,7 +23045,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Mineral"
                                                       className="emotion-3"
                                                       element="th"
@@ -23083,11 +23083,11 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="color"
                                                 label="Color"
@@ -23138,7 +23138,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Color"
                                                       className="emotion-3"
                                                       element="th"
@@ -23176,11 +23176,11 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="luster"
                                                 label="Luster"
@@ -23231,7 +23231,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Luster"
                                                       className="emotion-3"
                                                       element="th"
@@ -23269,11 +23269,11 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="crystalSystem"
                                                 label="Crystal System"
@@ -23324,7 +23324,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Crystal System"
                                                       className="emotion-3"
                                                       element="th"
@@ -23362,11 +23362,11 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="crystalHabit"
                                                 label="Crystal Habit"
@@ -23417,7 +23417,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Crystal Habit"
                                                       className="emotion-3"
                                                       element="th"
@@ -23455,10 +23455,10 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
+                                              </TableHeaderCell>
                                             </tr>
                                           </TableRow>
                                         </TableRow>
@@ -24061,7 +24061,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <Grid
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-84"
@@ -24109,7 +24109,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-82"
@@ -24137,7 +24137,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                 aria-label="Pagination"
                                 className="emotion-81"
                               >
-                                <GridItem
+                                <FlexItem
                                   grow={0}
                                   key=".1"
                                   shrink={1}
@@ -24147,7 +24147,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-79"
                                       element="div"
                                       grow={0}
@@ -24197,7 +24197,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                               totalPages={5}
                                               visibleRange={5}
                                             >
-                                              <GridItem
+                                              <FlexItem
                                                 className="emotion-76"
                                                 currentPage={1}
                                                 grow={0}
@@ -24236,7 +24236,7 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                   totalPages={5}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-74"
                                                     currentPage={1}
                                                     element="div"
@@ -24697,23 +24697,23 @@ exports[`Table demo examples Snapshots: pagination 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
-                                              </GridItem>
+                                              </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
-                                </GridItem>
+                                </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </Grid>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -25154,7 +25154,7 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                     <tr
                                       className="emotion-27"
                                     >
-                                      <TableSortableHeaderCell
+                                      <TableHeaderCell
                                         element="th"
                                         key="Fruit"
                                         label="Fruit"
@@ -25208,7 +25208,7 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                             primary={true}
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Fruit"
                                               className="emotion-3"
                                               element="th"
@@ -25246,11 +25246,11 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Family"
                                         label="Family"
@@ -25301,7 +25301,7 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Family"
                                               className="emotion-3"
                                               element="th"
@@ -25339,11 +25339,11 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Etymology"
                                         label="Etymology"
@@ -25394,7 +25394,7 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Etymology"
                                               className="emotion-3"
                                               element="th"
@@ -25432,11 +25432,11 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Color"
                                         label="Color"
@@ -25487,7 +25487,7 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Color"
                                               className="emotion-3"
                                               element="th"
@@ -25525,11 +25525,11 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
-                                      <TableSortableHeaderCell
+                                      </TableHeaderCell>
+                                      <TableHeaderCell
                                         element="th"
                                         key="Taste"
                                         label="Taste"
@@ -25580,7 +25580,7 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                             }
                                             textAlign="start"
                                           >
-                                            <TableHeaderCell
+                                            <WithTheme(Themed(TableCell))
                                               aria-label="Taste"
                                               className="emotion-3"
                                               element="th"
@@ -25618,10 +25618,10 @@ exports[`Table demo examples Snapshots: primary-column 1`] = `
                                                   </ThemeProvider>
                                                 </ThemeProvider>
                                               </Themed(TableCell)>
-                                            </TableHeaderCell>
+                                            </WithTheme(Themed(TableCell))>
                                           </TableHeaderCell>
                                         </withProps(TableHeaderCell)>
-                                      </TableSortableHeaderCell>
+                                      </TableHeaderCell>
                                     </tr>
                                   </TableRow>
                                 </TableRow>
@@ -27444,7 +27444,7 @@ button:focus > .emotion-4 {
                                                       role="columnheader"
                                                       textAlign="start"
                                                     >
-                                                      <TableSortableHeaderCell
+                                                      <TableHeaderCell
                                                         aria-label="ثمار"
                                                         aria-sort="none"
                                                         className="emotion-18"
@@ -27473,7 +27473,7 @@ button:focus > .emotion-4 {
                                                             role="columnheader"
                                                             textAlign="start"
                                                           >
-                                                            <TableHeaderCell
+                                                            <WithTheme(Themed(TableCell))
                                                               aria-label="ثمار"
                                                               aria-sort="none"
                                                               className="emotion-14"
@@ -27518,17 +27518,17 @@ button:focus > .emotion-4 {
                                                                           className="emotion-13"
                                                                           role="columnheader"
                                                                         >
-                                                                          <withProps(Styled(TableSortableHeaderCell))
+                                                                          <withProps(Styled(TableHeaderCell))
                                                                             aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                             onClick={[Function]}
                                                                           >
-                                                                            <Styled(TableSortableHeaderCell)
+                                                                            <Styled(TableHeaderCell)
                                                                               aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                               element="button"
                                                                               onClick={[Function]}
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableSortableHeaderCell
+                                                                              <TableHeaderCell
                                                                                 aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                                 className="emotion-10"
                                                                                 element="button"
@@ -27551,7 +27551,7 @@ button:focus > .emotion-4 {
                                                                                     onClick={[Function]}
                                                                                     textAlign="start"
                                                                                   >
-                                                                                    <TableHeaderCell
+                                                                                    <WithTheme(Themed(TableCell))
                                                                                       aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                                       className="emotion-6"
                                                                                       element="button"
@@ -27643,26 +27643,26 @@ button:focus > .emotion-4 {
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(TableCell)>
-                                                                                    </TableHeaderCell>
+                                                                                    </WithTheme(Themed(TableCell))>
                                                                                   </TableHeaderCell>
                                                                                 </withProps(TableHeaderCell)>
-                                                                              </TableSortableHeaderCell>
-                                                                            </Styled(TableSortableHeaderCell)>
-                                                                          </withProps(Styled(TableSortableHeaderCell))>
+                                                                              </TableHeaderCell>
+                                                                            </Styled(TableHeaderCell)>
+                                                                          </withProps(Styled(TableHeaderCell))>
                                                                         </th>
                                                                       </TableCell>
                                                                     </TableCell>
                                                                   </ThemeProvider>
                                                                 </ThemeProvider>
                                                               </Themed(TableCell)>
-                                                            </TableHeaderCell>
+                                                            </WithTheme(Themed(TableCell))>
                                                           </TableHeaderCell>
                                                         </withProps(TableHeaderCell)>
-                                                      </TableSortableHeaderCell>
+                                                      </TableHeaderCell>
                                                     </TableSortableHeaderCell>
                                                   </withProps(TableSortableHeaderCell)>
                                                 </TableSortableHeaderCell>
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   element="th"
                                                   key="Vegetables"
                                                   label="خضروات"
@@ -27713,7 +27713,7 @@ button:focus > .emotion-4 {
                                                       }
                                                       textAlign="center"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="خضروات"
                                                         className="emotion-22"
                                                         element="th"
@@ -27751,11 +27751,11 @@ button:focus > .emotion-4 {
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
-                                                <TableSortableHeaderCell
+                                                </TableHeaderCell>
+                                                <TableHeaderCell
                                                   element="th"
                                                   key="Grains"
                                                   label="بقوليات"
@@ -27806,7 +27806,7 @@ button:focus > .emotion-4 {
                                                       }
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="بقوليات"
                                                         className="emotion-22"
                                                         element="th"
@@ -27844,10 +27844,10 @@ button:focus > .emotion-4 {
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                                 <TableSortableHeaderCell
                                                   key="Dairy"
                                                   label="الألبان"
@@ -27908,7 +27908,7 @@ button:focus > .emotion-4 {
                                                       role="columnheader"
                                                       textAlign="end"
                                                     >
-                                                      <TableSortableHeaderCell
+                                                      <TableHeaderCell
                                                         aria-label="الألبان"
                                                         aria-sort="none"
                                                         className="emotion-18"
@@ -27937,7 +27937,7 @@ button:focus > .emotion-4 {
                                                             role="columnheader"
                                                             textAlign="end"
                                                           >
-                                                            <TableHeaderCell
+                                                            <WithTheme(Themed(TableCell))
                                                               aria-label="الألبان"
                                                               aria-sort="none"
                                                               className="emotion-14"
@@ -27982,18 +27982,18 @@ button:focus > .emotion-4 {
                                                                           className="emotion-42"
                                                                           role="columnheader"
                                                                         >
-                                                                          <withProps(Styled(TableSortableHeaderCell))
+                                                                          <withProps(Styled(TableHeaderCell))
                                                                             aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                             onClick={[Function]}
                                                                             textAlign="end"
                                                                           >
-                                                                            <Styled(TableSortableHeaderCell)
+                                                                            <Styled(TableHeaderCell)
                                                                               aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                               element="button"
                                                                               onClick={[Function]}
                                                                               textAlign="end"
                                                                             >
-                                                                              <TableSortableHeaderCell
+                                                                              <TableHeaderCell
                                                                                 aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                                 className="emotion-10"
                                                                                 element="button"
@@ -28016,7 +28016,7 @@ button:focus > .emotion-4 {
                                                                                     onClick={[Function]}
                                                                                     textAlign="end"
                                                                                   >
-                                                                                    <TableHeaderCell
+                                                                                    <WithTheme(Themed(TableCell))
                                                                                       aria-label="ترتيب العمود في تصاعدي الطلب"
                                                                                       className="emotion-6"
                                                                                       element="button"
@@ -28108,26 +28108,26 @@ button:focus > .emotion-4 {
                                                                                           </ThemeProvider>
                                                                                         </ThemeProvider>
                                                                                       </Themed(TableCell)>
-                                                                                    </TableHeaderCell>
+                                                                                    </WithTheme(Themed(TableCell))>
                                                                                   </TableHeaderCell>
                                                                                 </withProps(TableHeaderCell)>
-                                                                              </TableSortableHeaderCell>
-                                                                            </Styled(TableSortableHeaderCell)>
-                                                                          </withProps(Styled(TableSortableHeaderCell))>
+                                                                              </TableHeaderCell>
+                                                                            </Styled(TableHeaderCell)>
+                                                                          </withProps(Styled(TableHeaderCell))>
                                                                         </th>
                                                                       </TableCell>
                                                                     </TableCell>
                                                                   </ThemeProvider>
                                                                 </ThemeProvider>
                                                               </Themed(TableCell)>
-                                                            </TableHeaderCell>
+                                                            </WithTheme(Themed(TableCell))>
                                                           </TableHeaderCell>
                                                         </withProps(TableHeaderCell)>
-                                                      </TableSortableHeaderCell>
+                                                      </TableHeaderCell>
                                                     </TableSortableHeaderCell>
                                                   </withProps(TableSortableHeaderCell)>
                                                 </TableSortableHeaderCell>
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   element="th"
                                                   key="Protein"
                                                   label="بروتين"
@@ -28178,7 +28178,7 @@ button:focus > .emotion-4 {
                                                       }
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="بروتين"
                                                         className="emotion-22"
                                                         element="th"
@@ -28216,10 +28216,10 @@ button:focus > .emotion-4 {
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </tr>
                                             </TableRow>
                                           </TableRow>
@@ -28966,7 +28966,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
   box-sizing: inherit;
 }
 
-<FlexItem
+<Box
   element="div"
   width="50%"
 >
@@ -29308,7 +29308,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                         <tr
                                           className="emotion-27"
                                         >
-                                          <TableSortableHeaderCell
+                                          <TableHeaderCell
                                             element="th"
                                             key="Fruits"
                                             label="Fruits"
@@ -29359,7 +29359,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Fruits"
                                                   className="emotion-3"
                                                   element="th"
@@ -29399,11 +29399,11 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Vegetables"
                                             label="Vegetables"
@@ -29454,7 +29454,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Vegetables"
                                                   className="emotion-3"
                                                   element="th"
@@ -29494,11 +29494,11 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Grains"
                                             label="Grains"
@@ -29549,7 +29549,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Grains"
                                                   className="emotion-3"
                                                   element="th"
@@ -29589,11 +29589,11 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Dairy"
                                             label="Dairy"
@@ -29644,7 +29644,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Dairy"
                                                   className="emotion-3"
                                                   element="th"
@@ -29684,11 +29684,11 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Protein"
                                             label="Protein"
@@ -29739,7 +29739,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Protein"
                                                   className="emotion-3"
                                                   element="th"
@@ -29779,10 +29779,10 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
+                                          </TableHeaderCell>
                                         </tr>
                                       </TableRow>
                                     </TableRow>
@@ -30756,7 +30756,7 @@ exports[`Table demo examples Snapshots: scrollable 1`] = `
       </Table>
     </div>
   </Styled(div)>
-</FlexItem>
+</Box>
 `;
 
 exports[`Table demo examples Snapshots: selectable 1`] = `
@@ -31809,7 +31809,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                             label="Deselect all rows"
                                             onChange={[Function]}
                                           >
-                                            <TableSortableHeaderCell
+                                            <TableHeaderCell
                                               aria-label="Selected rows"
                                               element="th"
                                               noPadding={true}
@@ -31832,7 +31832,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                   textAlign="start"
                                                   width={1}
                                                 >
-                                                  <TableHeaderCell
+                                                  <WithTheme(Themed(TableCell))
                                                     aria-label="Selected rows"
                                                     className="emotion-10"
                                                     element="th"
@@ -32050,12 +32050,12 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                         </ThemeProvider>
                                                       </ThemeProvider>
                                                     </Themed(TableCell)>
-                                                  </TableHeaderCell>
+                                                  </WithTheme(Themed(TableCell))>
                                                 </TableHeaderCell>
                                               </withProps(TableHeaderCell)>
-                                            </TableSortableHeaderCell>
+                                            </TableHeaderCell>
                                           </TableSelectableCell>
-                                          <TableSortableHeaderCell
+                                          <TableHeaderCell
                                             element="th"
                                             key="Fruits"
                                             label="Fruits"
@@ -32106,7 +32106,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Fruits"
                                                   className="emotion-15"
                                                   element="th"
@@ -32144,11 +32144,11 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Vegetables"
                                             label="Vegetables"
@@ -32199,7 +32199,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Vegetables"
                                                   className="emotion-15"
                                                   element="th"
@@ -32237,11 +32237,11 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Grains"
                                             label="Grains"
@@ -32292,7 +32292,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Grains"
                                                   className="emotion-15"
                                                   element="th"
@@ -32330,11 +32330,11 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Dairy"
                                             label="Dairy"
@@ -32385,7 +32385,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Dairy"
                                                   className="emotion-15"
                                                   element="th"
@@ -32423,11 +32423,11 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          </TableHeaderCell>
+                                          <TableHeaderCell
                                             element="th"
                                             key="Protein"
                                             label="Protein"
@@ -32478,7 +32478,7 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Protein"
                                                   className="emotion-15"
                                                   element="th"
@@ -32516,10 +32516,10 @@ exports[`Table demo examples Snapshots: selectable 1`] = `
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
+                                          </TableHeaderCell>
                                         </tr>
                                       </TableRow>
                                     </TableRow>
@@ -34327,7 +34327,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
 <Component>
   <MyTable>
     <div>
-      <Grid
+      <Flex
         alignItems="stretch"
         direction="row"
         gutterWidth="md"
@@ -34356,7 +34356,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <FlexItem
+              <Box
                 alignItems="stretch"
                 className="emotion-19"
                 direction="row"
@@ -34377,7 +34377,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                   <div
                     className="emotion-18"
                   >
-                    <GridItem
+                    <FlexItem
                       grow={0}
                       key=".0"
                       marginBottom="md"
@@ -34391,7 +34391,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                         marginEnd="1em"
                         shrink={1}
                       >
-                        <FlexItem
+                        <Box
                           className="emotion-4"
                           element="div"
                           grow={0}
@@ -34448,10 +34448,10 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                               </Button>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </FlexItem>
-                    </GridItem>
-                    <GridItem
+                    </FlexItem>
+                    <FlexItem
                       grow={0}
                       key=".1"
                       marginBottom="md"
@@ -34467,7 +34467,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                         marginRight="auto"
                         shrink={1}
                       >
-                        <FlexItem
+                        <Box
                           className="emotion-4"
                           element="div"
                           grow={0}
@@ -34526,10 +34526,10 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                               </Button>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </FlexItem>
-                    </GridItem>
-                    <GridItem
+                    </FlexItem>
+                    <FlexItem
                       grow={0}
                       key=".2"
                       marginBottom="md"
@@ -34541,7 +34541,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                         marginBottom="md"
                         shrink={1}
                       >
-                        <FlexItem
+                        <Box
                           className="emotion-4"
                           element="div"
                           grow={0}
@@ -34596,16 +34596,16 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                               </Button>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </FlexItem>
-                    </GridItem>
+                    </FlexItem>
                   </div>
                 </Styled(div)>
-              </FlexItem>
+              </Box>
             </Flex>
           </Component>
         </WithTheme(Component)>
-      </Grid>
+      </Flex>
       <Table
         data={
           Array [
@@ -35185,7 +35185,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                 label="Select all rows"
                                                 onChange={[Function]}
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Selected rows"
                                                   element="th"
                                                   noPadding={true}
@@ -35208,7 +35208,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                       textAlign="start"
                                                       width={1}
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Selected rows"
                                                         className="emotion-31"
                                                         element="th"
@@ -35426,12 +35426,12 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSelectableCell>
-                                              <TableSortableHeaderCell
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="Fruits"
                                                 label="Fruits"
@@ -35482,7 +35482,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Fruits"
                                                       className="emotion-36"
                                                       element="th"
@@ -35520,11 +35520,11 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="Vegetables"
                                                 label="Vegetables"
@@ -35575,7 +35575,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Vegetables"
                                                       className="emotion-36"
                                                       element="th"
@@ -35613,11 +35613,11 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="Grains"
                                                 label="Grains"
@@ -35668,7 +35668,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Grains"
                                                       className="emotion-36"
                                                       element="th"
@@ -35706,11 +35706,11 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="Dairy"
                                                 label="Dairy"
@@ -35761,7 +35761,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Dairy"
                                                       className="emotion-36"
                                                       element="th"
@@ -35799,11 +35799,11 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
-                                              <TableSortableHeaderCell
+                                              </TableHeaderCell>
+                                              <TableHeaderCell
                                                 element="th"
                                                 key="Protein"
                                                 label="Protein"
@@ -35854,7 +35854,7 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                     }
                                                     textAlign="start"
                                                   >
-                                                    <TableHeaderCell
+                                                    <WithTheme(Themed(TableCell))
                                                       aria-label="Protein"
                                                       className="emotion-36"
                                                       element="th"
@@ -35892,10 +35892,10 @@ exports[`Table demo examples Snapshots: selectable-controlled 1`] = `
                                                           </ThemeProvider>
                                                         </ThemeProvider>
                                                       </Themed(TableCell)>
-                                                    </TableHeaderCell>
+                                                    </WithTheme(Themed(TableCell))>
                                                   </TableHeaderCell>
                                                 </withProps(TableHeaderCell)>
-                                              </TableSortableHeaderCell>
+                                              </TableHeaderCell>
                                             </tr>
                                           </TableRow>
                                         </TableRow>
@@ -38928,7 +38928,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                     label="Select all rows"
                                                     onChange={[Function]}
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       aria-label="Selected rows"
                                                       element="th"
                                                       noPadding={true}
@@ -38951,7 +38951,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                           textAlign="start"
                                                           width={1}
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="Selected rows"
                                                             className="emotion-10"
                                                             element="th"
@@ -39169,12 +39169,12 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </TableSelectableCell>
-                                                  <TableSortableHeaderCell
+                                                  <TableHeaderCell
                                                     element="th"
                                                     key="name"
                                                     label="Mineral"
@@ -39225,7 +39225,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                         }
                                                         textAlign="start"
                                                       >
-                                                        <TableHeaderCell
+                                                        <WithTheme(Themed(TableCell))
                                                           aria-label="Mineral"
                                                           className="emotion-15"
                                                           element="th"
@@ -39263,11 +39263,11 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                               </ThemeProvider>
                                                             </ThemeProvider>
                                                           </Themed(TableCell)>
-                                                        </TableHeaderCell>
+                                                        </WithTheme(Themed(TableCell))>
                                                       </TableHeaderCell>
                                                     </withProps(TableHeaderCell)>
-                                                  </TableSortableHeaderCell>
-                                                  <TableSortableHeaderCell
+                                                  </TableHeaderCell>
+                                                  <TableHeaderCell
                                                     element="th"
                                                     key="color"
                                                     label="Color"
@@ -39318,7 +39318,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                         }
                                                         textAlign="start"
                                                       >
-                                                        <TableHeaderCell
+                                                        <WithTheme(Themed(TableCell))
                                                           aria-label="Color"
                                                           className="emotion-15"
                                                           element="th"
@@ -39356,11 +39356,11 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                               </ThemeProvider>
                                                             </ThemeProvider>
                                                           </Themed(TableCell)>
-                                                        </TableHeaderCell>
+                                                        </WithTheme(Themed(TableCell))>
                                                       </TableHeaderCell>
                                                     </withProps(TableHeaderCell)>
-                                                  </TableSortableHeaderCell>
-                                                  <TableSortableHeaderCell
+                                                  </TableHeaderCell>
+                                                  <TableHeaderCell
                                                     element="th"
                                                     key="luster"
                                                     label="Luster"
@@ -39411,7 +39411,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                         }
                                                         textAlign="start"
                                                       >
-                                                        <TableHeaderCell
+                                                        <WithTheme(Themed(TableCell))
                                                           aria-label="Luster"
                                                           className="emotion-15"
                                                           element="th"
@@ -39449,11 +39449,11 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                               </ThemeProvider>
                                                             </ThemeProvider>
                                                           </Themed(TableCell)>
-                                                        </TableHeaderCell>
+                                                        </WithTheme(Themed(TableCell))>
                                                       </TableHeaderCell>
                                                     </withProps(TableHeaderCell)>
-                                                  </TableSortableHeaderCell>
-                                                  <TableSortableHeaderCell
+                                                  </TableHeaderCell>
+                                                  <TableHeaderCell
                                                     element="th"
                                                     key="crystalSystem"
                                                     label="Crystal System"
@@ -39504,7 +39504,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                         }
                                                         textAlign="start"
                                                       >
-                                                        <TableHeaderCell
+                                                        <WithTheme(Themed(TableCell))
                                                           aria-label="Crystal System"
                                                           className="emotion-15"
                                                           element="th"
@@ -39542,11 +39542,11 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                               </ThemeProvider>
                                                             </ThemeProvider>
                                                           </Themed(TableCell)>
-                                                        </TableHeaderCell>
+                                                        </WithTheme(Themed(TableCell))>
                                                       </TableHeaderCell>
                                                     </withProps(TableHeaderCell)>
-                                                  </TableSortableHeaderCell>
-                                                  <TableSortableHeaderCell
+                                                  </TableHeaderCell>
+                                                  <TableHeaderCell
                                                     element="th"
                                                     key="crystalHabit"
                                                     label="Crystal Habit"
@@ -39597,7 +39597,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                         }
                                                         textAlign="start"
                                                       >
-                                                        <TableHeaderCell
+                                                        <WithTheme(Themed(TableCell))
                                                           aria-label="Crystal Habit"
                                                           className="emotion-15"
                                                           element="th"
@@ -39635,10 +39635,10 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                               </ThemeProvider>
                                                             </ThemeProvider>
                                                           </Themed(TableCell)>
-                                                        </TableHeaderCell>
+                                                        </WithTheme(Themed(TableCell))>
                                                       </TableHeaderCell>
                                                     </withProps(TableHeaderCell)>
-                                                  </TableSortableHeaderCell>
+                                                  </TableHeaderCell>
                                                 </tr>
                                               </TableRow>
                                             </TableRow>
@@ -40822,7 +40822,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <Grid
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-120"
@@ -40870,7 +40870,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-118"
@@ -40898,7 +40898,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                 aria-label="Pagination"
                                 className="emotion-117"
                               >
-                                <GridItem
+                                <FlexItem
                                   grow={0}
                                   key=".1"
                                   shrink={1}
@@ -40908,7 +40908,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-115"
                                       element="div"
                                       grow={0}
@@ -40958,7 +40958,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                               totalPages={5}
                                               visibleRange={5}
                                             >
-                                              <GridItem
+                                              <FlexItem
                                                 className="emotion-112"
                                                 currentPage={1}
                                                 grow={0}
@@ -40997,7 +40997,7 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                   totalPages={5}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-110"
                                                     currentPage={1}
                                                     element="div"
@@ -41458,23 +41458,23 @@ exports[`Table demo examples Snapshots: selectable-paginated 1`] = `
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
-                                              </GridItem>
+                                              </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
-                                </GridItem>
+                                </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </Grid>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -42558,7 +42558,7 @@ button:focus > .emotion-23 {
                                                 role="columnheader"
                                                 textAlign="start"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Fruits"
                                                   aria-sort="ascending"
                                                   className="emotion-18"
@@ -42587,7 +42587,7 @@ button:focus > .emotion-23 {
                                                       role="columnheader"
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Fruits"
                                                         aria-sort="ascending"
                                                         className="emotion-14"
@@ -42632,17 +42632,17 @@ button:focus > .emotion-23 {
                                                                     className="emotion-13"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in descending order"
                                                                       onClick={[Function]}
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in descending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="start"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in descending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -42665,7 +42665,7 @@ button:focus > .emotion-23 {
                                                                               onClick={[Function]}
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in descending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -42757,22 +42757,22 @@ button:focus > .emotion-23 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -42843,7 +42843,7 @@ button:focus > .emotion-23 {
                                                 role="columnheader"
                                                 textAlign="start"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Vegetables"
                                                   aria-sort="none"
                                                   className="emotion-18"
@@ -42872,7 +42872,7 @@ button:focus > .emotion-23 {
                                                       role="columnheader"
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Vegetables"
                                                         aria-sort="none"
                                                         className="emotion-14"
@@ -42917,17 +42917,17 @@ button:focus > .emotion-23 {
                                                                     className="emotion-13"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in ascending order"
                                                                       onClick={[Function]}
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in ascending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="start"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in ascending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -42950,7 +42950,7 @@ button:focus > .emotion-23 {
                                                                               onClick={[Function]}
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in ascending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -43042,22 +43042,22 @@ button:focus > .emotion-23 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -43128,7 +43128,7 @@ button:focus > .emotion-23 {
                                                 role="columnheader"
                                                 textAlign="start"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Grains"
                                                   aria-sort="none"
                                                   className="emotion-18"
@@ -43157,7 +43157,7 @@ button:focus > .emotion-23 {
                                                       role="columnheader"
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Grains"
                                                         aria-sort="none"
                                                         className="emotion-14"
@@ -43202,17 +43202,17 @@ button:focus > .emotion-23 {
                                                                     className="emotion-13"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in ascending order"
                                                                       onClick={[Function]}
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in ascending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         textAlign="start"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in ascending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -43235,7 +43235,7 @@ button:focus > .emotion-23 {
                                                                               onClick={[Function]}
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in ascending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -43327,22 +43327,22 @@ button:focus > .emotion-23 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
@@ -43416,7 +43416,7 @@ button:focus > .emotion-23 {
                                                 sortComparator={[Function]}
                                                 textAlign="start"
                                               >
-                                                <TableSortableHeaderCell
+                                                <TableHeaderCell
                                                   aria-label="Dairy"
                                                   aria-sort="none"
                                                   className="emotion-18"
@@ -43448,7 +43448,7 @@ button:focus > .emotion-23 {
                                                       sortComparator={[Function]}
                                                       textAlign="start"
                                                     >
-                                                      <TableHeaderCell
+                                                      <WithTheme(Themed(TableCell))
                                                         aria-label="Dairy"
                                                         aria-sort="none"
                                                         className="emotion-14"
@@ -43493,19 +43493,19 @@ button:focus > .emotion-23 {
                                                                     className="emotion-13"
                                                                     role="columnheader"
                                                                   >
-                                                                    <withProps(Styled(TableSortableHeaderCell))
+                                                                    <withProps(Styled(TableHeaderCell))
                                                                       aria-label="Sort column in ascending order"
                                                                       onClick={[Function]}
                                                                       sortComparator={[Function]}
                                                                     >
-                                                                      <Styled(TableSortableHeaderCell)
+                                                                      <Styled(TableHeaderCell)
                                                                         aria-label="Sort column in ascending order"
                                                                         element="button"
                                                                         onClick={[Function]}
                                                                         sortComparator={[Function]}
                                                                         textAlign="start"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           aria-label="Sort column in ascending order"
                                                                           className="emotion-10"
                                                                           element="button"
@@ -43531,7 +43531,7 @@ button:focus > .emotion-23 {
                                                                               sortComparator={[Function]}
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Sort column in ascending order"
                                                                                 className="emotion-6"
                                                                                 element="button"
@@ -43623,26 +43623,26 @@ button:focus > .emotion-23 {
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                      </Styled(TableSortableHeaderCell)>
-                                                                    </withProps(Styled(TableSortableHeaderCell))>
+                                                                        </TableHeaderCell>
+                                                                      </Styled(TableHeaderCell)>
+                                                                    </withProps(Styled(TableHeaderCell))>
                                                                   </th>
                                                                 </TableCell>
                                                               </TableCell>
                                                             </ThemeProvider>
                                                           </ThemeProvider>
                                                         </Themed(TableCell)>
-                                                      </TableHeaderCell>
+                                                      </WithTheme(Themed(TableCell))>
                                                     </TableHeaderCell>
                                                   </withProps(TableHeaderCell)>
-                                                </TableSortableHeaderCell>
+                                                </TableHeaderCell>
                                               </TableSortableHeaderCell>
                                             </withProps(TableSortableHeaderCell)>
                                           </TableSortableHeaderCell>
-                                          <TableSortableHeaderCell
+                                          <TableHeaderCell
                                             element="th"
                                             key="Protein"
                                             label="Protein"
@@ -43693,7 +43693,7 @@ button:focus > .emotion-23 {
                                                 }
                                                 textAlign="start"
                                               >
-                                                <TableHeaderCell
+                                                <WithTheme(Themed(TableCell))
                                                   aria-label="Protein"
                                                   className="emotion-79"
                                                   element="th"
@@ -43731,10 +43731,10 @@ button:focus > .emotion-23 {
                                                       </ThemeProvider>
                                                     </ThemeProvider>
                                                   </Themed(TableCell)>
-                                                </TableHeaderCell>
+                                                </WithTheme(Themed(TableCell))>
                                               </TableHeaderCell>
                                             </withProps(TableHeaderCell)>
-                                          </TableSortableHeaderCell>
+                                          </TableHeaderCell>
                                         </tr>
                                       </TableRow>
                                     </TableRow>
@@ -45161,7 +45161,7 @@ button:focus > .emotion-44 {
     }
   >
     <div>
-      <Grid
+      <Flex
         alignItems="stretch"
         direction="row"
         gutterWidth="md"
@@ -45190,7 +45190,7 @@ button:focus > .emotion-44 {
               justifyContent="start"
               wrap={true}
             >
-              <FlexItem
+              <Box
                 alignItems="stretch"
                 className="emotion-19"
                 direction="row"
@@ -45211,7 +45211,7 @@ button:focus > .emotion-44 {
                   <div
                     className="emotion-18"
                   >
-                    <GridItem
+                    <FlexItem
                       grow={0}
                       key=".0"
                       marginBottom="md"
@@ -45225,7 +45225,7 @@ button:focus > .emotion-44 {
                         marginEnd="1em"
                         shrink={1}
                       >
-                        <FlexItem
+                        <Box
                           className="emotion-4"
                           element="div"
                           grow={0}
@@ -45282,10 +45282,10 @@ button:focus > .emotion-44 {
                               </Button>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </FlexItem>
-                    </GridItem>
-                    <GridItem
+                    </FlexItem>
+                    <FlexItem
                       grow={0}
                       key=".1"
                       marginBottom="md"
@@ -45301,7 +45301,7 @@ button:focus > .emotion-44 {
                         marginRight="auto"
                         shrink={1}
                       >
-                        <FlexItem
+                        <Box
                           className="emotion-4"
                           element="div"
                           grow={0}
@@ -45360,10 +45360,10 @@ button:focus > .emotion-44 {
                               </Button>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </FlexItem>
-                    </GridItem>
-                    <GridItem
+                    </FlexItem>
+                    <FlexItem
                       grow={0}
                       key=".2"
                       marginBottom="md"
@@ -45375,7 +45375,7 @@ button:focus > .emotion-44 {
                         marginBottom="md"
                         shrink={1}
                       >
-                        <FlexItem
+                        <Box
                           className="emotion-4"
                           element="div"
                           grow={0}
@@ -45430,16 +45430,16 @@ button:focus > .emotion-44 {
                               </Button>
                             </div>
                           </Styled(div)>
-                        </FlexItem>
+                        </Box>
                       </FlexItem>
-                    </GridItem>
+                    </FlexItem>
                   </div>
                 </Styled(div)>
-              </FlexItem>
+              </Box>
             </Flex>
           </Component>
         </WithTheme(Component)>
-      </Grid>
+      </Flex>
       <Table
         data={
           Array [
@@ -46033,7 +46033,7 @@ button:focus > .emotion-44 {
                                                     role="columnheader"
                                                     textAlign="start"
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       aria-label="Fruits"
                                                       aria-sort="ascending"
                                                       className="emotion-39"
@@ -46062,7 +46062,7 @@ button:focus > .emotion-44 {
                                                           role="columnheader"
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="Fruits"
                                                             aria-sort="ascending"
                                                             className="emotion-35"
@@ -46107,17 +46107,17 @@ button:focus > .emotion-44 {
                                                                         className="emotion-34"
                                                                         role="columnheader"
                                                                       >
-                                                                        <withProps(Styled(TableSortableHeaderCell))
+                                                                        <withProps(Styled(TableHeaderCell))
                                                                           aria-label="Sort column in descending order"
                                                                           onClick={[Function]}
                                                                         >
-                                                                          <Styled(TableSortableHeaderCell)
+                                                                          <Styled(TableHeaderCell)
                                                                             aria-label="Sort column in descending order"
                                                                             element="button"
                                                                             onClick={[Function]}
                                                                             textAlign="start"
                                                                           >
-                                                                            <TableSortableHeaderCell
+                                                                            <TableHeaderCell
                                                                               aria-label="Sort column in descending order"
                                                                               className="emotion-31"
                                                                               element="button"
@@ -46140,7 +46140,7 @@ button:focus > .emotion-44 {
                                                                                   onClick={[Function]}
                                                                                   textAlign="start"
                                                                                 >
-                                                                                  <TableHeaderCell
+                                                                                  <WithTheme(Themed(TableCell))
                                                                                     aria-label="Sort column in descending order"
                                                                                     className="emotion-27"
                                                                                     element="button"
@@ -46232,22 +46232,22 @@ button:focus > .emotion-44 {
                                                                                         </ThemeProvider>
                                                                                       </ThemeProvider>
                                                                                     </Themed(TableCell)>
-                                                                                  </TableHeaderCell>
+                                                                                  </WithTheme(Themed(TableCell))>
                                                                                 </TableHeaderCell>
                                                                               </withProps(TableHeaderCell)>
-                                                                            </TableSortableHeaderCell>
-                                                                          </Styled(TableSortableHeaderCell)>
-                                                                        </withProps(Styled(TableSortableHeaderCell))>
+                                                                            </TableHeaderCell>
+                                                                          </Styled(TableHeaderCell)>
+                                                                        </withProps(Styled(TableHeaderCell))>
                                                                       </th>
                                                                     </TableCell>
                                                                   </TableCell>
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </TableSortableHeaderCell>
                                                 </withProps(TableSortableHeaderCell)>
                                               </TableSortableHeaderCell>
@@ -46318,7 +46318,7 @@ button:focus > .emotion-44 {
                                                     role="columnheader"
                                                     textAlign="start"
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       aria-label="Vegetables"
                                                       aria-sort="none"
                                                       className="emotion-39"
@@ -46347,7 +46347,7 @@ button:focus > .emotion-44 {
                                                           role="columnheader"
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="Vegetables"
                                                             aria-sort="none"
                                                             className="emotion-35"
@@ -46392,17 +46392,17 @@ button:focus > .emotion-44 {
                                                                         className="emotion-34"
                                                                         role="columnheader"
                                                                       >
-                                                                        <withProps(Styled(TableSortableHeaderCell))
+                                                                        <withProps(Styled(TableHeaderCell))
                                                                           aria-label="Sort column in ascending order"
                                                                           onClick={[Function]}
                                                                         >
-                                                                          <Styled(TableSortableHeaderCell)
+                                                                          <Styled(TableHeaderCell)
                                                                             aria-label="Sort column in ascending order"
                                                                             element="button"
                                                                             onClick={[Function]}
                                                                             textAlign="start"
                                                                           >
-                                                                            <TableSortableHeaderCell
+                                                                            <TableHeaderCell
                                                                               aria-label="Sort column in ascending order"
                                                                               className="emotion-31"
                                                                               element="button"
@@ -46425,7 +46425,7 @@ button:focus > .emotion-44 {
                                                                                   onClick={[Function]}
                                                                                   textAlign="start"
                                                                                 >
-                                                                                  <TableHeaderCell
+                                                                                  <WithTheme(Themed(TableCell))
                                                                                     aria-label="Sort column in ascending order"
                                                                                     className="emotion-27"
                                                                                     element="button"
@@ -46517,22 +46517,22 @@ button:focus > .emotion-44 {
                                                                                         </ThemeProvider>
                                                                                       </ThemeProvider>
                                                                                     </Themed(TableCell)>
-                                                                                  </TableHeaderCell>
+                                                                                  </WithTheme(Themed(TableCell))>
                                                                                 </TableHeaderCell>
                                                                               </withProps(TableHeaderCell)>
-                                                                            </TableSortableHeaderCell>
-                                                                          </Styled(TableSortableHeaderCell)>
-                                                                        </withProps(Styled(TableSortableHeaderCell))>
+                                                                            </TableHeaderCell>
+                                                                          </Styled(TableHeaderCell)>
+                                                                        </withProps(Styled(TableHeaderCell))>
                                                                       </th>
                                                                     </TableCell>
                                                                   </TableCell>
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </TableSortableHeaderCell>
                                                 </withProps(TableSortableHeaderCell)>
                                               </TableSortableHeaderCell>
@@ -46603,7 +46603,7 @@ button:focus > .emotion-44 {
                                                     role="columnheader"
                                                     textAlign="start"
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       aria-label="Grains"
                                                       aria-sort="none"
                                                       className="emotion-39"
@@ -46632,7 +46632,7 @@ button:focus > .emotion-44 {
                                                           role="columnheader"
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="Grains"
                                                             aria-sort="none"
                                                             className="emotion-35"
@@ -46677,17 +46677,17 @@ button:focus > .emotion-44 {
                                                                         className="emotion-34"
                                                                         role="columnheader"
                                                                       >
-                                                                        <withProps(Styled(TableSortableHeaderCell))
+                                                                        <withProps(Styled(TableHeaderCell))
                                                                           aria-label="Sort column in ascending order"
                                                                           onClick={[Function]}
                                                                         >
-                                                                          <Styled(TableSortableHeaderCell)
+                                                                          <Styled(TableHeaderCell)
                                                                             aria-label="Sort column in ascending order"
                                                                             element="button"
                                                                             onClick={[Function]}
                                                                             textAlign="start"
                                                                           >
-                                                                            <TableSortableHeaderCell
+                                                                            <TableHeaderCell
                                                                               aria-label="Sort column in ascending order"
                                                                               className="emotion-31"
                                                                               element="button"
@@ -46710,7 +46710,7 @@ button:focus > .emotion-44 {
                                                                                   onClick={[Function]}
                                                                                   textAlign="start"
                                                                                 >
-                                                                                  <TableHeaderCell
+                                                                                  <WithTheme(Themed(TableCell))
                                                                                     aria-label="Sort column in ascending order"
                                                                                     className="emotion-27"
                                                                                     element="button"
@@ -46802,22 +46802,22 @@ button:focus > .emotion-44 {
                                                                                         </ThemeProvider>
                                                                                       </ThemeProvider>
                                                                                     </Themed(TableCell)>
-                                                                                  </TableHeaderCell>
+                                                                                  </WithTheme(Themed(TableCell))>
                                                                                 </TableHeaderCell>
                                                                               </withProps(TableHeaderCell)>
-                                                                            </TableSortableHeaderCell>
-                                                                          </Styled(TableSortableHeaderCell)>
-                                                                        </withProps(Styled(TableSortableHeaderCell))>
+                                                                            </TableHeaderCell>
+                                                                          </Styled(TableHeaderCell)>
+                                                                        </withProps(Styled(TableHeaderCell))>
                                                                       </th>
                                                                     </TableCell>
                                                                   </TableCell>
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </TableSortableHeaderCell>
                                                 </withProps(TableSortableHeaderCell)>
                                               </TableSortableHeaderCell>
@@ -46888,7 +46888,7 @@ button:focus > .emotion-44 {
                                                     role="columnheader"
                                                     textAlign="start"
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       aria-label="Dairy"
                                                       aria-sort="none"
                                                       className="emotion-39"
@@ -46917,7 +46917,7 @@ button:focus > .emotion-44 {
                                                           role="columnheader"
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="Dairy"
                                                             aria-sort="none"
                                                             className="emotion-35"
@@ -46962,17 +46962,17 @@ button:focus > .emotion-44 {
                                                                         className="emotion-34"
                                                                         role="columnheader"
                                                                       >
-                                                                        <withProps(Styled(TableSortableHeaderCell))
+                                                                        <withProps(Styled(TableHeaderCell))
                                                                           aria-label="Sort column in ascending order"
                                                                           onClick={[Function]}
                                                                         >
-                                                                          <Styled(TableSortableHeaderCell)
+                                                                          <Styled(TableHeaderCell)
                                                                             aria-label="Sort column in ascending order"
                                                                             element="button"
                                                                             onClick={[Function]}
                                                                             textAlign="start"
                                                                           >
-                                                                            <TableSortableHeaderCell
+                                                                            <TableHeaderCell
                                                                               aria-label="Sort column in ascending order"
                                                                               className="emotion-31"
                                                                               element="button"
@@ -46995,7 +46995,7 @@ button:focus > .emotion-44 {
                                                                                   onClick={[Function]}
                                                                                   textAlign="start"
                                                                                 >
-                                                                                  <TableHeaderCell
+                                                                                  <WithTheme(Themed(TableCell))
                                                                                     aria-label="Sort column in ascending order"
                                                                                     className="emotion-27"
                                                                                     element="button"
@@ -47087,22 +47087,22 @@ button:focus > .emotion-44 {
                                                                                         </ThemeProvider>
                                                                                       </ThemeProvider>
                                                                                     </Themed(TableCell)>
-                                                                                  </TableHeaderCell>
+                                                                                  </WithTheme(Themed(TableCell))>
                                                                                 </TableHeaderCell>
                                                                               </withProps(TableHeaderCell)>
-                                                                            </TableSortableHeaderCell>
-                                                                          </Styled(TableSortableHeaderCell)>
-                                                                        </withProps(Styled(TableSortableHeaderCell))>
+                                                                            </TableHeaderCell>
+                                                                          </Styled(TableHeaderCell)>
+                                                                        </withProps(Styled(TableHeaderCell))>
                                                                       </th>
                                                                     </TableCell>
                                                                   </TableCell>
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </TableSortableHeaderCell>
                                                 </withProps(TableSortableHeaderCell)>
                                               </TableSortableHeaderCell>
@@ -47173,7 +47173,7 @@ button:focus > .emotion-44 {
                                                     role="columnheader"
                                                     textAlign="start"
                                                   >
-                                                    <TableSortableHeaderCell
+                                                    <TableHeaderCell
                                                       aria-label="Protein"
                                                       aria-sort="none"
                                                       className="emotion-39"
@@ -47202,7 +47202,7 @@ button:focus > .emotion-44 {
                                                           role="columnheader"
                                                           textAlign="start"
                                                         >
-                                                          <TableHeaderCell
+                                                          <WithTheme(Themed(TableCell))
                                                             aria-label="Protein"
                                                             aria-sort="none"
                                                             className="emotion-35"
@@ -47247,17 +47247,17 @@ button:focus > .emotion-44 {
                                                                         className="emotion-34"
                                                                         role="columnheader"
                                                                       >
-                                                                        <withProps(Styled(TableSortableHeaderCell))
+                                                                        <withProps(Styled(TableHeaderCell))
                                                                           aria-label="Sort column in ascending order"
                                                                           onClick={[Function]}
                                                                         >
-                                                                          <Styled(TableSortableHeaderCell)
+                                                                          <Styled(TableHeaderCell)
                                                                             aria-label="Sort column in ascending order"
                                                                             element="button"
                                                                             onClick={[Function]}
                                                                             textAlign="start"
                                                                           >
-                                                                            <TableSortableHeaderCell
+                                                                            <TableHeaderCell
                                                                               aria-label="Sort column in ascending order"
                                                                               className="emotion-31"
                                                                               element="button"
@@ -47280,7 +47280,7 @@ button:focus > .emotion-44 {
                                                                                   onClick={[Function]}
                                                                                   textAlign="start"
                                                                                 >
-                                                                                  <TableHeaderCell
+                                                                                  <WithTheme(Themed(TableCell))
                                                                                     aria-label="Sort column in ascending order"
                                                                                     className="emotion-27"
                                                                                     element="button"
@@ -47372,22 +47372,22 @@ button:focus > .emotion-44 {
                                                                                         </ThemeProvider>
                                                                                       </ThemeProvider>
                                                                                     </Themed(TableCell)>
-                                                                                  </TableHeaderCell>
+                                                                                  </WithTheme(Themed(TableCell))>
                                                                                 </TableHeaderCell>
                                                                               </withProps(TableHeaderCell)>
-                                                                            </TableSortableHeaderCell>
-                                                                          </Styled(TableSortableHeaderCell)>
-                                                                        </withProps(Styled(TableSortableHeaderCell))>
+                                                                            </TableHeaderCell>
+                                                                          </Styled(TableHeaderCell)>
+                                                                        </withProps(Styled(TableHeaderCell))>
                                                                       </th>
                                                                     </TableCell>
                                                                   </TableCell>
                                                                 </ThemeProvider>
                                                               </ThemeProvider>
                                                             </Themed(TableCell)>
-                                                          </TableHeaderCell>
+                                                          </WithTheme(Themed(TableCell))>
                                                         </TableHeaderCell>
                                                       </withProps(TableHeaderCell)>
-                                                    </TableSortableHeaderCell>
+                                                    </TableHeaderCell>
                                                   </TableSortableHeaderCell>
                                                 </withProps(TableSortableHeaderCell)>
                                               </TableSortableHeaderCell>
@@ -49664,7 +49664,7 @@ button:focus > .emotion-23 {
                                                         role="columnheader"
                                                         textAlign="start"
                                                       >
-                                                        <TableSortableHeaderCell
+                                                        <TableHeaderCell
                                                           aria-label="Mineral"
                                                           aria-sort="ascending"
                                                           className="emotion-18"
@@ -49693,7 +49693,7 @@ button:focus > .emotion-23 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableHeaderCell
+                                                              <WithTheme(Themed(TableCell))
                                                                 aria-label="Mineral"
                                                                 aria-sort="ascending"
                                                                 className="emotion-14"
@@ -49738,17 +49738,17 @@ button:focus > .emotion-23 {
                                                                             className="emotion-13"
                                                                             role="columnheader"
                                                                           >
-                                                                            <withProps(Styled(TableSortableHeaderCell))
+                                                                            <withProps(Styled(TableHeaderCell))
                                                                               aria-label="Sort column in descending order"
                                                                               onClick={[Function]}
                                                                             >
-                                                                              <Styled(TableSortableHeaderCell)
+                                                                              <Styled(TableHeaderCell)
                                                                                 aria-label="Sort column in descending order"
                                                                                 element="button"
                                                                                 onClick={[Function]}
                                                                                 textAlign="start"
                                                                               >
-                                                                                <TableSortableHeaderCell
+                                                                                <TableHeaderCell
                                                                                   aria-label="Sort column in descending order"
                                                                                   className="emotion-10"
                                                                                   element="button"
@@ -49771,7 +49771,7 @@ button:focus > .emotion-23 {
                                                                                       onClick={[Function]}
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableHeaderCell
+                                                                                      <WithTheme(Themed(TableCell))
                                                                                         aria-label="Sort column in descending order"
                                                                                         className="emotion-6"
                                                                                         element="button"
@@ -49863,22 +49863,22 @@ button:focus > .emotion-23 {
                                                                                             </ThemeProvider>
                                                                                           </ThemeProvider>
                                                                                         </Themed(TableCell)>
-                                                                                      </TableHeaderCell>
+                                                                                      </WithTheme(Themed(TableCell))>
                                                                                     </TableHeaderCell>
                                                                                   </withProps(TableHeaderCell)>
-                                                                                </TableSortableHeaderCell>
-                                                                              </Styled(TableSortableHeaderCell)>
-                                                                            </withProps(Styled(TableSortableHeaderCell))>
+                                                                                </TableHeaderCell>
+                                                                              </Styled(TableHeaderCell)>
+                                                                            </withProps(Styled(TableHeaderCell))>
                                                                           </th>
                                                                         </TableCell>
                                                                       </TableCell>
                                                                     </ThemeProvider>
                                                                   </ThemeProvider>
                                                                 </Themed(TableCell)>
-                                                              </TableHeaderCell>
+                                                              </WithTheme(Themed(TableCell))>
                                                             </TableHeaderCell>
                                                           </withProps(TableHeaderCell)>
-                                                        </TableSortableHeaderCell>
+                                                        </TableHeaderCell>
                                                       </TableSortableHeaderCell>
                                                     </withProps(TableSortableHeaderCell)>
                                                   </TableSortableHeaderCell>
@@ -49942,7 +49942,7 @@ button:focus > .emotion-23 {
                                                         role="columnheader"
                                                         textAlign="start"
                                                       >
-                                                        <TableSortableHeaderCell
+                                                        <TableHeaderCell
                                                           aria-label="Color"
                                                           aria-sort="none"
                                                           className="emotion-18"
@@ -49971,7 +49971,7 @@ button:focus > .emotion-23 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableHeaderCell
+                                                              <WithTheme(Themed(TableCell))
                                                                 aria-label="Color"
                                                                 aria-sort="none"
                                                                 className="emotion-14"
@@ -50016,17 +50016,17 @@ button:focus > .emotion-23 {
                                                                             className="emotion-13"
                                                                             role="columnheader"
                                                                           >
-                                                                            <withProps(Styled(TableSortableHeaderCell))
+                                                                            <withProps(Styled(TableHeaderCell))
                                                                               aria-label="Sort column in ascending order"
                                                                               onClick={[Function]}
                                                                             >
-                                                                              <Styled(TableSortableHeaderCell)
+                                                                              <Styled(TableHeaderCell)
                                                                                 aria-label="Sort column in ascending order"
                                                                                 element="button"
                                                                                 onClick={[Function]}
                                                                                 textAlign="start"
                                                                               >
-                                                                                <TableSortableHeaderCell
+                                                                                <TableHeaderCell
                                                                                   aria-label="Sort column in ascending order"
                                                                                   className="emotion-10"
                                                                                   element="button"
@@ -50049,7 +50049,7 @@ button:focus > .emotion-23 {
                                                                                       onClick={[Function]}
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableHeaderCell
+                                                                                      <WithTheme(Themed(TableCell))
                                                                                         aria-label="Sort column in ascending order"
                                                                                         className="emotion-6"
                                                                                         element="button"
@@ -50141,22 +50141,22 @@ button:focus > .emotion-23 {
                                                                                             </ThemeProvider>
                                                                                           </ThemeProvider>
                                                                                         </Themed(TableCell)>
-                                                                                      </TableHeaderCell>
+                                                                                      </WithTheme(Themed(TableCell))>
                                                                                     </TableHeaderCell>
                                                                                   </withProps(TableHeaderCell)>
-                                                                                </TableSortableHeaderCell>
-                                                                              </Styled(TableSortableHeaderCell)>
-                                                                            </withProps(Styled(TableSortableHeaderCell))>
+                                                                                </TableHeaderCell>
+                                                                              </Styled(TableHeaderCell)>
+                                                                            </withProps(Styled(TableHeaderCell))>
                                                                           </th>
                                                                         </TableCell>
                                                                       </TableCell>
                                                                     </ThemeProvider>
                                                                   </ThemeProvider>
                                                                 </Themed(TableCell)>
-                                                              </TableHeaderCell>
+                                                              </WithTheme(Themed(TableCell))>
                                                             </TableHeaderCell>
                                                           </withProps(TableHeaderCell)>
-                                                        </TableSortableHeaderCell>
+                                                        </TableHeaderCell>
                                                       </TableSortableHeaderCell>
                                                     </withProps(TableSortableHeaderCell)>
                                                   </TableSortableHeaderCell>
@@ -50220,7 +50220,7 @@ button:focus > .emotion-23 {
                                                         role="columnheader"
                                                         textAlign="start"
                                                       >
-                                                        <TableSortableHeaderCell
+                                                        <TableHeaderCell
                                                           aria-label="Luster"
                                                           aria-sort="none"
                                                           className="emotion-18"
@@ -50249,7 +50249,7 @@ button:focus > .emotion-23 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableHeaderCell
+                                                              <WithTheme(Themed(TableCell))
                                                                 aria-label="Luster"
                                                                 aria-sort="none"
                                                                 className="emotion-14"
@@ -50294,17 +50294,17 @@ button:focus > .emotion-23 {
                                                                             className="emotion-13"
                                                                             role="columnheader"
                                                                           >
-                                                                            <withProps(Styled(TableSortableHeaderCell))
+                                                                            <withProps(Styled(TableHeaderCell))
                                                                               aria-label="Sort column in ascending order"
                                                                               onClick={[Function]}
                                                                             >
-                                                                              <Styled(TableSortableHeaderCell)
+                                                                              <Styled(TableHeaderCell)
                                                                                 aria-label="Sort column in ascending order"
                                                                                 element="button"
                                                                                 onClick={[Function]}
                                                                                 textAlign="start"
                                                                               >
-                                                                                <TableSortableHeaderCell
+                                                                                <TableHeaderCell
                                                                                   aria-label="Sort column in ascending order"
                                                                                   className="emotion-10"
                                                                                   element="button"
@@ -50327,7 +50327,7 @@ button:focus > .emotion-23 {
                                                                                       onClick={[Function]}
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableHeaderCell
+                                                                                      <WithTheme(Themed(TableCell))
                                                                                         aria-label="Sort column in ascending order"
                                                                                         className="emotion-6"
                                                                                         element="button"
@@ -50419,22 +50419,22 @@ button:focus > .emotion-23 {
                                                                                             </ThemeProvider>
                                                                                           </ThemeProvider>
                                                                                         </Themed(TableCell)>
-                                                                                      </TableHeaderCell>
+                                                                                      </WithTheme(Themed(TableCell))>
                                                                                     </TableHeaderCell>
                                                                                   </withProps(TableHeaderCell)>
-                                                                                </TableSortableHeaderCell>
-                                                                              </Styled(TableSortableHeaderCell)>
-                                                                            </withProps(Styled(TableSortableHeaderCell))>
+                                                                                </TableHeaderCell>
+                                                                              </Styled(TableHeaderCell)>
+                                                                            </withProps(Styled(TableHeaderCell))>
                                                                           </th>
                                                                         </TableCell>
                                                                       </TableCell>
                                                                     </ThemeProvider>
                                                                   </ThemeProvider>
                                                                 </Themed(TableCell)>
-                                                              </TableHeaderCell>
+                                                              </WithTheme(Themed(TableCell))>
                                                             </TableHeaderCell>
                                                           </withProps(TableHeaderCell)>
-                                                        </TableSortableHeaderCell>
+                                                        </TableHeaderCell>
                                                       </TableSortableHeaderCell>
                                                     </withProps(TableSortableHeaderCell)>
                                                   </TableSortableHeaderCell>
@@ -50498,7 +50498,7 @@ button:focus > .emotion-23 {
                                                         role="columnheader"
                                                         textAlign="start"
                                                       >
-                                                        <TableSortableHeaderCell
+                                                        <TableHeaderCell
                                                           aria-label="Crystal System"
                                                           aria-sort="none"
                                                           className="emotion-18"
@@ -50527,7 +50527,7 @@ button:focus > .emotion-23 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableHeaderCell
+                                                              <WithTheme(Themed(TableCell))
                                                                 aria-label="Crystal System"
                                                                 aria-sort="none"
                                                                 className="emotion-14"
@@ -50572,17 +50572,17 @@ button:focus > .emotion-23 {
                                                                             className="emotion-13"
                                                                             role="columnheader"
                                                                           >
-                                                                            <withProps(Styled(TableSortableHeaderCell))
+                                                                            <withProps(Styled(TableHeaderCell))
                                                                               aria-label="Sort column in ascending order"
                                                                               onClick={[Function]}
                                                                             >
-                                                                              <Styled(TableSortableHeaderCell)
+                                                                              <Styled(TableHeaderCell)
                                                                                 aria-label="Sort column in ascending order"
                                                                                 element="button"
                                                                                 onClick={[Function]}
                                                                                 textAlign="start"
                                                                               >
-                                                                                <TableSortableHeaderCell
+                                                                                <TableHeaderCell
                                                                                   aria-label="Sort column in ascending order"
                                                                                   className="emotion-10"
                                                                                   element="button"
@@ -50605,7 +50605,7 @@ button:focus > .emotion-23 {
                                                                                       onClick={[Function]}
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableHeaderCell
+                                                                                      <WithTheme(Themed(TableCell))
                                                                                         aria-label="Sort column in ascending order"
                                                                                         className="emotion-6"
                                                                                         element="button"
@@ -50697,22 +50697,22 @@ button:focus > .emotion-23 {
                                                                                             </ThemeProvider>
                                                                                           </ThemeProvider>
                                                                                         </Themed(TableCell)>
-                                                                                      </TableHeaderCell>
+                                                                                      </WithTheme(Themed(TableCell))>
                                                                                     </TableHeaderCell>
                                                                                   </withProps(TableHeaderCell)>
-                                                                                </TableSortableHeaderCell>
-                                                                              </Styled(TableSortableHeaderCell)>
-                                                                            </withProps(Styled(TableSortableHeaderCell))>
+                                                                                </TableHeaderCell>
+                                                                              </Styled(TableHeaderCell)>
+                                                                            </withProps(Styled(TableHeaderCell))>
                                                                           </th>
                                                                         </TableCell>
                                                                       </TableCell>
                                                                     </ThemeProvider>
                                                                   </ThemeProvider>
                                                                 </Themed(TableCell)>
-                                                              </TableHeaderCell>
+                                                              </WithTheme(Themed(TableCell))>
                                                             </TableHeaderCell>
                                                           </withProps(TableHeaderCell)>
-                                                        </TableSortableHeaderCell>
+                                                        </TableHeaderCell>
                                                       </TableSortableHeaderCell>
                                                     </withProps(TableSortableHeaderCell)>
                                                   </TableSortableHeaderCell>
@@ -50776,7 +50776,7 @@ button:focus > .emotion-23 {
                                                         role="columnheader"
                                                         textAlign="start"
                                                       >
-                                                        <TableSortableHeaderCell
+                                                        <TableHeaderCell
                                                           aria-label="Crystal Habit"
                                                           aria-sort="none"
                                                           className="emotion-18"
@@ -50805,7 +50805,7 @@ button:focus > .emotion-23 {
                                                               role="columnheader"
                                                               textAlign="start"
                                                             >
-                                                              <TableHeaderCell
+                                                              <WithTheme(Themed(TableCell))
                                                                 aria-label="Crystal Habit"
                                                                 aria-sort="none"
                                                                 className="emotion-14"
@@ -50850,17 +50850,17 @@ button:focus > .emotion-23 {
                                                                             className="emotion-13"
                                                                             role="columnheader"
                                                                           >
-                                                                            <withProps(Styled(TableSortableHeaderCell))
+                                                                            <withProps(Styled(TableHeaderCell))
                                                                               aria-label="Sort column in ascending order"
                                                                               onClick={[Function]}
                                                                             >
-                                                                              <Styled(TableSortableHeaderCell)
+                                                                              <Styled(TableHeaderCell)
                                                                                 aria-label="Sort column in ascending order"
                                                                                 element="button"
                                                                                 onClick={[Function]}
                                                                                 textAlign="start"
                                                                               >
-                                                                                <TableSortableHeaderCell
+                                                                                <TableHeaderCell
                                                                                   aria-label="Sort column in ascending order"
                                                                                   className="emotion-10"
                                                                                   element="button"
@@ -50883,7 +50883,7 @@ button:focus > .emotion-23 {
                                                                                       onClick={[Function]}
                                                                                       textAlign="start"
                                                                                     >
-                                                                                      <TableHeaderCell
+                                                                                      <WithTheme(Themed(TableCell))
                                                                                         aria-label="Sort column in ascending order"
                                                                                         className="emotion-6"
                                                                                         element="button"
@@ -50975,22 +50975,22 @@ button:focus > .emotion-23 {
                                                                                             </ThemeProvider>
                                                                                           </ThemeProvider>
                                                                                         </Themed(TableCell)>
-                                                                                      </TableHeaderCell>
+                                                                                      </WithTheme(Themed(TableCell))>
                                                                                     </TableHeaderCell>
                                                                                   </withProps(TableHeaderCell)>
-                                                                                </TableSortableHeaderCell>
-                                                                              </Styled(TableSortableHeaderCell)>
-                                                                            </withProps(Styled(TableSortableHeaderCell))>
+                                                                                </TableHeaderCell>
+                                                                              </Styled(TableHeaderCell)>
+                                                                            </withProps(Styled(TableHeaderCell))>
                                                                           </th>
                                                                         </TableCell>
                                                                       </TableCell>
                                                                     </ThemeProvider>
                                                                   </ThemeProvider>
                                                                 </Themed(TableCell)>
-                                                              </TableHeaderCell>
+                                                              </WithTheme(Themed(TableCell))>
                                                             </TableHeaderCell>
                                                           </withProps(TableHeaderCell)>
-                                                        </TableSortableHeaderCell>
+                                                        </TableHeaderCell>
                                                       </TableSortableHeaderCell>
                                                     </withProps(TableSortableHeaderCell)>
                                                   </TableSortableHeaderCell>
@@ -51598,7 +51598,7 @@ button:focus > .emotion-23 {
                   showPageNumbers={true}
                   visibleRange={5}
                 >
-                  <Grid
+                  <Flex
                     alignItems="stretch"
                     aria-label="Pagination"
                     className="emotion-154"
@@ -51646,7 +51646,7 @@ button:focus > .emotion-23 {
                           showPageNumbers={true}
                           visibleRange={5}
                         >
-                          <FlexItem
+                          <Box
                             alignItems="stretch"
                             aria-label="Pagination"
                             className="emotion-152"
@@ -51674,7 +51674,7 @@ button:focus > .emotion-23 {
                                 aria-label="Pagination"
                                 className="emotion-151"
                               >
-                                <GridItem
+                                <FlexItem
                                   grow={0}
                                   key=".1"
                                   shrink={1}
@@ -51684,7 +51684,7 @@ button:focus > .emotion-23 {
                                     grow={0}
                                     shrink={1}
                                   >
-                                    <FlexItem
+                                    <Box
                                       className="emotion-149"
                                       element="div"
                                       grow={0}
@@ -51734,7 +51734,7 @@ button:focus > .emotion-23 {
                                               totalPages={5}
                                               visibleRange={5}
                                             >
-                                              <GridItem
+                                              <FlexItem
                                                 className="emotion-146"
                                                 currentPage={1}
                                                 grow={0}
@@ -51773,7 +51773,7 @@ button:focus > .emotion-23 {
                                                   totalPages={5}
                                                   visibleRange={5}
                                                 >
-                                                  <FlexItem
+                                                  <Box
                                                     className="emotion-144"
                                                     currentPage={1}
                                                     element="div"
@@ -52234,23 +52234,23 @@ button:focus > .emotion-23 {
                                                         </IncrementButton>
                                                       </div>
                                                     </Styled(div)>
-                                                  </FlexItem>
+                                                  </Box>
                                                 </FlexItem>
-                                              </GridItem>
+                                              </FlexItem>
                                             </Styled(FlexItem)>
                                           </Pages>
                                         </div>
                                       </Styled(div)>
-                                    </FlexItem>
+                                    </Box>
                                   </FlexItem>
-                                </GridItem>
+                                </FlexItem>
                               </nav>
                             </Styled(nav)>
-                          </FlexItem>
+                          </Box>
                         </Flex>
                       </Component>
                     </WithTheme(Component)>
-                  </Grid>
+                  </Flex>
                 </Styled(Flex)>
               </withProps(Styled(Flex))>
             </Pagination>
@@ -52672,7 +52672,7 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                   <tr
                                     className="emotion-27"
                                   >
-                                    <TableSortableHeaderCell
+                                    <TableHeaderCell
                                       element="th"
                                       key="Fruits"
                                       label="Fruits"
@@ -52725,7 +52725,7 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                           striped={true}
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Fruits"
                                             className="emotion-3"
                                             element="th"
@@ -52764,11 +52764,11 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Vegetables"
                                       label="Vegetables"
@@ -52821,7 +52821,7 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                           striped={true}
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Vegetables"
                                             className="emotion-3"
                                             element="th"
@@ -52860,11 +52860,11 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Grains"
                                       label="Grains"
@@ -52917,7 +52917,7 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                           striped={true}
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Grains"
                                             className="emotion-3"
                                             element="th"
@@ -52956,11 +52956,11 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Dairy"
                                       label="Dairy"
@@ -53013,7 +53013,7 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                           striped={true}
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Dairy"
                                             className="emotion-3"
                                             element="th"
@@ -53052,11 +53052,11 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
-                                    <TableSortableHeaderCell
+                                    </TableHeaderCell>
+                                    <TableHeaderCell
                                       element="th"
                                       key="Protein"
                                       label="Protein"
@@ -53109,7 +53109,7 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                           striped={true}
                                           textAlign="start"
                                         >
-                                          <TableHeaderCell
+                                          <WithTheme(Themed(TableCell))
                                             aria-label="Protein"
                                             className="emotion-3"
                                             element="th"
@@ -53148,10 +53148,10 @@ exports[`Table demo examples Snapshots: striped 1`] = `
                                                 </ThemeProvider>
                                               </ThemeProvider>
                                             </Themed(TableCell)>
-                                          </TableHeaderCell>
+                                          </WithTheme(Themed(TableCell))>
                                         </TableHeaderCell>
                                       </withProps(TableHeaderCell)>
-                                    </TableSortableHeaderCell>
+                                    </TableHeaderCell>
                                   </tr>
                                 </TableRow>
                               </TableRow>
@@ -54324,7 +54324,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
       justifyContent="start"
       wrap={true}
     >
-      <Grid
+      <Flex
         alignItems="end"
         breakpoints={
           Array [
@@ -54381,7 +54381,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
               justifyContent="start"
               wrap={true}
             >
-              <FlexItem
+              <Box
                 alignItems="end"
                 breakpoints={
                   Array [
@@ -54483,7 +54483,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                             ]
                           }
                         >
-                          <GridItem
+                          <FlexItem
                             breakpoints={
                               Array [
                                 "57em",
@@ -54534,7 +54534,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                 ]
                               }
                             >
-                              <FlexItem
+                              <Box
                                 breakpoints={
                                   Array [
                                     "57em",
@@ -54846,7 +54846,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                       <tr
                                                                         className="emotion-27"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Fruits"
                                                                           label="Fruits"
@@ -54897,7 +54897,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Fruits"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -54935,11 +54935,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Vegetables"
                                                                           label="Vegetables"
@@ -54990,7 +54990,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Vegetables"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -55028,11 +55028,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Grains"
                                                                           label="Grains"
@@ -55083,7 +55083,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Grains"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -55121,11 +55121,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Dairy"
                                                                           label="Dairy"
@@ -55176,7 +55176,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Dairy"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -55214,11 +55214,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Protein"
                                                                           label="Protein"
@@ -55269,7 +55269,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Protein"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -55307,10 +55307,10 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
+                                                                        </TableHeaderCell>
                                                                       </tr>
                                                                     </TableRow>
                                                                   </TableRow>
@@ -56024,9 +56024,9 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                     </Table>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </FlexItem>
-                          </GridItem>
+                          </FlexItem>
                         </GridItem>
                       </withProps(GridItem)>
                     </GridItem>
@@ -56078,7 +56078,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                             ]
                           }
                         >
-                          <GridItem
+                          <FlexItem
                             breakpoints={
                               Array [
                                 "57em",
@@ -56115,7 +56115,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                 ]
                               }
                             >
-                              <FlexItem
+                              <Box
                                 breakpoints={
                                   Array [
                                     "57em",
@@ -56419,7 +56419,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                       <tr
                                                                         className="emotion-27"
                                                                       >
-                                                                        <TableSortableHeaderCell
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Fruits"
                                                                           label="Fruits"
@@ -56470,7 +56470,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Fruits"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -56508,11 +56508,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Vegetables"
                                                                           label="Vegetables"
@@ -56563,7 +56563,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Vegetables"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -56601,11 +56601,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Grains"
                                                                           label="Grains"
@@ -56656,7 +56656,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Grains"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -56694,11 +56694,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Dairy"
                                                                           label="Dairy"
@@ -56749,7 +56749,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Dairy"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -56787,11 +56787,11 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
-                                                                        <TableSortableHeaderCell
+                                                                        </TableHeaderCell>
+                                                                        <TableHeaderCell
                                                                           element="th"
                                                                           key="Protein"
                                                                           label="Protein"
@@ -56842,7 +56842,7 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                               }
                                                                               textAlign="start"
                                                                             >
-                                                                              <TableHeaderCell
+                                                                              <WithTheme(Themed(TableCell))
                                                                                 aria-label="Protein"
                                                                                 className="emotion-3"
                                                                                 element="th"
@@ -56880,10 +56880,10 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                                                                     </ThemeProvider>
                                                                                   </ThemeProvider>
                                                                                 </Themed(TableCell)>
-                                                                              </TableHeaderCell>
+                                                                              </WithTheme(Themed(TableCell))>
                                                                             </TableHeaderCell>
                                                                           </withProps(TableHeaderCell)>
-                                                                        </TableSortableHeaderCell>
+                                                                        </TableHeaderCell>
                                                                       </tr>
                                                                     </TableRow>
                                                                   </TableRow>
@@ -57597,19 +57597,19 @@ exports[`Table demo examples Snapshots: title 1`] = `
                                     </Table>
                                   </div>
                                 </Styled(div)>
-                              </FlexItem>
+                              </Box>
                             </FlexItem>
-                          </GridItem>
+                          </FlexItem>
                         </GridItem>
                       </withProps(GridItem)>
                     </GridItem>
                   </div>
                 </Styled(div)>
-              </FlexItem>
+              </Box>
             </Flex>
           </Component>
         </WithTheme(Component)>
-      </Grid>
+      </Flex>
     </Grid>
   </withProps(Grid)>
 </Grid>

--- a/src/library/Tabs/Tab.js
+++ b/src/library/Tabs/Tab.js
@@ -7,6 +7,8 @@ import { tabPropTypes } from './propTypes';
 import type { TabProps } from './types';
 
 export default class Tab extends Component<TabProps> {
+  static displayName = 'Tab';
+
   static propTypes = tabPropTypes;
 
   render() {

--- a/src/library/Tabs/TabList.js
+++ b/src/library/Tabs/TabList.js
@@ -17,6 +17,8 @@ import { POSITION } from './constants';
 import type { TabListDefaultProps, TabListProps, TabListState } from './types';
 
 export default class TabList extends Component<TabListProps, TabListState> {
+  static displayName = 'TabList';
+
   static defaultProps: TabListDefaultProps = {
     position: POSITION.top
   };

--- a/src/library/Tabs/TabPanel.js
+++ b/src/library/Tabs/TabPanel.js
@@ -8,6 +8,8 @@ import {
 import type { TabPanelProps } from './types';
 
 export default class TabPanel extends Component<TabPanelProps> {
+  static displayName = 'TabPanel';
+
   render() {
     const { children, tabId, ...restProps } = this.props;
     const rootProps = {

--- a/src/library/Tabs/Tabs.js
+++ b/src/library/Tabs/Tabs.js
@@ -12,6 +12,8 @@ import { tabsPropTypes } from './propTypes';
 import type { TabsDefaultProps, TabsProps, TabsState } from './types';
 
 export class Tabs extends Component<TabsProps, TabsState> {
+  static displayName = 'Tabs';
+
   static defaultProps: TabsDefaultProps = {
     align: ALIGN.start,
     maxTabWidth: '8.5em',

--- a/src/library/Tabs/__tests__/__snapshots__/TabList.spec.js.snap
+++ b/src/library/Tabs/__tests__/__snapshots__/TabList.spec.js.snap
@@ -254,7 +254,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
           size="medium"
           tabIndex={-1}
         >
-          <ArrowButton
+          <WithTheme(Themed(Button))
             aria-hidden={true}
             className="emotion-3"
             iconStart={<IconChevronLeft />}
@@ -346,7 +346,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(Button)>
-          </ArrowButton>
+          </WithTheme(Themed(Button))>
         </ArrowButton>
       </TabListIncrementButton>
       <withProps(Inner)
@@ -360,7 +360,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
           scrollX={true}
           tabIndex={null}
         >
-          <Inner
+          <WithTheme(Themed(OverflowContainerWithShadows))
             className="emotion-14"
             hideScrollbars={true}
             position="top"
@@ -401,7 +401,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
                           scrollX={true}
                           tabIndex={0}
                         >
-                          <Scroller
+                          <WithTheme(Themed(OverflowContainer))
                             className="emotion-9"
                             containerRef={[Function]}
                             hideScrollbars={true}
@@ -466,7 +466,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(OverflowContainer)>
-                          </Scroller>
+                          </WithTheme(Themed(OverflowContainer))>
                         </Scroller>
                       </div>
                     </OverflowContainerWithShadows>
@@ -474,7 +474,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(OverflowContainerWithShadows)>
-          </Inner>
+          </WithTheme(Themed(OverflowContainerWithShadows))>
         </Inner>
       </withProps(Inner)>
       <TabListIncrementButton
@@ -490,7 +490,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
           size="medium"
           tabIndex={-1}
         >
-          <ArrowButton
+          <WithTheme(Themed(Button))
             aria-hidden={true}
             className="emotion-3"
             iconStart={<IconChevronRight />}
@@ -582,7 +582,7 @@ exports[`TabList applies shadow when scrollable 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(Button)>
-          </ArrowButton>
+          </WithTheme(Themed(Button))>
         </ArrowButton>
       </TabListIncrementButton>
       <EventListener

--- a/src/library/Tabs/__tests__/__snapshots__/Tabs.spec.js.snap
+++ b/src/library/Tabs/__tests__/__snapshots__/Tabs.spec.js.snap
@@ -1301,7 +1301,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-11-panel-0"
                                     aria-selected={true}
                                     className="emotion-4"
@@ -1429,7 +1429,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -1483,7 +1483,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-11-panel-1"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -1611,7 +1611,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -1665,7 +1665,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-11-panel-2"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -1793,7 +1793,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -2015,7 +2015,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-12-panel-0"
                                     aria-selected={true}
                                     className="emotion-4"
@@ -2143,7 +2143,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -2197,7 +2197,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-12-panel-1"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -2325,7 +2325,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -2379,7 +2379,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-12-panel-2"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -2507,7 +2507,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -2729,7 +2729,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-13-panel-0"
                                     aria-selected={true}
                                     className="emotion-4"
@@ -2857,7 +2857,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -2911,7 +2911,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-13-panel-1"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -3039,7 +3039,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -3093,7 +3093,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-13-panel-2"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -3221,7 +3221,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -3440,7 +3440,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-14-panel-0"
                                     aria-selected={true}
                                     className="emotion-103"
@@ -3564,7 +3564,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -3615,7 +3615,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-14-panel-1"
                                     aria-selected={false}
                                     className="emotion-111"
@@ -3739,7 +3739,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -3790,7 +3790,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-14-panel-2"
                                     aria-selected={false}
                                     className="emotion-111"
@@ -3914,7 +3914,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -4137,7 +4137,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-15-panel-0"
                                     aria-selected={true}
                                     className="emotion-136"
@@ -4265,7 +4265,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -4319,7 +4319,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-15-panel-1"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -4447,7 +4447,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -4501,7 +4501,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-15-panel-2"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -4629,7 +4629,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -4852,7 +4852,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-16-panel-0"
                                     aria-selected={true}
                                     className="emotion-136"
@@ -4980,7 +4980,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -5034,7 +5034,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-16-panel-1"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -5162,7 +5162,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -5216,7 +5216,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-16-panel-2"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -5344,7 +5344,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -5567,7 +5567,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-17-panel-0"
                                     aria-selected={true}
                                     className="emotion-136"
@@ -5695,7 +5695,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -5749,7 +5749,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-17-panel-1"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -5877,7 +5877,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -5931,7 +5931,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-17-panel-2"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -6059,7 +6059,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -6282,7 +6282,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-18-panel-0"
                                     aria-selected={true}
                                     className="emotion-136"
@@ -6410,7 +6410,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -6464,7 +6464,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-18-panel-1"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -6592,7 +6592,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -6646,7 +6646,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-18-panel-2"
                                     aria-selected={false}
                                     className="emotion-144"
@@ -6774,7 +6774,7 @@ exports[`Tabs demo examples Snapshots: alignment 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -7411,7 +7411,7 @@ exports[`Tabs demo examples Snapshots: basic 1`] = `
                           tabIndex={-1}
                           title="Malachite"
                         >
-                          <Tab
+                          <WithTheme(Themed(Button))
                             aria-controls="tabs-1-panel-0"
                             aria-selected={false}
                             className="emotion-4"
@@ -7539,7 +7539,7 @@ exports[`Tabs demo examples Snapshots: basic 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(Button)>
-                          </Tab>
+                          </WithTheme(Themed(Button))>
                         </Tab>
                       </withProps(Tab)>
                     </li>
@@ -7593,7 +7593,7 @@ exports[`Tabs demo examples Snapshots: basic 1`] = `
                           tabIndex={0}
                           title="Fluorite"
                         >
-                          <Tab
+                          <WithTheme(Themed(Button))
                             aria-controls="tabs-1-panel-1"
                             aria-selected={true}
                             className="emotion-12"
@@ -7721,7 +7721,7 @@ exports[`Tabs demo examples Snapshots: basic 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(Button)>
-                          </Tab>
+                          </WithTheme(Themed(Button))>
                         </Tab>
                       </withProps(Tab)>
                     </li>
@@ -7775,7 +7775,7 @@ exports[`Tabs demo examples Snapshots: basic 1`] = `
                           tabIndex={-1}
                           title="Magnetite"
                         >
-                          <Tab
+                          <WithTheme(Themed(Button))
                             aria-controls="tabs-1-panel-2"
                             aria-selected={false}
                             className="emotion-4"
@@ -7903,7 +7903,7 @@ exports[`Tabs demo examples Snapshots: basic 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(Button)>
-                          </Tab>
+                          </WithTheme(Themed(Button))>
                         </Tab>
                       </withProps(Tab)>
                     </li>
@@ -8689,7 +8689,7 @@ exports[`Tabs demo examples Snapshots: controlled 1`] = `
                                     tabIndex={0}
                                     title="Malachite"
                                   >
-                                    <Tab
+                                    <WithTheme(Themed(Button))
                                       aria-controls="tabs-33-panel-0"
                                       aria-selected={true}
                                       className="emotion-7"
@@ -8817,7 +8817,7 @@ exports[`Tabs demo examples Snapshots: controlled 1`] = `
                                           </ThemeProvider>
                                         </ThemeProvider>
                                       </Themed(Button)>
-                                    </Tab>
+                                    </WithTheme(Themed(Button))>
                                   </Tab>
                                 </withProps(Tab)>
                               </li>
@@ -8871,7 +8871,7 @@ exports[`Tabs demo examples Snapshots: controlled 1`] = `
                                     tabIndex={-1}
                                     title="Fluorite"
                                   >
-                                    <Tab
+                                    <WithTheme(Themed(Button))
                                       aria-controls="tabs-33-panel-1"
                                       aria-selected={false}
                                       className="emotion-15"
@@ -8999,7 +8999,7 @@ exports[`Tabs demo examples Snapshots: controlled 1`] = `
                                           </ThemeProvider>
                                         </ThemeProvider>
                                       </Themed(Button)>
-                                    </Tab>
+                                    </WithTheme(Themed(Button))>
                                   </Tab>
                                 </withProps(Tab)>
                               </li>
@@ -9053,7 +9053,7 @@ exports[`Tabs demo examples Snapshots: controlled 1`] = `
                                     tabIndex={-1}
                                     title="Magnetite"
                                   >
-                                    <Tab
+                                    <WithTheme(Themed(Button))
                                       aria-controls="tabs-33-panel-2"
                                       aria-selected={false}
                                       className="emotion-15"
@@ -9181,7 +9181,7 @@ exports[`Tabs demo examples Snapshots: controlled 1`] = `
                                           </ThemeProvider>
                                         </ThemeProvider>
                                       </Themed(Button)>
-                                    </Tab>
+                                    </WithTheme(Themed(Button))>
                                   </Tab>
                                 </withProps(Tab)>
                               </li>
@@ -9817,7 +9817,7 @@ exports[`Tabs demo examples Snapshots: max-tab-width 1`] = `
                           tabIndex={0}
                           title="Malachite Will Truncate"
                         >
-                          <Tab
+                          <WithTheme(Themed(Button))
                             aria-controls="tabs-27-panel-0"
                             aria-selected={true}
                             className="emotion-4"
@@ -9945,7 +9945,7 @@ exports[`Tabs demo examples Snapshots: max-tab-width 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(Button)>
-                          </Tab>
+                          </WithTheme(Themed(Button))>
                         </Tab>
                       </withProps(Tab)>
                     </li>
@@ -9999,7 +9999,7 @@ exports[`Tabs demo examples Snapshots: max-tab-width 1`] = `
                           tabIndex={-1}
                           title="Fluorite"
                         >
-                          <Tab
+                          <WithTheme(Themed(Button))
                             aria-controls="tabs-27-panel-1"
                             aria-selected={false}
                             className="emotion-12"
@@ -10127,7 +10127,7 @@ exports[`Tabs demo examples Snapshots: max-tab-width 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(Button)>
-                          </Tab>
+                          </WithTheme(Themed(Button))>
                         </Tab>
                       </withProps(Tab)>
                     </li>
@@ -10181,7 +10181,7 @@ exports[`Tabs demo examples Snapshots: max-tab-width 1`] = `
                           tabIndex={-1}
                           title="Magnetite"
                         >
-                          <Tab
+                          <WithTheme(Themed(Button))
                             aria-controls="tabs-27-panel-2"
                             aria-selected={false}
                             className="emotion-12"
@@ -10309,7 +10309,7 @@ exports[`Tabs demo examples Snapshots: max-tab-width 1`] = `
                                 </ThemeProvider>
                               </ThemeProvider>
                             </Themed(Button)>
-                          </Tab>
+                          </WithTheme(Themed(Button))>
                         </Tab>
                       </withProps(Tab)>
                     </li>
@@ -11314,7 +11314,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-0"
                                     aria-selected={true}
                                     className="emotion-4"
@@ -11442,7 +11442,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -11496,7 +11496,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-1"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -11624,7 +11624,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -11678,7 +11678,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-2"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -11806,7 +11806,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -11860,7 +11860,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-3"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -11988,7 +11988,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -12042,7 +12042,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-4"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -12170,7 +12170,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -12224,7 +12224,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-5"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -12352,7 +12352,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -12406,7 +12406,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-6"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -12534,7 +12534,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -12588,7 +12588,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-7"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -12716,7 +12716,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -12770,7 +12770,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-8"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -12898,7 +12898,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -12952,7 +12952,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-9"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -13080,7 +13080,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -13134,7 +13134,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-10"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -13262,7 +13262,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -13316,7 +13316,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-11"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -13444,7 +13444,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -13498,7 +13498,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-12"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -13626,7 +13626,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -13680,7 +13680,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-13"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -13808,7 +13808,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -13862,7 +13862,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-14"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -13990,7 +13990,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -14044,7 +14044,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-15"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -14172,7 +14172,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -14226,7 +14226,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-16"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -14354,7 +14354,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -14408,7 +14408,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-17"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -14536,7 +14536,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -14590,7 +14590,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-18"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -14718,7 +14718,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -14772,7 +14772,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-29-panel-19"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -14900,7 +14900,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -15122,7 +15122,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-0"
                                     aria-selected={true}
                                     className="emotion-173"
@@ -15250,7 +15250,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -15304,7 +15304,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-1"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -15432,7 +15432,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -15486,7 +15486,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-2"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -15614,7 +15614,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -15668,7 +15668,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-3"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -15796,7 +15796,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -15850,7 +15850,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-4"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -15978,7 +15978,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -16032,7 +16032,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-5"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -16160,7 +16160,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -16214,7 +16214,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-6"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -16342,7 +16342,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -16396,7 +16396,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-7"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -16524,7 +16524,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -16578,7 +16578,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-8"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -16706,7 +16706,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -16760,7 +16760,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-9"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -16888,7 +16888,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -16942,7 +16942,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-10"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -17070,7 +17070,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -17124,7 +17124,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-11"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -17252,7 +17252,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -17306,7 +17306,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-12"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -17434,7 +17434,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -17488,7 +17488,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-13"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -17616,7 +17616,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -17670,7 +17670,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-14"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -17798,7 +17798,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -17852,7 +17852,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-15"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -17980,7 +17980,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -18034,7 +18034,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-16"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -18162,7 +18162,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -18216,7 +18216,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-17"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -18344,7 +18344,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -18398,7 +18398,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-18"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -18526,7 +18526,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -18580,7 +18580,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-30-panel-19"
                                     aria-selected={false}
                                     className="emotion-181"
@@ -18708,7 +18708,7 @@ exports[`Tabs demo examples Snapshots: overflow 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -20200,7 +20200,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-3-panel-0"
                                     aria-selected={true}
                                     className="emotion-4"
@@ -20328,7 +20328,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -20382,7 +20382,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-3-panel-1"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -20510,7 +20510,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -20564,7 +20564,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-3-panel-2"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -20692,7 +20692,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -20914,7 +20914,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-4-panel-0"
                                     aria-selected={true}
                                     className="emotion-37"
@@ -21042,7 +21042,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -21096,7 +21096,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-4-panel-1"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -21224,7 +21224,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -21278,7 +21278,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-4-panel-2"
                                     aria-selected={false}
                                     className="emotion-12"
@@ -21406,7 +21406,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -21628,7 +21628,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-5-panel-0"
                                     aria-selected={true}
                                     className="emotion-70"
@@ -21756,7 +21756,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -21810,7 +21810,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-5-panel-1"
                                     aria-selected={false}
                                     className="emotion-78"
@@ -21938,7 +21938,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -21992,7 +21992,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-5-panel-2"
                                     aria-selected={false}
                                     className="emotion-78"
@@ -22120,7 +22120,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -22342,7 +22342,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={0}
                                   title="Malachite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-6-panel-0"
                                     aria-selected={true}
                                     className="emotion-103"
@@ -22470,7 +22470,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -22524,7 +22524,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Fluorite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-6-panel-1"
                                     aria-selected={false}
                                     className="emotion-111"
@@ -22652,7 +22652,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -22706,7 +22706,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                   tabIndex={-1}
                                   title="Magnetite"
                                 >
-                                  <Tab
+                                  <WithTheme(Themed(Button))
                                     aria-controls="tabs-6-panel-2"
                                     aria-selected={false}
                                     className="emotion-111"
@@ -22834,7 +22834,7 @@ exports[`Tabs demo examples Snapshots: position 1`] = `
                                         </ThemeProvider>
                                       </ThemeProvider>
                                     </Themed(Button)>
-                                  </Tab>
+                                  </WithTheme(Themed(Button))>
                                 </Tab>
                               </withProps(Tab)>
                             </li>
@@ -23848,7 +23848,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                         tabIndex={0}
                                         title="علامة التبويب 1"
                                       >
-                                        <Tab
+                                        <WithTheme(Themed(Button))
                                           aria-controls="tabs-35-panel-0"
                                           aria-selected={true}
                                           className="emotion-4"
@@ -23976,7 +23976,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                               </ThemeProvider>
                                             </ThemeProvider>
                                           </Themed(Button)>
-                                        </Tab>
+                                        </WithTheme(Themed(Button))>
                                       </Tab>
                                     </withProps(Tab)>
                                   </li>
@@ -24030,7 +24030,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                         tabIndex={-1}
                                         title="علامة التبويب 2"
                                       >
-                                        <Tab
+                                        <WithTheme(Themed(Button))
                                           aria-controls="tabs-35-panel-1"
                                           aria-selected={false}
                                           className="emotion-12"
@@ -24158,7 +24158,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                               </ThemeProvider>
                                             </ThemeProvider>
                                           </Themed(Button)>
-                                        </Tab>
+                                        </WithTheme(Themed(Button))>
                                       </Tab>
                                     </withProps(Tab)>
                                   </li>
@@ -24212,7 +24212,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                         tabIndex={-1}
                                         title="علامة التبويب 3"
                                       >
-                                        <Tab
+                                        <WithTheme(Themed(Button))
                                           aria-controls="tabs-35-panel-2"
                                           aria-selected={false}
                                           className="emotion-12"
@@ -24340,7 +24340,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                               </ThemeProvider>
                                             </ThemeProvider>
                                           </Themed(Button)>
-                                        </Tab>
+                                        </WithTheme(Themed(Button))>
                                       </Tab>
                                     </withProps(Tab)>
                                   </li>
@@ -24557,7 +24557,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                         tabIndex={0}
                                         title="علامة التبويب 1"
                                       >
-                                        <Tab
+                                        <WithTheme(Themed(Button))
                                           aria-controls="tabs-36-panel-0"
                                           aria-selected={true}
                                           className="emotion-37"
@@ -24685,7 +24685,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                               </ThemeProvider>
                                             </ThemeProvider>
                                           </Themed(Button)>
-                                        </Tab>
+                                        </WithTheme(Themed(Button))>
                                       </Tab>
                                     </withProps(Tab)>
                                   </li>
@@ -24739,7 +24739,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                         tabIndex={-1}
                                         title="علامة التبويب 2"
                                       >
-                                        <Tab
+                                        <WithTheme(Themed(Button))
                                           aria-controls="tabs-36-panel-1"
                                           aria-selected={false}
                                           className="emotion-45"
@@ -24867,7 +24867,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                               </ThemeProvider>
                                             </ThemeProvider>
                                           </Themed(Button)>
-                                        </Tab>
+                                        </WithTheme(Themed(Button))>
                                       </Tab>
                                     </withProps(Tab)>
                                   </li>
@@ -24921,7 +24921,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                         tabIndex={-1}
                                         title="علامة التبويب 3"
                                       >
-                                        <Tab
+                                        <WithTheme(Themed(Button))
                                           aria-controls="tabs-36-panel-2"
                                           aria-selected={false}
                                           className="emotion-45"
@@ -25049,7 +25049,7 @@ exports[`Tabs demo examples Snapshots: rtl 1`] = `
                                               </ThemeProvider>
                                             </ThemeProvider>
                                           </Themed(Button)>
-                                        </Tab>
+                                        </WithTheme(Themed(Button))>
                                       </Tab>
                                     </withProps(Tab)>
                                   </li>

--- a/src/library/Tabs/styled.js
+++ b/src/library/Tabs/styled.js
@@ -295,6 +295,7 @@ export const TabListRoot = createStyledComponent(
   }
 );
 
+// eslint-disable-next-line react/display-name
 export const TabListIncrementButton = ({
   icon,
   ...restProps

--- a/src/library/Text/Text.js
+++ b/src/library/Text/Text.js
@@ -8,6 +8,8 @@ import { textPropTypes } from './propTypes';
 import type { TextDefaultProps, TextProps } from './types';
 
 export default class Text extends Component<TextProps> {
+  static displayName = 'Text';
+
   static defaultProps: TextDefaultProps = {
     appearance: APPEARANCE.p,
     element: 'p'

--- a/src/library/Text/TextProvider.js
+++ b/src/library/Text/TextProvider.js
@@ -8,6 +8,8 @@ import { APPEARANCE } from './constants';
 import type { TextProviderDefaultProps, TextProviderProps } from './types';
 
 export default class TextProvider extends Component<TextProviderProps> {
+  static displayName = 'TextProvider';
+
   static defaultProps: TextProviderDefaultProps = {
     appearance: APPEARANCE.p,
     element: 'p'

--- a/src/library/TextArea/TextArea.js
+++ b/src/library/TextArea/TextArea.js
@@ -9,6 +9,8 @@ import { textAreaPropTypes } from './propTypes';
 import type { TextAreaDefaultProps, TextAreaProps } from './types';
 
 export default class TextArea extends Component<TextAreaProps> {
+  static displayName = 'TextArea';
+
   static defaultProps: TextAreaDefaultProps = {
     size: SIZE.large
   };

--- a/src/library/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
+++ b/src/library/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
@@ -254,7 +254,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
           iconEnd={null}
           size="large"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -393,7 +393,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -423,7 +423,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
           iconEnd={null}
           size="large"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -544,7 +544,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -574,7 +574,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
           iconEnd={null}
           size="small"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -695,7 +695,7 @@ Duis vitae nisl dignissim, congue elit et, ornare dolor. Pellentesque eu dui pel
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
     </div>
@@ -873,7 +873,7 @@ exports[`TextArea demo examples Snapshots: controlled 1`] = `
         iconEnd={null}
         size="large"
       >
-        <TextArea
+        <WithTheme(Themed(FauxControl))
           className="emotion-3"
           control={[Function]}
           controlProps={
@@ -999,7 +999,7 @@ exports[`TextArea demo examples Snapshots: controlled 1`] = `
               </ThemeProvider>
             </ThemeProvider>
           </Themed(FauxControl)>
-        </TextArea>
+        </WithTheme(Themed(FauxControl))>
       </TextArea>
     </TextArea>
   </MyForm>
@@ -1165,7 +1165,7 @@ exports[`TextArea demo examples Snapshots: disabled 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextArea
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -1293,7 +1293,7 @@ exports[`TextArea demo examples Snapshots: disabled 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextArea>
+    </WithTheme(Themed(FauxControl))>
   </TextArea>
 </TextArea>
 `;
@@ -1564,7 +1564,7 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
                   iconEnd={null}
                   size="large"
                 >
-                  <TextArea
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-5"
                     control={[Function]}
                     controlProps={
@@ -1689,13 +1689,14 @@ exports[`TextArea demo examples Snapshots: form-field 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextArea>
+                  </WithTheme(Themed(FauxControl))>
                 </TextArea>
               </TextArea>
             </label>
             <Styled(div)
               caption="Please keep comments brief and descriptive"
               id="formField-1-caption"
+              isGroup={false}
             >
               <div
                 className="emotion-9"
@@ -2011,7 +2012,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
               iconEnd={null}
               size="large"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -2125,7 +2126,7 @@ exports[`TextArea demo examples Snapshots: input-ref 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <Button
@@ -2336,7 +2337,7 @@ exports[`TextArea demo examples Snapshots: invalid 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextArea
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -2452,7 +2453,7 @@ exports[`TextArea demo examples Snapshots: invalid 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextArea>
+    </WithTheme(Themed(FauxControl))>
   </TextArea>
 </TextArea>
 `;
@@ -3950,7 +3951,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="small"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4070,7 +4071,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextArea
@@ -4100,7 +4101,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="small"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4221,7 +4222,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextInput
@@ -4245,7 +4246,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="small"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-17"
                 control={[Function]}
                 controlProps={
@@ -4341,7 +4342,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -4405,7 +4406,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="medium"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4525,7 +4526,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextArea
@@ -4555,7 +4556,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="medium"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4676,7 +4677,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextInput
@@ -4700,7 +4701,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="medium"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-17"
                 control={[Function]}
                 controlProps={
@@ -4796,7 +4797,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -4860,7 +4861,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="large"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4980,7 +4981,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextArea
@@ -5010,7 +5011,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="large"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -5131,7 +5132,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextInput
@@ -5155,7 +5156,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-17"
                 control={[Function]}
                 controlProps={
@@ -5251,7 +5252,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -5315,7 +5316,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="jumbo"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -5435,7 +5436,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextArea
@@ -5465,7 +5466,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               iconEnd={null}
               size="jumbo"
             >
-              <TextArea
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -5586,7 +5587,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextArea>
+              </WithTheme(Themed(FauxControl))>
             </TextArea>
           </TextArea>
           <TextInput
@@ -5610,7 +5611,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
               }
               size="jumbo"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-17"
                 control={[Function]}
                 controlProps={
@@ -5706,7 +5707,7 @@ exports[`TextArea demo examples Snapshots: next-to-other-inputs 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -5915,7 +5916,7 @@ exports[`TextArea demo examples Snapshots: placeholder 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextArea
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -6035,7 +6036,7 @@ exports[`TextArea demo examples Snapshots: placeholder 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextArea>
+    </WithTheme(Themed(FauxControl))>
   </TextArea>
 </TextArea>
 `;
@@ -6208,7 +6209,7 @@ exports[`TextArea demo examples Snapshots: read-only 1`] = `
     readOnly={true}
     size="large"
   >
-    <TextArea
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -6336,7 +6337,7 @@ exports[`TextArea demo examples Snapshots: read-only 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextArea>
+    </WithTheme(Themed(FauxControl))>
   </TextArea>
 </TextArea>
 `;
@@ -6506,7 +6507,7 @@ exports[`TextArea demo examples Snapshots: required 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextArea
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -6624,7 +6625,7 @@ exports[`TextArea demo examples Snapshots: required 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextArea>
+    </WithTheme(Themed(FauxControl))>
   </TextArea>
 </TextArea>
 `;
@@ -7017,7 +7018,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="small"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7137,7 +7138,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -7166,7 +7167,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="medium"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7286,7 +7287,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -7315,7 +7316,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="large"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7435,7 +7436,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -7464,7 +7465,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
           iconEnd={null}
           size="jumbo"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7584,7 +7585,7 @@ exports[`TextArea demo examples Snapshots: rows 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
     </div>
@@ -7763,7 +7764,7 @@ exports[`TextArea demo examples Snapshots: rtl 1`] = `
           iconEnd={null}
           size="large"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -7883,7 +7884,7 @@ exports[`TextArea demo examples Snapshots: rtl 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
     </ThemeProvider>
@@ -8278,7 +8279,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="small"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -8398,7 +8399,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -8426,7 +8427,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="medium"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -8546,7 +8547,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -8574,7 +8575,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="large"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -8694,7 +8695,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -8722,7 +8723,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
           iconEnd={null}
           size="jumbo"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -8842,7 +8843,7 @@ exports[`TextArea demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
     </div>
@@ -9016,7 +9017,7 @@ exports[`TextArea demo examples Snapshots: uncontrolled 1`] = `
     iconEnd={null}
     size="large"
   >
-    <TextArea
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -9136,7 +9137,7 @@ exports[`TextArea demo examples Snapshots: uncontrolled 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextArea>
+    </WithTheme(Themed(FauxControl))>
   </TextArea>
 </TextArea>
 `;
@@ -9574,7 +9575,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
           size="large"
           variant="success"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -9701,7 +9702,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -9731,7 +9732,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
           size="large"
           variant="warning"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -9858,7 +9859,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
       <TextArea
@@ -9888,7 +9889,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
           size="large"
           variant="danger"
         >
-          <TextArea
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -10015,7 +10016,7 @@ exports[`TextArea demo examples Snapshots: variants 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextArea>
+          </WithTheme(Themed(FauxControl))>
         </TextArea>
       </TextArea>
     </div>

--- a/src/library/TextInput/TextInput.js
+++ b/src/library/TextInput/TextInput.js
@@ -51,11 +51,11 @@ const TextInput = (props: TextInputProps) => {
   return <Root {...rootProps} />;
 };
 
+TextInput.displayName = 'TextInput';
 const defaultProps: TextInputDefaultProps = {
   size: SIZE.large,
   type: TYPE.text
 };
-
 TextInput.defaultProps = defaultProps;
 TextInput.propTypes = textInputPropTypes;
 

--- a/src/library/TextInput/__tests__/__snapshots__/TextInput.spec.js.snap
+++ b/src/library/TextInput/__tests__/__snapshots__/TextInput.spec.js.snap
@@ -194,7 +194,7 @@ exports[`TextInput demo examples Snapshots: controlled 1`] = `
         }
         size="large"
       >
-        <TextInput
+        <WithTheme(Themed(FauxControl))
           className="emotion-3"
           control={[Function]}
           controlProps={
@@ -296,7 +296,7 @@ exports[`TextInput demo examples Snapshots: controlled 1`] = `
               </ThemeProvider>
             </ThemeProvider>
           </Themed(FauxControl)>
-        </TextInput>
+        </WithTheme(Themed(FauxControl))>
       </TextInput>
     </TextInput>
   </MyForm>
@@ -486,7 +486,7 @@ exports[`TextInput demo examples Snapshots: disabled 1`] = `
     disabled={true}
     size="large"
   >
-    <TextInput
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -590,7 +590,7 @@ exports[`TextInput demo examples Snapshots: disabled 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextInput>
+    </WithTheme(Themed(FauxControl))>
   </TextInput>
 </TextInput>
 `;
@@ -891,7 +891,7 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
                   iconStart={<IconAccountBox />}
                   size="large"
                 >
-                  <TextInput
+                  <WithTheme(Themed(FauxControl))
                     className="emotion-6"
                     control={[Function]}
                     controlProps={
@@ -1027,13 +1027,14 @@ exports[`TextInput demo examples Snapshots: form-field 1`] = `
                         </ThemeProvider>
                       </ThemeProvider>
                     </Themed(FauxControl)>
-                  </TextInput>
+                  </WithTheme(Themed(FauxControl))>
                 </TextInput>
               </TextInput>
             </label>
             <Styled(div)
               caption="Surname, family name"
               id="formField-21-caption"
+              isGroup={false}
             >
               <div
                 className="emotion-10"
@@ -1403,7 +1404,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="large"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-4"
               control={[Function]}
               controlProps={
@@ -1529,7 +1530,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
         <TextInput
@@ -1553,7 +1554,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
             iconEnd={<IconCloud />}
             size="large"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-4"
               control={[Function]}
               controlProps={
@@ -1679,7 +1680,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
         <TextInput
@@ -1705,7 +1706,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
             iconStart={<IconCloud />}
             size="large"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-4"
               control={[Function]}
               controlProps={
@@ -1867,7 +1868,7 @@ exports[`TextInput demo examples Snapshots: icons 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
       </div>
@@ -2199,7 +2200,7 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
               }
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -2291,7 +2292,7 @@ exports[`TextInput demo examples Snapshots: input-ref 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -2526,7 +2527,7 @@ exports[`TextInput demo examples Snapshots: invalid 1`] = `
     }
     size="large"
   >
-    <TextInput
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -2618,7 +2619,7 @@ exports[`TextInput demo examples Snapshots: invalid 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextInput>
+    </WithTheme(Themed(FauxControl))>
   </TextInput>
 </TextInput>
 `;
@@ -3478,7 +3479,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               }
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3574,7 +3575,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -3600,7 +3601,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               prefix="$"
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3711,7 +3712,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -3737,7 +3738,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               size="large"
               suffix="cm"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -3847,7 +3848,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -3875,7 +3876,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               size="large"
               suffix="cm"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4000,7 +4001,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -4028,7 +4029,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               prefix="$"
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4176,7 +4177,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -4204,7 +4205,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               size="large"
               suffix="cm"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4351,7 +4352,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -4383,7 +4384,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               size="large"
               suffix="cm"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4584,7 +4585,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -4612,7 +4613,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               suffix="cm"
               variant="danger"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-66"
                 control={[Function]}
                 controlProps={
@@ -4762,7 +4763,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <TextInput
@@ -4794,7 +4795,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
               size="small"
               suffix="cm"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -4995,7 +4996,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
         </div>
@@ -5037,7 +5038,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     }
                     size="large"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -5133,7 +5134,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -5159,7 +5160,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     prefix="$"
                     size="large"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -5270,7 +5271,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -5296,7 +5297,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     size="large"
                     suffix="cm"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -5406,7 +5407,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -5434,7 +5435,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     size="large"
                     suffix="cm"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -5559,7 +5560,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -5587,7 +5588,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     prefix="$"
                     size="large"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -5735,7 +5736,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -5763,7 +5764,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     size="large"
                     suffix="cm"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -5910,7 +5911,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -5942,7 +5943,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     size="large"
                     suffix="cm"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -6143,7 +6144,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -6171,7 +6172,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     suffix="cm"
                     variant="danger"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-66"
                       control={[Function]}
                       controlProps={
@@ -6321,7 +6322,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
                 <TextInput
@@ -6353,7 +6354,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                     size="small"
                     suffix="cm"
                   >
-                    <TextInput
+                    <WithTheme(Themed(FauxControl))
                       className="emotion-3"
                       control={[Function]}
                       controlProps={
@@ -6554,7 +6555,7 @@ exports[`TextInput demo examples Snapshots: kitchen-sink 1`] = `
                           </ThemeProvider>
                         </ThemeProvider>
                       </Themed(FauxControl)>
-                    </TextInput>
+                    </WithTheme(Themed(FauxControl))>
                   </TextInput>
                 </TextInput>
               </div>
@@ -7439,7 +7440,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               }
               size="small"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -7535,7 +7536,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -7594,7 +7595,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               }
               size="medium"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -7690,7 +7691,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -7749,7 +7750,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               }
               size="large"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -7845,7 +7846,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -7904,7 +7905,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
               }
               size="jumbo"
             >
-              <TextInput
+              <WithTheme(Themed(FauxControl))
                 className="emotion-3"
                 control={[Function]}
                 controlProps={
@@ -8000,7 +8001,7 @@ exports[`TextInput demo examples Snapshots: next-to-button 1`] = `
                     </ThemeProvider>
                   </ThemeProvider>
                 </Themed(FauxControl)>
-              </TextInput>
+              </WithTheme(Themed(FauxControl))>
             </TextInput>
           </TextInput>
           <Button
@@ -8233,7 +8234,7 @@ exports[`TextInput demo examples Snapshots: placeholder 1`] = `
     }
     size="large"
   >
-    <TextInput
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -8329,7 +8330,7 @@ exports[`TextInput demo examples Snapshots: placeholder 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextInput>
+    </WithTheme(Themed(FauxControl))>
   </TextInput>
 </TextInput>
 `;
@@ -8638,7 +8639,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
             prefix="$"
             size="large"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-4"
               control={[Function]}
               controlProps={
@@ -8743,7 +8744,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
         <TextInput
@@ -8767,7 +8768,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
             size="large"
             suffix="cm"
           >
-            <TextInput
+            <WithTheme(Themed(FauxControl))
               className="emotion-4"
               control={[Function]}
               controlProps={
@@ -8871,7 +8872,7 @@ exports[`TextInput demo examples Snapshots: prefix-and-suffix 1`] = `
                   </ThemeProvider>
                 </ThemeProvider>
               </Themed(FauxControl)>
-            </TextInput>
+            </WithTheme(Themed(FauxControl))>
           </TextInput>
         </TextInput>
       </div>
@@ -9072,7 +9073,7 @@ exports[`TextInput demo examples Snapshots: read-only 1`] = `
     readOnly={true}
     size="large"
   >
-    <TextInput
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -9176,7 +9177,7 @@ exports[`TextInput demo examples Snapshots: read-only 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextInput>
+    </WithTheme(Themed(FauxControl))>
   </TextInput>
 </TextInput>
 `;
@@ -9370,7 +9371,7 @@ exports[`TextInput demo examples Snapshots: required 1`] = `
     }
     size="large"
   >
-    <TextInput
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -9464,7 +9465,7 @@ exports[`TextInput demo examples Snapshots: required 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextInput>
+    </WithTheme(Themed(FauxControl))>
   </TextInput>
 </TextInput>
 `;
@@ -9934,7 +9935,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                 iconStart={<IconBackspace />}
                 size="large"
               >
-                <TextInput
+                <WithTheme(Themed(FauxControl))
                   className="emotion-4"
                   control={[Function]}
                   controlProps={
@@ -10066,7 +10067,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                       </ThemeProvider>
                     </ThemeProvider>
                   </Themed(FauxControl)>
-                </TextInput>
+                </WithTheme(Themed(FauxControl))>
               </TextInput>
             </TextInput>
             <TextInput
@@ -10092,7 +10093,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                 iconEnd={<IconBackspace />}
                 size="large"
               >
-                <TextInput
+                <WithTheme(Themed(FauxControl))
                   className="emotion-4"
                   control={[Function]}
                   controlProps={
@@ -10224,7 +10225,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                       </ThemeProvider>
                     </ThemeProvider>
                   </Themed(FauxControl)>
-                </TextInput>
+                </WithTheme(Themed(FauxControl))>
               </TextInput>
             </TextInput>
             <TextInput
@@ -10250,7 +10251,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                 size="large"
                 variant="success"
               >
-                <TextInput
+                <WithTheme(Themed(FauxControl))
                   className="emotion-20"
                   control={[Function]}
                   controlProps={
@@ -10385,7 +10386,7 @@ exports[`TextInput demo examples Snapshots: rtl 1`] = `
                       </ThemeProvider>
                     </ThemeProvider>
                   </Themed(FauxControl)>
-                </TextInput>
+                </WithTheme(Themed(FauxControl))>
               </TextInput>
             </TextInput>
           </div>
@@ -10813,7 +10814,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
           }
           size="small"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -10909,7 +10910,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
       <TextInput
@@ -10933,7 +10934,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
           }
           size="medium"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -11029,7 +11030,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
       <TextInput
@@ -11053,7 +11054,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
           }
           size="large"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -11149,7 +11150,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
       <TextInput
@@ -11173,7 +11174,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
           }
           size="jumbo"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-3"
             control={[Function]}
             controlProps={
@@ -11269,7 +11270,7 @@ exports[`TextInput demo examples Snapshots: size 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
     </div>
@@ -11467,7 +11468,7 @@ exports[`TextInput demo examples Snapshots: uncontrolled 1`] = `
     }
     size="large"
   >
-    <TextInput
+    <WithTheme(Themed(FauxControl))
       className="emotion-3"
       control={[Function]}
       controlProps={
@@ -11563,7 +11564,7 @@ exports[`TextInput demo examples Snapshots: uncontrolled 1`] = `
           </ThemeProvider>
         </ThemeProvider>
       </Themed(FauxControl)>
-    </TextInput>
+    </WithTheme(Themed(FauxControl))>
   </TextInput>
 </TextInput>
 `;
@@ -12114,7 +12115,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
           size="large"
           variant="success"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-4"
             control={[Function]}
             controlProps={
@@ -12249,7 +12250,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
       <TextInput
@@ -12275,7 +12276,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
           size="large"
           variant="warning"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-12"
             control={[Function]}
             controlProps={
@@ -12410,7 +12411,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
       <TextInput
@@ -12436,7 +12437,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
           size="large"
           variant="danger"
         >
-          <TextInput
+          <WithTheme(Themed(FauxControl))
             className="emotion-20"
             control={[Function]}
             controlProps={
@@ -12571,7 +12572,7 @@ exports[`TextInput demo examples Snapshots: variants 1`] = `
                 </ThemeProvider>
               </ThemeProvider>
             </Themed(FauxControl)>
-          </TextInput>
+          </WithTheme(Themed(FauxControl))>
         </TextInput>
       </TextInput>
     </div>

--- a/src/library/Tooltip/Tooltip.js
+++ b/src/library/Tooltip/Tooltip.js
@@ -15,6 +15,8 @@ import type {
 } from './types';
 
 export default class Tooltip extends Component<TooltipProps, TooltipState> {
+  static displayName = 'Tooltip';
+
   static defaultProps: TooltipDefaultProps = {
     hasArrow: true,
     placement: PLACEMENT.bottom

--- a/src/library/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
+++ b/src/library/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
@@ -166,7 +166,7 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
               placement="bottom"
               tag="span"
             >
-              <Popover
+              <Manager
                 className="emotion-5"
                 id="tooltip-1"
                 tag="span"
@@ -197,7 +197,7 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
                     <PopoverTrigger
                       component="span"
                     >
-                      <PopoverTrigger
+                      <Target
                         className="emotion-3"
                         component="span"
                       >
@@ -301,11 +301,11 @@ exports[`Tooltip demo examples Snapshots: basic 1`] = `
                             </Button>
                           </Button>
                         </span>
-                      </PopoverTrigger>
+                      </Target>
                     </PopoverTrigger>
                   </PopoverTrigger>
                 </span>
-              </Popover>
+              </Manager>
             </Popover>
           </Popover>
         </ThemeProvider>
@@ -585,7 +585,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                     placement="top"
                     tag="span"
                   >
-                    <Popover
+                    <Manager
                       className="emotion-13"
                       id="tooltip-27"
                       tag="span"
@@ -611,7 +611,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-3"
                               component="span"
                             >
@@ -679,7 +679,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                   </Button>
                                 </Button>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                         <PopoverContent
@@ -697,7 +697,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                             placement="top"
                             role="tooltip"
                           >
-                            <PopoverContent
+                            <WithTheme(RtlPopper)
                               aria-live="polite"
                               className="emotion-9"
                               id="tooltip-27-content"
@@ -769,7 +769,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                         aria-hidden={true}
                                         size="8px"
                                       >
-                                        <PopoverArrow
+                                        <Arrow
                                           aria-hidden={true}
                                           className="emotion-7"
                                         >
@@ -780,13 +780,13 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                                           >
                                             ▼
                                           </span>
-                                        </PopoverArrow>
+                                        </Arrow>
                                       </PopoverArrow>
                                     </PopoverArrow>
                                   </div>
                                 </Popper>
                               </RtlPopper>
-                            </PopoverContent>
+                            </WithTheme(RtlPopper)>
                           </PopoverContent>
                         </PopoverContent>
                         <EventListener
@@ -808,7 +808,7 @@ exports[`Tooltip demo examples Snapshots: controlled 1`] = `
                           }
                         />
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </ThemeProvider>
@@ -948,7 +948,7 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                   placement="bottom"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-3"
                     id="tooltip-17"
                     tag="span"
@@ -973,7 +973,7 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                           component="span"
                           cursor="help"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-1"
                             component="span"
                             cursor="help"
@@ -1009,11 +1009,11 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                                 </span>
                               </Styled(span)>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </ThemeProvider>
@@ -1074,7 +1074,7 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                   placement="bottom"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-3"
                     id="tooltip-18"
                     tag="span"
@@ -1099,7 +1099,7 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                           component="span"
                           cursor="not-allowed"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-6"
                             component="span"
                             cursor="not-allowed"
@@ -1135,11 +1135,11 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                                 </span>
                               </Styled(span)>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </ThemeProvider>
@@ -1200,7 +1200,7 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                   placement="bottom"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-3"
                     id="tooltip-19"
                     tag="span"
@@ -1225,7 +1225,7 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                           component="span"
                           cursor="move"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-11"
                             component="span"
                             cursor="move"
@@ -1261,11 +1261,11 @@ exports[`Tooltip demo examples Snapshots: cursor 1`] = `
                                 </span>
                               </Styled(span)>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </ThemeProvider>
@@ -1726,7 +1726,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                   placement="top"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-13"
                     id="tooltip-11"
                     tag="span"
@@ -1752,7 +1752,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-3"
                             component="span"
                           >
@@ -1820,7 +1820,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                                 </Button>
                               </Button>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                       <PopoverContent
@@ -1838,7 +1838,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                           placement="top"
                           role="tooltip"
                         >
-                          <PopoverContent
+                          <WithTheme(RtlPopper)
                             aria-live="polite"
                             className="emotion-9"
                             id="tooltip-11-content"
@@ -1910,7 +1910,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                                       aria-hidden={true}
                                       size="8px"
                                     >
-                                      <PopoverArrow
+                                      <Arrow
                                         aria-hidden={true}
                                         className="emotion-7"
                                       >
@@ -1921,13 +1921,13 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                                         >
                                           ▼
                                         </span>
-                                      </PopoverArrow>
+                                      </Arrow>
                                     </PopoverArrow>
                                   </PopoverArrow>
                                 </div>
                               </Popper>
                             </RtlPopper>
-                          </PopoverContent>
+                          </WithTheme(RtlPopper)>
                         </PopoverContent>
                       </PopoverContent>
                       <EventListener
@@ -1949,7 +1949,7 @@ exports[`Tooltip demo examples Snapshots: overflow 1`] = `
                         }
                       />
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </ThemeProvider>
@@ -2220,7 +2220,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                   placement="bottom"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-13"
                     id="tooltip-7"
                     tag="span"
@@ -2252,7 +2252,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-3"
                             component="span"
                           >
@@ -2358,7 +2358,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                                 </Button>
                               </Button>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                       <PopoverContent
@@ -2376,7 +2376,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                           placement="bottom"
                           role="tooltip"
                         >
-                          <PopoverContent
+                          <WithTheme(RtlPopper)
                             aria-live="polite"
                             className="emotion-9"
                             id="tooltip-7-content"
@@ -2448,7 +2448,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                                       aria-hidden={true}
                                       size="8px"
                                     >
-                                      <PopoverArrow
+                                      <Arrow
                                         aria-hidden={true}
                                         className="emotion-7"
                                       >
@@ -2459,13 +2459,13 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                                         >
                                           ▼
                                         </span>
-                                      </PopoverArrow>
+                                      </Arrow>
                                     </PopoverArrow>
                                   </PopoverArrow>
                                 </div>
                               </Popper>
                             </RtlPopper>
-                          </PopoverContent>
+                          </WithTheme(RtlPopper)>
                         </PopoverContent>
                       </PopoverContent>
                       <EventListener
@@ -2487,7 +2487,7 @@ exports[`Tooltip demo examples Snapshots: placement 1`] = `
                         }
                       />
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </ThemeProvider>
@@ -2867,7 +2867,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                             tag="span"
                             usePortal={true}
                           >
-                            <Popover
+                            <Manager
                               className="emotion-5"
                               id="tooltip-15"
                               tag="span"
@@ -2893,7 +2893,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                                   <PopoverTrigger
                                     component="span"
                                   >
-                                    <PopoverTrigger
+                                    <Target
                                       className="emotion-3"
                                       component="span"
                                     >
@@ -2961,7 +2961,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                                           </Button>
                                         </Button>
                                       </span>
-                                    </PopoverTrigger>
+                                    </Target>
                                   </PopoverTrigger>
                                 </PopoverTrigger>
                                 <Portal />
@@ -2984,7 +2984,7 @@ exports[`Tooltip demo examples Snapshots: portal 1`] = `
                                   }
                                 />
                               </span>
-                            </Popover>
+                            </Manager>
                           </Popover>
                         </Popover>
                       </ThemeProvider>
@@ -3128,7 +3128,7 @@ exports[`Tooltip demo examples Snapshots: prose 1`] = `
                     tag="span"
                     usePortal={true}
                   >
-                    <Popover
+                    <Manager
                       className="emotion-3"
                       id="tooltip-5"
                       tag="span"
@@ -3151,7 +3151,7 @@ exports[`Tooltip demo examples Snapshots: prose 1`] = `
                           <PopoverTrigger
                             component="span"
                           >
-                            <PopoverTrigger
+                            <Target
                               className="emotion-1"
                               component="span"
                             >
@@ -3185,7 +3185,7 @@ exports[`Tooltip demo examples Snapshots: prose 1`] = `
                                   </span>
                                 </Styled(span)>
                               </span>
-                            </PopoverTrigger>
+                            </Target>
                           </PopoverTrigger>
                         </PopoverTrigger>
                         <Portal />
@@ -3208,7 +3208,7 @@ exports[`Tooltip demo examples Snapshots: prose 1`] = `
                           }
                         />
                       </span>
-                    </Popover>
+                    </Manager>
                   </Popover>
                 </Popover>
               </ThemeProvider>
@@ -3622,7 +3622,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                             placement="left"
                             tag="span"
                           >
-                            <Popover
+                            <Manager
                               className="emotion-13"
                               id="tooltip-13"
                               tag="span"
@@ -3648,7 +3648,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                   <PopoverTrigger
                                     component="span"
                                   >
-                                    <PopoverTrigger
+                                    <Target
                                       className="emotion-3"
                                       component="span"
                                     >
@@ -3716,7 +3716,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                           </Button>
                                         </Button>
                                       </span>
-                                    </PopoverTrigger>
+                                    </Target>
                                   </PopoverTrigger>
                                 </PopoverTrigger>
                                 <PopoverContent
@@ -3734,7 +3734,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                     placement="left"
                                     role="tooltip"
                                   >
-                                    <PopoverContent
+                                    <WithTheme(RtlPopper)
                                       aria-live="polite"
                                       className="emotion-9"
                                       id="tooltip-13-content"
@@ -3806,7 +3806,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                                 aria-hidden={true}
                                                 size="8px"
                                               >
-                                                <PopoverArrow
+                                                <Arrow
                                                   aria-hidden={true}
                                                   className="emotion-7"
                                                 >
@@ -3817,13 +3817,13 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                                   >
                                                     ▼
                                                   </span>
-                                                </PopoverArrow>
+                                                </Arrow>
                                               </PopoverArrow>
                                             </PopoverArrow>
                                           </div>
                                         </Popper>
                                       </RtlPopper>
-                                    </PopoverContent>
+                                    </WithTheme(RtlPopper)>
                                   </PopoverContent>
                                 </PopoverContent>
                                 <EventListener
@@ -3845,7 +3845,7 @@ exports[`Tooltip demo examples Snapshots: scrolling-container 1`] = `
                                   }
                                 />
                               </span>
-                            </Popover>
+                            </Manager>
                           </Popover>
                         </Popover>
                       </ThemeProvider>

--- a/src/library/Truncate/Truncate.js
+++ b/src/library/Truncate/Truncate.js
@@ -8,6 +8,8 @@ export default class Truncate extends PureComponent<
   TruncateProps,
   TruncateState
 > {
+  static displayName = 'Truncate';
+
   state = {
     showTooltip: false
   };

--- a/src/library/Truncate/__tests__/__snapshots__/Truncate.spec.js.snap
+++ b/src/library/Truncate/__tests__/__snapshots__/Truncate.spec.js.snap
@@ -117,7 +117,7 @@ exports[`Truncate renders a tooltip when truncated 1`] = `
                   placement="bottom"
                   tag="span"
                 >
-                  <Popover
+                  <Manager
                     className="emotion-3"
                     id="tooltip-1"
                     tag="span"
@@ -141,7 +141,7 @@ exports[`Truncate renders a tooltip when truncated 1`] = `
                         <PopoverTrigger
                           component="span"
                         >
-                          <PopoverTrigger
+                          <Target
                             className="emotion-1"
                             component="span"
                           >
@@ -176,11 +176,11 @@ exports[`Truncate renders a tooltip when truncated 1`] = `
                                 </span>
                               </Truncate>
                             </span>
-                          </PopoverTrigger>
+                          </Target>
                         </PopoverTrigger>
                       </PopoverTrigger>
                     </span>
-                  </Popover>
+                  </Manager>
                 </Popover>
               </Popover>
             </ThemeProvider>

--- a/src/library/styles/createStyledComponent.js
+++ b/src/library/styles/createStyledComponent.js
@@ -39,10 +39,6 @@ const createStyledComponent: CreateStyledComponent = (
     return componentStyles;
   };
 
-  if (displayName && typeof element !== 'string') {
-    element.displayName = displayName;
-  }
-
   const styledComponent = styled(element, {
     ...(process.env.NODE_ENV !== 'production' && displayName
       ? { label: displayName }

--- a/src/library/themes/ThemeProvider.js
+++ b/src/library/themes/ThemeProvider.js
@@ -15,6 +15,7 @@ const ThemeProvider = (props: ThemeProviderProps) => {
   );
 };
 
+ThemeProvider.displayName = 'ThemeProvider';
 ThemeProvider.defaultProps = {
   theme: mineralTheme
 };

--- a/src/website/.eslintrc
+++ b/src/website/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react/display-name": 0
+  }
+}

--- a/utils/enzymeUtils.js
+++ b/utils/enzymeUtils.js
@@ -6,6 +6,7 @@ import type { ReactWrapper } from 'enzyme';
 import ThemeProvider from '../src/library/themes/ThemeProvider';
 
 export const mountInWrapper = (component: React$Element<*>) => {
+  // eslint-disable-next-line react/display-name
   class Wrapper extends React.Component<*, *> {
     render() {
       return (


### PR DESCRIPTION
### Description

Addresses a couple of issues with regards to component displayNames

* Stop setting `displayName` on `element` passed to `createStyledComponent`.  It is a static property and this was incorrectly overwriting values when the `element` was a component. This should have been set on the returned component rather than the element. As the call to Emotion/styled already does this for us, we actually don’t need to do anything at all.
* Manually add component displayNames to library components.  This was also implemented using babel plugin but we decided against it as it had to be done in the website too (> bundle size) and also the plugin did not have babel 7 compatibility.

### Motivation and context

* Component displayNames were being erroneously set in `createStyledComponent` and it could cause confusion, particularly when debugging.
* Adding displayNames to components allows us to use those values in production.  Mineral uses them in several places for loose/flexible type checking, such as in `ButtonGroup` and `FormField`.  

### Screenshots, videos, or demo, if appropriate

https://fix-display-names--mineral-ui.netlify.com/

### How to test

1. No change in functionality
2. Validate that ButtonGroup still works appropriately.  It uses a displayName type check.
4. View the snapshots and see that they are inline with expectations
5. Have a look at dev-tools and see that component names look correct, and also that dev mode CSS classNames are still labelled correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change
