### PR TITLE
[CardTitle] Ensure icons stay same size when resize Card

### DIFF
--- a/src/library/Card/__tests__/__snapshots__/Card.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/Card.spec.js.snap
@@ -82,6 +82,9 @@ exports[`Card demo examples Snapshots: basic 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -288,6 +291,9 @@ exports[`Card demo examples Snapshots: children 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -575,6 +581,9 @@ exports[`Card demo examples Snapshots: clickable 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -763,6 +772,9 @@ exports[`Card demo examples Snapshots: order 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;

--- a/src/library/Card/__tests__/__snapshots__/CardBlock.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/CardBlock.spec.js.snap
@@ -98,6 +98,9 @@ exports[`CardBlock demo examples Snapshots: children 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -425,6 +428,9 @@ exports[`CardBlock demo examples Snapshots: consistent-spacing 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;

--- a/src/library/Card/__tests__/__snapshots__/CardDivider.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/CardDivider.spec.js.snap
@@ -88,6 +88,9 @@ exports[`CardDivider demo examples Snapshots: basic 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;

--- a/src/library/Card/__tests__/__snapshots__/CardImage.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/CardImage.spec.js.snap
@@ -99,6 +99,9 @@ exports[`CardImage demo examples Snapshots: with-image 1`] = `
 }
 
 .emotion-2 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;

--- a/src/library/Card/__tests__/__snapshots__/CardStatus.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/CardStatus.spec.js.snap
@@ -113,6 +113,9 @@ exports[`CardStatus demo examples Snapshots: basic 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;

--- a/src/library/Card/__tests__/__snapshots__/CardTitle.spec.js.snap
+++ b/src/library/Card/__tests__/__snapshots__/CardTitle.spec.js.snap
@@ -30,6 +30,9 @@ exports[`CardTitle demo examples Snapshots: actions-menu 1`] = `
 }
 
 .emotion-10 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -641,6 +644,9 @@ exports[`CardTitle demo examples Snapshots: avatar 1`] = `
 }
 
 .emotion-3 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -1229,6 +1235,9 @@ exports[`CardTitle demo examples Snapshots: rtl 1`] = `
 }
 
 .emotion-3 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-left: 0.5em;
   position: relative;
   top: 0.25em;
@@ -1452,6 +1461,9 @@ exports[`CardTitle demo examples Snapshots: secondary-text 1`] = `
 }
 
 .emotion-2 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -1715,6 +1727,9 @@ exports[`CardTitle demo examples Snapshots: titles 1`] = `
 }
 
 .emotion-1 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -1993,6 +2008,9 @@ exports[`CardTitle demo examples Snapshots: variants 1`] = `
 
 .emotion-2 > [role="img"] {
   color: #de1b1b;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -2018,6 +2036,9 @@ exports[`CardTitle demo examples Snapshots: variants 1`] = `
 
 .emotion-10 > [role="img"] {
   color: #2a854e;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;
@@ -2036,6 +2057,9 @@ exports[`CardTitle demo examples Snapshots: variants 1`] = `
 
 .emotion-18 > [role="img"] {
   color: #ad5f00;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;

--- a/src/library/Card/styled.js
+++ b/src/library/Card/styled.js
@@ -404,6 +404,7 @@ export const CardTitleTitle = createStyledComponent(
 
       '& > [role="img"]': {
         color: variant ? theme[`icon_color_${variant}`] : null,
+        flex: '0 0 auto',
         marginLeft: rtl ? theme.CardTitleIcon_margin : null,
         marginRight: rtl ? null : theme.CardTitleIcon_margin,
         position: 'relative',

--- a/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
+++ b/src/library/Popover/__tests__/__snapshots__/Popover.spec.js.snap
@@ -3978,6 +3978,9 @@ exports[`Popover demo examples Snapshots: title 1`] = `
 }
 
 .emotion-6 > [role="img"] {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   margin-right: 0.5em;
   position: relative;
   top: 0.25em;


### PR DESCRIPTION
### Description

Ensure icons stay same size when resize Card

### Motivation and context

CardTitle icons were noticed to shrink when a Card was resized.  The issue can be replicated by viewing https://mineral-ui.com/components/card-title/variants and resizing the window.

### Screenshots, videos, or demo, if appropriate

https://cardtitle-icons--mineral-ui.netlify.com/components/card-title/variants

### How to test

Visit the demo link above and ensure that the icons in the CardTitle stay the same size when the window is resized.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [ ] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - [n/a]
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - [n/a]
* [x] Documentation created or updated - [n/a]
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - [n/a]
