### PR TITLE
[Select] Fix click to open in Edge

### DIFF
--- a/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
+++ b/src/library/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
@@ -4611,6 +4611,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                     Array [
                                                                                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                       <input
+                                                                                                                        onClick={[Function]}
                                                                                                                         type="hidden"
                                                                                                                         value="2"
                                                                                                                       />,
@@ -4647,6 +4648,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                         <input
+                                                                                                                          onClick={[Function]}
                                                                                                                           type="hidden"
                                                                                                                           value="2"
                                                                                                                         />,
@@ -4684,6 +4686,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         Array [
                                                                                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                           <input
+                                                                                                                            onClick={[Function]}
                                                                                                                             type="hidden"
                                                                                                                             value="2"
                                                                                                                           />,
@@ -4723,6 +4726,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                               Array [
                                                                                                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                 <input
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />,
@@ -4856,6 +4860,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                                                                                                 <input
                                                                                                                                   key="input"
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />
@@ -6653,6 +6658,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                     Array [
                                                                                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                       <input
+                                                                                                                        onClick={[Function]}
                                                                                                                         type="hidden"
                                                                                                                         value="2"
                                                                                                                       />,
@@ -6689,6 +6695,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                         <input
+                                                                                                                          onClick={[Function]}
                                                                                                                           type="hidden"
                                                                                                                           value="2"
                                                                                                                         />,
@@ -6726,6 +6733,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         Array [
                                                                                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                           <input
+                                                                                                                            onClick={[Function]}
                                                                                                                             type="hidden"
                                                                                                                             value="2"
                                                                                                                           />,
@@ -6765,6 +6773,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                               Array [
                                                                                                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                 <input
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />,
@@ -6898,6 +6907,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                                                                                                 <input
                                                                                                                                   key="input"
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />
@@ -8695,6 +8705,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                     Array [
                                                                                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                       <input
+                                                                                                                        onClick={[Function]}
                                                                                                                         type="hidden"
                                                                                                                         value="2"
                                                                                                                       />,
@@ -8731,6 +8742,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                         <input
+                                                                                                                          onClick={[Function]}
                                                                                                                           type="hidden"
                                                                                                                           value="2"
                                                                                                                         />,
@@ -8768,6 +8780,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         Array [
                                                                                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                           <input
+                                                                                                                            onClick={[Function]}
                                                                                                                             type="hidden"
                                                                                                                             value="2"
                                                                                                                           />,
@@ -8807,6 +8820,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                               Array [
                                                                                                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                 <input
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />,
@@ -8940,6 +8954,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                                                                                                 <input
                                                                                                                                   key="input"
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />
@@ -10737,6 +10752,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                     Array [
                                                                                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                       <input
+                                                                                                                        onClick={[Function]}
                                                                                                                         type="hidden"
                                                                                                                         value="2"
                                                                                                                       />,
@@ -10773,6 +10789,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                         <input
+                                                                                                                          onClick={[Function]}
                                                                                                                           type="hidden"
                                                                                                                           value="2"
                                                                                                                         />,
@@ -10810,6 +10827,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                         Array [
                                                                                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                           <input
+                                                                                                                            onClick={[Function]}
                                                                                                                             type="hidden"
                                                                                                                             value="2"
                                                                                                                           />,
@@ -10849,6 +10867,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                               Array [
                                                                                                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                 <input
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />,
@@ -10982,6 +11001,7 @@ exports[`Pagination demo examples Snapshots: kitchen-sink 1`] = `
                                                                                                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                                                                                                 <input
                                                                                                                                   key="input"
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />
@@ -17305,6 +17325,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                     Array [
                                                                                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                       <input
+                                                                                                                        onClick={[Function]}
                                                                                                                         type="hidden"
                                                                                                                         value="2"
                                                                                                                       />,
@@ -17341,6 +17362,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                       Array [
                                                                                                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                         <input
+                                                                                                                          onClick={[Function]}
                                                                                                                           type="hidden"
                                                                                                                           value="2"
                                                                                                                         />,
@@ -17378,6 +17400,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                         Array [
                                                                                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                           <input
+                                                                                                                            onClick={[Function]}
                                                                                                                             type="hidden"
                                                                                                                             value="2"
                                                                                                                           />,
@@ -17417,6 +17440,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                               Array [
                                                                                                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                 <input
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />,
@@ -17550,6 +17574,7 @@ exports[`Pagination demo examples Snapshots: page-sizer 1`] = `
                                                                                                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                                                                                                 <input
                                                                                                                                   key="input"
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="2"
                                                                                                                                 />
@@ -22659,6 +22684,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                           Array [
                                                                                                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                             <input
+                                                                                                                              onClick={[Function]}
                                                                                                                               type="hidden"
                                                                                                                               value="3"
                                                                                                                             />,
@@ -22695,6 +22721,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                             Array [
                                                                                                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                               <input
+                                                                                                                                onClick={[Function]}
                                                                                                                                 type="hidden"
                                                                                                                                 value="3"
                                                                                                                               />,
@@ -22732,6 +22759,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                               Array [
                                                                                                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                 <input
+                                                                                                                                  onClick={[Function]}
                                                                                                                                   type="hidden"
                                                                                                                                   value="3"
                                                                                                                                 />,
@@ -22771,6 +22799,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                                     Array [
                                                                                                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                                                                                                       <input
+                                                                                                                                        onClick={[Function]}
                                                                                                                                         type="hidden"
                                                                                                                                         value="3"
                                                                                                                                       />,
@@ -22904,6 +22933,7 @@ exports[`Pagination demo examples Snapshots: rtl 1`] = `
                                                                                                                                       </withProps(Styled(IconArrowDropdownDown))>
                                                                                                                                       <input
                                                                                                                                         key="input"
+                                                                                                                                        onClick={[Function]}
                                                                                                                                         type="hidden"
                                                                                                                                         value="3"
                                                                                                                                       />

--- a/src/library/Select/SelectTrigger.js
+++ b/src/library/Select/SelectTrigger.js
@@ -24,6 +24,8 @@ const iconMarginMap = {
   jumbo: 14
 };
 
+const stopPropagation = (event: SyntheticEvent<*>) => event.stopPropagation();
+
 export default class SelectTrigger extends Component<SelectTriggerProps> {
   static displayName = 'SelectTrigger';
 
@@ -64,6 +66,7 @@ export default class SelectTrigger extends Component<SelectTriggerProps> {
 
     const inputProps = {
       name,
+      onClick: stopPropagation, // Stop extra click Event in Edge from closing Select
       type: 'hidden',
       value: item ? item.value : ''
     };

--- a/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
+++ b/src/library/Select/__tests__/__snapshots__/Select.spec.js.snap
@@ -508,6 +508,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -538,6 +539,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -569,6 +571,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -602,6 +605,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -723,6 +727,7 @@ exports[`Select demo examples Snapshots: controlled 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -1292,6 +1297,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -1322,6 +1328,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -1353,6 +1360,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -1386,6 +1394,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -1507,6 +1516,7 @@ exports[`Select demo examples Snapshots: custom-item 1`] = `
                                                   </withProps(Styled(IconArrowDropdownDown))>
                                                   <input
                                                     key="input"
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />
@@ -2041,6 +2051,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -2071,6 +2082,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -2102,6 +2114,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -2135,6 +2148,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -2256,6 +2270,7 @@ exports[`Select demo examples Snapshots: custom-menu 1`] = `
                                                   </withProps(Styled(IconArrowDropdownDown))>
                                                   <input
                                                     key="input"
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />
@@ -3256,6 +3271,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -3286,6 +3302,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -3317,6 +3334,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -3350,6 +3368,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -3471,6 +3490,7 @@ exports[`Select demo examples Snapshots: data 1`] = `
                                                   </withProps(Styled(IconArrowDropdownDown))>
                                                   <input
                                                     key="input"
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />
@@ -4001,6 +4021,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                     Array [
                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                       <input
+                                        onClick={[Function]}
                                         type="hidden"
                                         value=""
                                       />,
@@ -4031,6 +4052,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -4062,6 +4084,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -4095,6 +4118,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -4216,6 +4240,7 @@ exports[`Select demo examples Snapshots: disabled 1`] = `
                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                 <input
                                                   key="input"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />
@@ -6015,6 +6040,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
                                                     name="state"
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -6047,6 +6073,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
                                                       name="state"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -6080,6 +6107,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                                       <input
                                                         name="state"
+                                                        onClick={[Function]}
                                                         type="hidden"
                                                         value=""
                                                       />,
@@ -6115,6 +6143,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                                             <input
                                                               name="state"
+                                                              onClick={[Function]}
                                                               type="hidden"
                                                               value=""
                                                             />,
@@ -6240,6 +6269,7 @@ exports[`Select demo examples Snapshots: form-field 1`] = `
                                                             <input
                                                               key="input"
                                                               name="state"
+                                                              onClick={[Function]}
                                                               type="hidden"
                                                               value=""
                                                             />
@@ -6798,6 +6828,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                     Array [
                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                       <input
+                                        onClick={[Function]}
                                         type="hidden"
                                         value=""
                                       />,
@@ -6829,6 +6860,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -6861,6 +6893,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -6895,6 +6928,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -7019,6 +7053,7 @@ exports[`Select demo examples Snapshots: invalid 1`] = `
                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                 <input
                                                   key="input"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />
@@ -7716,6 +7751,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownUp)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -7747,6 +7783,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownUp)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -7779,6 +7816,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownUp)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -7813,6 +7851,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownUp)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -7937,6 +7976,7 @@ exports[`Select demo examples Snapshots: overflow 1`] = `
                                                     </withProps(Styled(IconArrowDropdownUp))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -9810,6 +9850,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                     Array [
                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                       <input
+                                        onClick={[Function]}
                                         type="hidden"
                                         value=""
                                       />,
@@ -9840,6 +9881,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -9871,6 +9913,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -9904,6 +9947,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -10025,6 +10069,7 @@ exports[`Select demo examples Snapshots: placeholder 1`] = `
                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                 <input
                                                   key="input"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />
@@ -10731,6 +10776,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownUp)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -10762,6 +10808,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownUp)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -10794,6 +10841,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownUp)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -10828,6 +10876,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownUp)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -10952,6 +11001,7 @@ exports[`Select demo examples Snapshots: placement 1`] = `
                                                     </withProps(Styled(IconArrowDropdownUp))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -12121,6 +12171,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                       Array [
                                                         <withProps(Styled(IconArrowDropdownUp)) />,
                                                         <input
+                                                          onClick={[Function]}
                                                           type="hidden"
                                                           value=""
                                                         />,
@@ -12152,6 +12203,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                         Array [
                                                           <withProps(Styled(IconArrowDropdownUp)) />,
                                                           <input
+                                                            onClick={[Function]}
                                                             type="hidden"
                                                             value=""
                                                           />,
@@ -12184,6 +12236,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                           Array [
                                                             <withProps(Styled(IconArrowDropdownUp)) />,
                                                             <input
+                                                              onClick={[Function]}
                                                               type="hidden"
                                                               value=""
                                                             />,
@@ -12218,6 +12271,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                                 Array [
                                                                   <withProps(Styled(IconArrowDropdownUp)) />,
                                                                   <input
+                                                                    onClick={[Function]}
                                                                     type="hidden"
                                                                     value=""
                                                                   />,
@@ -12342,6 +12396,7 @@ exports[`Select demo examples Snapshots: portal 1`] = `
                                                                   </withProps(Styled(IconArrowDropdownUp))>
                                                                   <input
                                                                     key="input"
+                                                                    onClick={[Function]}
                                                                     type="hidden"
                                                                     value=""
                                                                   />
@@ -13013,6 +13068,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                     Array [
                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                       <input
+                                        onClick={[Function]}
                                         type="hidden"
                                         value="alpha"
                                       />,
@@ -13051,6 +13107,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value="alpha"
                                         />,
@@ -13090,6 +13147,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value="alpha"
                                           />,
@@ -13131,6 +13189,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value="alpha"
                                                 />,
@@ -13270,6 +13329,7 @@ exports[`Select demo examples Snapshots: read-only 1`] = `
                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                 <input
                                                   key="input"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value="alpha"
                                                 />
@@ -13813,6 +13873,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                     Array [
                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                       <input
+                                        onClick={[Function]}
                                         type="hidden"
                                         value=""
                                       />,
@@ -13844,6 +13905,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                       Array [
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
+                                          onClick={[Function]}
                                           type="hidden"
                                           value=""
                                         />,
@@ -13876,6 +13938,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -13910,6 +13973,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -14034,6 +14098,7 @@ exports[`Select demo examples Snapshots: required 1`] = `
                                                 </withProps(Styled(IconArrowDropdownDown))>
                                                 <input
                                                   key="input"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />
@@ -14765,6 +14830,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -14795,6 +14861,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -14826,6 +14893,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -14859,6 +14927,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                         Array [
                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                           <input
+                                                            onClick={[Function]}
                                                             type="hidden"
                                                             value=""
                                                           />,
@@ -14980,6 +15049,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                           </withProps(Styled(IconArrowDropdownDown))>
                                                           <input
                                                             key="input"
+                                                            onClick={[Function]}
                                                             type="hidden"
                                                             value=""
                                                           />
@@ -15291,6 +15361,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -15322,6 +15393,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -15354,6 +15426,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -15388,6 +15461,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                         Array [
                                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                                           <input
+                                                            onClick={[Function]}
                                                             type="hidden"
                                                             value=""
                                                           />,
@@ -15544,6 +15618,7 @@ exports[`Select demo examples Snapshots: rtl 1`] = `
                                                           </withProps(Styled(IconArrowDropdownDown))>
                                                           <input
                                                             key="input"
+                                                            onClick={[Function]}
                                                             type="hidden"
                                                             value=""
                                                           />
@@ -16430,6 +16505,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                       Array [
                                                         <withProps(Styled(IconArrowDropdownUp)) />,
                                                         <input
+                                                          onClick={[Function]}
                                                           type="hidden"
                                                           value=""
                                                         />,
@@ -16461,6 +16537,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                         Array [
                                                           <withProps(Styled(IconArrowDropdownUp)) />,
                                                           <input
+                                                            onClick={[Function]}
                                                             type="hidden"
                                                             value=""
                                                           />,
@@ -16493,6 +16570,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                           Array [
                                                             <withProps(Styled(IconArrowDropdownUp)) />,
                                                             <input
+                                                              onClick={[Function]}
                                                               type="hidden"
                                                               value=""
                                                             />,
@@ -16527,6 +16605,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                 Array [
                                                                   <withProps(Styled(IconArrowDropdownUp)) />,
                                                                   <input
+                                                                    onClick={[Function]}
                                                                     type="hidden"
                                                                     value=""
                                                                   />,
@@ -16651,6 +16730,7 @@ exports[`Select demo examples Snapshots: scrolling-container 1`] = `
                                                                   </withProps(Styled(IconArrowDropdownUp))>
                                                                   <input
                                                                     key="input"
+                                                                    onClick={[Function]}
                                                                     type="hidden"
                                                                     value=""
                                                                   />
@@ -17883,6 +17963,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -17913,6 +17994,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -17944,6 +18026,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -17977,6 +18060,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -18098,6 +18182,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -18400,6 +18485,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -18430,6 +18516,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -18461,6 +18548,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -18494,6 +18582,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -18615,6 +18704,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -18917,6 +19007,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -18947,6 +19038,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -18978,6 +19070,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -19011,6 +19104,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -19132,6 +19226,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -19434,6 +19529,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -19464,6 +19560,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -19495,6 +19592,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -19528,6 +19626,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -19649,6 +19748,7 @@ exports[`Select demo examples Snapshots: size 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -20318,6 +20418,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -20348,6 +20449,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                               Array [
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value=""
                                                 />,
@@ -20379,6 +20481,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                                 Array [
                                                   <withProps(Styled(IconArrowDropdownDown)) />,
                                                   <input
+                                                    onClick={[Function]}
                                                     type="hidden"
                                                     value=""
                                                   />,
@@ -20412,6 +20515,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                                       Array [
                                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                                         <input
+                                                          onClick={[Function]}
                                                           type="hidden"
                                                           value=""
                                                         />,
@@ -20533,6 +20637,7 @@ exports[`Select demo examples Snapshots: trigger-ref 1`] = `
                                                         </withProps(Styled(IconArrowDropdownDown))>
                                                         <input
                                                           key="input"
+                                                          onClick={[Function]}
                                                           type="hidden"
                                                           value=""
                                                         />
@@ -22107,6 +22212,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                       <withProps(Styled(IconArrowDropdownDown)) />,
                                       <input
                                         name="state"
+                                        onClick={[Function]}
                                         type="hidden"
                                         value="CO"
                                       />,
@@ -22144,6 +22250,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                         <withProps(Styled(IconArrowDropdownDown)) />,
                                         <input
                                           name="state"
+                                          onClick={[Function]}
                                           type="hidden"
                                           value="CO"
                                         />,
@@ -22182,6 +22289,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
                                             name="state"
+                                            onClick={[Function]}
                                             type="hidden"
                                             value="CO"
                                           />,
@@ -22222,6 +22330,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                                 <withProps(Styled(IconArrowDropdownDown)) />,
                                                 <input
                                                   name="state"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value="CO"
                                                 />,
@@ -22356,6 +22465,7 @@ exports[`Select demo examples Snapshots: uncontrolled 1`] = `
                                                 <input
                                                   key="input"
                                                   name="state"
+                                                  onClick={[Function]}
                                                   type="hidden"
                                                   value="CO"
                                                 />
@@ -23271,6 +23381,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -23302,6 +23413,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -23334,6 +23446,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -23368,6 +23481,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -23524,6 +23638,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -23837,6 +23952,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -23868,6 +23984,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -23900,6 +24017,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -23934,6 +24052,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -24090,6 +24209,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />
@@ -24403,6 +24523,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                         Array [
                                           <withProps(Styled(IconArrowDropdownDown)) />,
                                           <input
+                                            onClick={[Function]}
                                             type="hidden"
                                             value=""
                                           />,
@@ -24434,6 +24555,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                           Array [
                                             <withProps(Styled(IconArrowDropdownDown)) />,
                                             <input
+                                              onClick={[Function]}
                                               type="hidden"
                                               value=""
                                             />,
@@ -24466,6 +24588,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                             Array [
                                               <withProps(Styled(IconArrowDropdownDown)) />,
                                               <input
+                                                onClick={[Function]}
                                                 type="hidden"
                                                 value=""
                                               />,
@@ -24500,6 +24623,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                                   Array [
                                                     <withProps(Styled(IconArrowDropdownDown)) />,
                                                     <input
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />,
@@ -24656,6 +24780,7 @@ exports[`Select demo examples Snapshots: variants 1`] = `
                                                     </withProps(Styled(IconArrowDropdownDown))>
                                                     <input
                                                       key="input"
+                                                      onClick={[Function]}
                                                       type="hidden"
                                                       value=""
                                                     />


### PR DESCRIPTION
### Description

Fix `Select`'s click to open in Edge

### Motivation and context

It was reported that a `Select` component in a `FormField` did not open on a single click using Edge.  The issue can be replicated here.  https://mineral-ui.com/components/select/form-field

It turns out that the hidden input element inside of the `SelectTrigger` was bubbling click events, causing the `Select` to open and immediately close.  This was resolved by stopping the propagation of the hidden input's click event.

### Screenshots, videos, or demo, if appropriate

https://select-fix-edge--mineral-ui.netlify.com/components/select/form-field

### How to test

Browse to the demo example link above, using MS Edge, and verify that `Select` opens on a single mouse click.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [ ] Automated tests written and passing - we don't currently have browser specific testing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**
