### PR TITLE
[Table] Legacy React lifecycle migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prop-types": "^15.5.7",
     "react-fast-compare": "2.0.1",
     "react-html-attributes": "1.4.2",
+    "react-lifecycles-compat": "3.0.4",
     "react-popper": "0.10.1",
     "react-transition-group": "2.3.0",
     "recompose": "0.27.0",

--- a/src/library/Table/Selectable.js
+++ b/src/library/Table/Selectable.js
@@ -1,25 +1,31 @@
 /* @flow */
 import { Component } from 'react';
+import { polyfill as polyfillReactLifecycles } from 'react-lifecycles-compat';
 import deepEqual from 'react-fast-compare';
 
 import type { SelectableItem, SelectableProps, SelectableState } from './types';
 
-export default class Selectable extends Component<
-  SelectableProps,
-  SelectableState
-> {
+class Selectable extends Component<SelectableProps, SelectableState> {
   static displayName = 'Selectable';
 
   state = {
     selected: this.props.defaultSelected || []
   };
 
-  componentWillReceiveProps(nextProps: SelectableProps) {
-    if (!deepEqual(this.props.selected, nextProps.selected)) {
-      this.setState({
+  static getDerivedStateFromProps(
+    nextProps: SelectableProps,
+    prevState: SelectableState
+  ): $Shape<SelectableState> | null {
+    if (
+      nextProps.selected !== undefined &&
+      !deepEqual(nextProps.selected, prevState.selected)
+    ) {
+      return {
         selected: nextProps.selected
-      });
+      };
     }
+
+    return null; // no change
   }
 
   render() {
@@ -116,3 +122,5 @@ export default class Selectable extends Component<
     return this.isControlled(key) ? this.props[key] : this.state[key];
   };
 }
+
+export default polyfillReactLifecycles(Selectable);

--- a/src/library/Table/utils.js
+++ b/src/library/Table/utils.js
@@ -1,0 +1,46 @@
+/* @flow */
+import type { Rows, TableProps } from './types';
+
+export const getColumns = ({ columns, data }: TableProps) => {
+  return (
+    columns ||
+    (data[0]
+      ? Object.keys(data[0]).reduce((acc, cell) => {
+          acc.push({ content: cell, key: cell });
+          return acc;
+        }, [])
+      : [])
+  );
+};
+
+export const getComparators = ({ columns }: TableProps) => {
+  const comparators =
+    columns &&
+    columns.reduce((acc, column) => {
+      const { key, sortComparator } = column;
+      if (sortComparator) {
+        acc[key] = sortComparator;
+      }
+      return acc;
+    }, {});
+
+  return comparators && Object.keys(comparators).length
+    ? comparators
+    : undefined;
+};
+
+export const getSelectableRows = (rows: Rows) =>
+  rows.filter((row) => !row.disabled);
+
+export const getSortable = ({
+  columns,
+  defaultSort,
+  sort,
+  sortable
+}: TableProps) =>
+  Boolean(
+    defaultSort ||
+      sort ||
+      sortable ||
+      (columns && columns.some((column) => column.sortable))
+  );


### PR DESCRIPTION
### Description

Updates `Table` legacy React lifecycle methods

### Motivation and context

Closes #764 
Connects #652

_Definitely some more deepEquals calls in here.  Open to suggestions on how to minimize them further..._

### Screenshots, videos, or demo, if appropriate

https://764-table-lifecycle--mineral-ui.netlify.com/

### How to test

1. Should be no change in functionality.
1. Works in React < 16.3. (I tested in CRA with React 16.2.0)

### Types of changes

- Other (provide details below)

Refactor

### Checklist

* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change