### PR TITLE
[Dialog] [Flex] Fix layout issues

### DIFF
--- a/src/library/Box/propTypes.js
+++ b/src/library/Box/propTypes.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { arrayOf, bool, number, oneOfType, string } from 'prop-types';
 
-const spacingPropType = oneOfType([
+export const spacingPropType = oneOfType([
   number,
   string,
   arrayOf(oneOfType([number, string]))

--- a/src/library/Box/types.js
+++ b/src/library/Box/types.js
@@ -42,7 +42,7 @@ export type SpacingStyles = {
 
 export type SpacingValue = StyleValue | SpacingSize;
 
-type HeightOrWidthProp = number | string | Array<number | string | null>;
+export type HeightOrWidthProp = number | string | Array<number | string | null>;
 
 type SpacingProp =
   | number

--- a/src/library/Dialog/__tests__/__snapshots__/Dialog.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/Dialog.spec.js.snap
@@ -285,6 +285,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-25 > div {
@@ -308,6 +309,7 @@ exports[`Dialog demo examples Snapshots: actions 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-24 > div {
@@ -1699,6 +1701,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -1722,6 +1725,7 @@ exports[`Dialog demo examples Snapshots: alternate 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -2739,6 +2743,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -2762,6 +2767,7 @@ exports[`Dialog demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -3910,6 +3916,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-23 > div {
@@ -3933,6 +3940,7 @@ exports[`Dialog demo examples Snapshots: close-button 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-22 > div {
@@ -5077,6 +5085,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -5100,6 +5109,7 @@ exports[`Dialog demo examples Snapshots: rtl 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -6178,6 +6188,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -6201,6 +6212,7 @@ exports[`Dialog demo examples Snapshots: sizes 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -8451,6 +8463,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -8474,6 +8487,7 @@ exports[`Dialog demo examples Snapshots: title 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -9776,6 +9790,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-17 > div {
@@ -9799,6 +9814,7 @@ exports[`Dialog demo examples Snapshots: variants 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {

--- a/src/library/Dialog/__tests__/__snapshots__/DialogActions.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogActions.spec.js.snap
@@ -286,6 +286,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-22 > div {
@@ -309,6 +310,7 @@ exports[`DialogActions demo examples Snapshots: actions 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-21 > div {
@@ -1244,6 +1246,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-22 > div {
@@ -1267,6 +1270,7 @@ exports[`DialogActions demo examples Snapshots: variants 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-21 > div {

--- a/src/library/Dialog/__tests__/__snapshots__/DialogBody.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogBody.spec.js.snap
@@ -69,6 +69,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -92,6 +93,7 @@ exports[`DialogBody demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -769,6 +771,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -792,6 +795,7 @@ exports[`DialogBody demo examples Snapshots: scrolling 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-14 > div {

--- a/src/library/Dialog/__tests__/__snapshots__/DialogFooter.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogFooter.spec.js.snap
@@ -295,6 +295,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -318,6 +319,7 @@ exports[`DialogFooter demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-14 > div {

--- a/src/library/Dialog/__tests__/__snapshots__/DialogHeader.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogHeader.spec.js.snap
@@ -267,6 +267,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -290,6 +291,7 @@ exports[`DialogHeader demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-14 > div {
@@ -928,6 +930,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-18 > div {
@@ -951,6 +954,7 @@ exports[`DialogHeader demo examples Snapshots: close-button 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-17 > div {

--- a/src/library/Dialog/__tests__/__snapshots__/DialogTitle.spec.js.snap
+++ b/src/library/Dialog/__tests__/__snapshots__/DialogTitle.spec.js.snap
@@ -267,6 +267,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -290,6 +291,7 @@ exports[`DialogTitle demo examples Snapshots: basic 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-14 > div {
@@ -904,6 +906,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {
@@ -927,6 +930,7 @@ exports[`DialogTitle demo examples Snapshots: element-appearance 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-14 > div {
@@ -1599,6 +1603,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-16 > div {
@@ -1622,6 +1627,7 @@ exports[`DialogTitle demo examples Snapshots: variants 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+  width: 100%;
 }
 
 .emotion-15 > div {

--- a/src/library/Dialog/styled.js
+++ b/src/library/Dialog/styled.js
@@ -138,6 +138,7 @@ export const DialogBodyOverflowContainerWithShadows = createStyledComponent(
     return {
       display: 'flex',
       flex: '1 1 auto',
+      width: '100%',
 
       // OverflowContainerWithShadows > Scroller
       '& > div': {

--- a/src/library/Flex/__tests__/__snapshots__/FlexItem.spec.js.snap
+++ b/src/library/Flex/__tests__/__snapshots__/FlexItem.spec.js.snap
@@ -3897,6 +3897,1186 @@ exports[`FlexItem demo examples Snapshots: grow 1`] = `
 </Styled(div)>
 `;
 
+exports[`FlexItem demo examples Snapshots: min-width 1`] = `
+.emotion-37 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.emotion-36 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: block;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.emotion-36 *,
+.emotion-36 *::before,
+.emotion-36 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: block;
+  margin-right: 1em;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.emotion-3 *,
+.emotion-3 *::before,
+.emotion-3 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  color: #3272d9;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  background-color: #ffffff;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  height: 2.5em;
+  margin: 0;
+  min-width: 2.5em;
+  padding: 0 0.5em;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.emotion-2 *,
+.emotion-2 *::before,
+.emotion-2 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-2:focus {
+  background-color: #ffffff;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+  color: #3272d9;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:hover {
+  background-color: #f5f7fa;
+  border-color: #5691f0;
+  color: #3272d9;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:focus:active,
+.emotion-2:focus:hover {
+  border-color: #c8d1e0;
+}
+
+.emotion-2:active {
+  background-color: #ebeff5;
+  border-color: #1d5bbf;
+  color: #3272d9;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+}
+
+.emotion-2 [role="img"] {
+  box-sizing: content-box;
+  color: #3272d9;
+  display: block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-2 [role="img"]:first-child {
+  margin-right: 0.5em;
+}
+
+.emotion-2 [role="img"]:last-child {
+  margin-left: 0.5em;
+}
+
+.emotion-2 [role="img"]:only-child {
+  margin: 0;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-height: 100%;
+  pointer-events: none;
+  width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  font-size: 0.875em;
+  line-height: 2.857142857142857em;
+}
+
+.emotion-0:first-child {
+  padding-left: 0.5714285714285714em;
+}
+
+.emotion-0:last-child {
+  padding-right: 0.5714285714285714em;
+}
+
+.emotion-34 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.emotion-33 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  display: block;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.emotion-33 *,
+.emotion-33 *::before,
+.emotion-33 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-28 {
+  width: 100%;
+}
+
+.emotion-28 > span {
+  width: 100%;
+}
+
+.emotion-26 {
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 > span {
+  width: 100%;
+}
+
+.emotion-24 {
+  display: inline-block;
+}
+
+.emotion-20 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-20 [role="img"] {
+  display: block;
+  color: #3272d9;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-20 [role="img"]:first-child {
+  color: #3272d9;
+  margin: 0 0.5em;
+}
+
+.emotion-20 :not([role="img"]) ~ [role="img"] {
+  color: #3272d9;
+}
+
+.emotion-20 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+  color: #3272d9;
+  margin-left: 0.5em;
+}
+
+.emotion-19 {
+  box-sizing: border-box;
+  color: #333840;
+  font-family: "Open Sans",-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  line-height: 1.25;
+  outline: 0;
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: antialiased;
+  position: relative;
+  z-index: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+}
+
+.emotion-19 *,
+.emotion-19 *::before,
+.emotion-19 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-19:hover > div:last-child {
+  border-color: #5691f0;
+}
+
+.emotion-19:focus > div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-19:active > div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-19 [role="img"] {
+  display: block;
+  color: #3272d9;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-19 [role="img"]:first-child {
+  color: #3272d9;
+  margin: 0 0.5em;
+}
+
+.emotion-19 :not([role="img"]) ~ [role="img"] {
+  color: #3272d9;
+}
+
+.emotion-19 :not([role="img"]) + [role="img"]:not(:last-of-type) {
+  color: #3272d9;
+  margin-left: 0.5em;
+}
+
+.emotion-13 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  height: 2.857142857142857em;
+  min-width: 0;
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-size: 0.875em;
+  font-style: italic;
+  outline: 0;
+  padding-left: 1.1428571428571428em;
+  padding-right: 1.1428571428571428em;
+}
+
+.emotion-13::-webkit-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-13::-moz-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-13:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-13::placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-13::-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-13:-ms-input-placeholder {
+  color: #8e99ab;
+  -webkit-text-fill-color: #8e99ab;
+  font-style: italic;
+}
+
+.emotion-13::-ms-clear {
+  display: none;
+}
+
+.emotion-13:focus ~ div:last-child {
+  border-color: #c8d1e0;
+  box-shadow: 0 0 0 1px #ffffff,0 0 0 2px #1d5bbf;
+}
+
+.emotion-12 {
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 100%;
+}
+
+.emotion-15 {
+  margin: 0.5em;
+}
+
+.emotion-14 {
+  fill: currentcolor;
+  font-size: 16px;
+  height: 1.5em;
+  width: 1.5em;
+  margin: 0.5em;
+}
+
+.emotion-18 {
+  background-color: #ffffff;
+  border-color: #c8d1e0;
+  border-radius: 0.1875em;
+  border-style: solid;
+  border-width: 1px;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: -1;
+}
+
+<Flex
+  alignItems="stretch"
+  direction="row"
+  gutterWidth="md"
+  justifyContent="start"
+>
+  <WithTheme(Component)
+    alignItems="stretch"
+    direction="row"
+    gutterWidth="md"
+    justifyContent="start"
+  >
+    <Component
+      alignItems="stretch"
+      direction="row"
+      gutterWidth="md"
+      justifyContent="start"
+    >
+      <Flex
+        alignItems="stretch"
+        direction="row"
+        element="div"
+        gutterWidth="md"
+        justifyContent="start"
+      >
+        <Box
+          alignItems="stretch"
+          className="emotion-37"
+          direction="row"
+          element="div"
+          gutterWidth="md"
+          justifyContent="start"
+        >
+          <Styled(div)
+            alignItems="stretch"
+            className="emotion-37"
+            direction="row"
+            element="div"
+            gutterWidth="md"
+            justifyContent="start"
+          >
+            <div
+              className="emotion-36"
+            >
+              <FlexItem
+                grow={0}
+                key=".0"
+                marginEnd="1em"
+                shrink={1}
+              >
+                <FlexItem
+                  element="div"
+                  grow={0}
+                  marginEnd="1em"
+                  shrink={1}
+                >
+                  <Box
+                    className="emotion-4"
+                    element="div"
+                    grow={0}
+                    marginEnd="1em"
+                    shrink={1}
+                  >
+                    <Styled(div)
+                      className="emotion-4"
+                      element="div"
+                      grow={0}
+                      marginEnd="1em"
+                      shrink={1}
+                    >
+                      <div
+                        className="emotion-3"
+                      >
+                        <Button
+                          element="button"
+                          size="large"
+                          type="button"
+                        >
+                          <Button
+                            element="button"
+                            size="large"
+                            text="Short Text"
+                            type="button"
+                          >
+                            <button
+                              className="emotion-2"
+                              type="button"
+                            >
+                              <Styled(span)>
+                                <span
+                                  className="emotion-1"
+                                >
+                                  <Styled(span)
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-0"
+                                    >
+                                      Short Text
+                                    </span>
+                                  </Styled(span)>
+                                </span>
+                              </Styled(span)>
+                            </button>
+                          </Button>
+                        </Button>
+                      </div>
+                    </Styled(div)>
+                  </Box>
+                </FlexItem>
+              </FlexItem>
+              <FlexItem
+                grow={0}
+                key=".1"
+                marginEnd="1em"
+                shrink={1}
+              >
+                <FlexItem
+                  element="div"
+                  grow={0}
+                  marginEnd="1em"
+                  shrink={1}
+                >
+                  <Box
+                    className="emotion-4"
+                    element="div"
+                    grow={0}
+                    marginEnd="1em"
+                    shrink={1}
+                  >
+                    <Styled(div)
+                      className="emotion-4"
+                      element="div"
+                      grow={0}
+                      marginEnd="1em"
+                      shrink={1}
+                    >
+                      <div
+                        className="emotion-3"
+                      >
+                        <Button
+                          element="button"
+                          size="large"
+                          type="button"
+                        >
+                          <Button
+                            element="button"
+                            size="large"
+                            text="Short Text"
+                            type="button"
+                          >
+                            <button
+                              className="emotion-2"
+                              type="button"
+                            >
+                              <Styled(span)>
+                                <span
+                                  className="emotion-1"
+                                >
+                                  <Styled(span)
+                                    size="large"
+                                  >
+                                    <span
+                                      className="emotion-0"
+                                    >
+                                      Short Text
+                                    </span>
+                                  </Styled(span)>
+                                </span>
+                              </Styled(span)>
+                            </button>
+                          </Button>
+                        </Button>
+                      </div>
+                    </Styled(div)>
+                  </Box>
+                </FlexItem>
+              </FlexItem>
+              <FlexItem
+                grow={0}
+                key=".2"
+                minWidth={0}
+                shrink={1}
+              >
+                <FlexItem
+                  element="div"
+                  grow={0}
+                  minWidth={0}
+                  shrink={1}
+                >
+                  <Box
+                    className="emotion-34"
+                    element="div"
+                    grow={0}
+                    shrink={1}
+                  >
+                    <Styled(div)
+                      className="emotion-34"
+                      element="div"
+                      grow={0}
+                      shrink={1}
+                    >
+                      <div
+                        className="emotion-33"
+                      >
+                        <Select
+                          data={
+                            Array [
+                              Object {
+                                "text": "This example item has some super long text as well, just to make sure this example is still illustrative when it is selected.",
+                              },
+                            ]
+                          }
+                          itemKey="value"
+                          placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                          placement="bottom-start"
+                          size="large"
+                        >
+                          <Select
+                            data={
+                              Array [
+                                Object {
+                                  "text": "This example item has some super long text as well, just to make sure this example is still illustrative when it is selected.",
+                                },
+                              ]
+                            }
+                            id="select-1"
+                            isOpen={false}
+                            itemKey="value"
+                            menu={[Function]}
+                            modifiers={
+                              Object {
+                                "contentWidth": Object {
+                                  "enabled": true,
+                                  "fn": [Function],
+                                },
+                              }
+                            }
+                            onClose={[Function]}
+                            onOpen={[Function]}
+                            placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                            placement="bottom-start"
+                            size="large"
+                          >
+                            <WithTheme(Themed(Dropdown))
+                              className="emotion-28"
+                              data={
+                                Array [
+                                  Object {
+                                    "text": "This example item has some super long text as well, just to make sure this example is still illustrative when it is selected.",
+                                  },
+                                ]
+                              }
+                              id="select-1"
+                              isOpen={false}
+                              itemKey="value"
+                              menu={[Function]}
+                              modifiers={
+                                Object {
+                                  "contentWidth": Object {
+                                    "enabled": true,
+                                    "fn": [Function],
+                                  },
+                                }
+                              }
+                              onClose={[Function]}
+                              onOpen={[Function]}
+                              placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                              placement="bottom-start"
+                              size="large"
+                            >
+                              <Themed(Dropdown)
+                                className="emotion-28"
+                                data={
+                                  Array [
+                                    Object {
+                                      "text": "This example item has some super long text as well, just to make sure this example is still illustrative when it is selected.",
+                                    },
+                                  ]
+                                }
+                                id="select-1"
+                                isOpen={false}
+                                itemKey="value"
+                                menu={[Function]}
+                                modifiers={
+                                  Object {
+                                    "contentWidth": Object {
+                                      "enabled": true,
+                                      "fn": [Function],
+                                    },
+                                  }
+                                }
+                                onClose={[Function]}
+                                onOpen={[Function]}
+                                placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                                placement="bottom-start"
+                                size="large"
+                              >
+                                <ThemeProvider>
+                                  <ThemeProvider>
+                                    <Dropdown
+                                      className="emotion-28"
+                                      data={
+                                        Array [
+                                          Object {
+                                            "text": "This example item has some super long text as well, just to make sure this example is still illustrative when it is selected.",
+                                          },
+                                        ]
+                                      }
+                                      id="select-1"
+                                      isOpen={false}
+                                      itemKey="value"
+                                      menu={[Function]}
+                                      modifiers={
+                                        Object {
+                                          "contentWidth": Object {
+                                            "enabled": true,
+                                            "fn": [Function],
+                                          },
+                                        }
+                                      }
+                                      onClose={[Function]}
+                                      onOpen={[Function]}
+                                      placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                                      placement="bottom-start"
+                                      size="large"
+                                    >
+                                      <Popover
+                                        className="emotion-28"
+                                        content={[Function]}
+                                        focusTriggerOnClose={true}
+                                        hasArrow={true}
+                                        id="select-1"
+                                        isOpen={false}
+                                        itemKey="value"
+                                        modifiers={
+                                          Object {
+                                            "contentWidth": Object {
+                                              "enabled": true,
+                                              "fn": [Function],
+                                            },
+                                          }
+                                        }
+                                        onClose={[Function]}
+                                        onOpen={[Function]}
+                                        placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                                        placement="bottom-start"
+                                        size="large"
+                                        triggerRef={[Function]}
+                                      >
+                                        <Popover
+                                          className="emotion-28"
+                                          content={[Function]}
+                                          focusTriggerOnClose={true}
+                                          hasArrow={true}
+                                          id="select-1"
+                                          isOpen={false}
+                                          itemKey="value"
+                                          modifiers={
+                                            Object {
+                                              "contentWidth": Object {
+                                                "enabled": true,
+                                                "fn": [Function],
+                                              },
+                                            }
+                                          }
+                                          onClose={[Function]}
+                                          onOpen={[Function]}
+                                          placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                                          placement="bottom-start"
+                                          size="large"
+                                          tag="span"
+                                          triggerRef={[Function]}
+                                        >
+                                          <Manager
+                                            className="emotion-26"
+                                            id="select-1"
+                                            tag="span"
+                                          >
+                                            <span
+                                              className="emotion-26"
+                                              id="select-1"
+                                            >
+                                              <PopoverTrigger
+                                                aria-describedby="select-1-content"
+                                                aria-expanded={false}
+                                                aria-haspopup="listbox"
+                                                aria-owns="select-1-content"
+                                                isOpen={false}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                                                role="button"
+                                                size="large"
+                                                tabIndex={0}
+                                                triggerRef={[Function]}
+                                              >
+                                                <PopoverTrigger
+                                                  component="span"
+                                                >
+                                                  <Target
+                                                    className="emotion-24"
+                                                    component="span"
+                                                  >
+                                                    <span
+                                                      className="emotion-24"
+                                                    >
+                                                      <SelectTrigger
+                                                        aria-describedby="select-1-content"
+                                                        aria-expanded={false}
+                                                        aria-haspopup="listbox"
+                                                        aria-owns="select-1-content"
+                                                        isOpen={false}
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide"
+                                                        role="button"
+                                                        size="large"
+                                                        tabIndex={0}
+                                                        triggerRef={[Function]}
+                                                      >
+                                                        <SelectTrigger
+                                                          afterItems={
+                                                            Array [
+                                                              <withProps(Styled(IconArrowDropdownDown)) />,
+                                                              <input
+                                                                onClick={[Function]}
+                                                                type="hidden"
+                                                                value=""
+                                                              />,
+                                                            ]
+                                                          }
+                                                          aria-describedby="select-1-content"
+                                                          aria-expanded={false}
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="select-1-content"
+                                                          control={[Function]}
+                                                          controlProps={
+                                                            Object {
+                                                              "hasPlaceholder": true,
+                                                              "variant": undefined,
+                                                            }
+                                                          }
+                                                          fauxControlRef={[Function]}
+                                                          onBlur={[Function]}
+                                                          onClick={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          role="button"
+                                                          size="large"
+                                                          tabIndex={0}
+                                                        >
+                                                          <WithTheme(Themed(FauxControl))
+                                                            afterItems={
+                                                              Array [
+                                                                <withProps(Styled(IconArrowDropdownDown)) />,
+                                                                <input
+                                                                  onClick={[Function]}
+                                                                  type="hidden"
+                                                                  value=""
+                                                                />,
+                                                              ]
+                                                            }
+                                                            aria-describedby="select-1-content"
+                                                            aria-expanded={false}
+                                                            aria-haspopup="listbox"
+                                                            aria-owns="select-1-content"
+                                                            className="emotion-20"
+                                                            control={[Function]}
+                                                            controlProps={
+                                                              Object {
+                                                                "hasPlaceholder": true,
+                                                                "variant": undefined,
+                                                              }
+                                                            }
+                                                            fauxControlRef={[Function]}
+                                                            onBlur={[Function]}
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            onKeyUp={[Function]}
+                                                            role="button"
+                                                            size="large"
+                                                            tabIndex={0}
+                                                          >
+                                                            <Themed(FauxControl)
+                                                              afterItems={
+                                                                Array [
+                                                                  <withProps(Styled(IconArrowDropdownDown)) />,
+                                                                  <input
+                                                                    onClick={[Function]}
+                                                                    type="hidden"
+                                                                    value=""
+                                                                  />,
+                                                                ]
+                                                              }
+                                                              aria-describedby="select-1-content"
+                                                              aria-expanded={false}
+                                                              aria-haspopup="listbox"
+                                                              aria-owns="select-1-content"
+                                                              className="emotion-20"
+                                                              control={[Function]}
+                                                              controlProps={
+                                                                Object {
+                                                                  "hasPlaceholder": true,
+                                                                  "variant": undefined,
+                                                                }
+                                                              }
+                                                              fauxControlRef={[Function]}
+                                                              onBlur={[Function]}
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              onKeyUp={[Function]}
+                                                              role="button"
+                                                              size="large"
+                                                              tabIndex={0}
+                                                            >
+                                                              <ThemeProvider>
+                                                                <ThemeProvider>
+                                                                  <FauxControl
+                                                                    afterItems={
+                                                                      Array [
+                                                                        <withProps(Styled(IconArrowDropdownDown)) />,
+                                                                        <input
+                                                                          onClick={[Function]}
+                                                                          type="hidden"
+                                                                          value=""
+                                                                        />,
+                                                                      ]
+                                                                    }
+                                                                    aria-describedby="select-1-content"
+                                                                    aria-expanded={false}
+                                                                    aria-haspopup="listbox"
+                                                                    aria-owns="select-1-content"
+                                                                    className="emotion-20"
+                                                                    control={[Function]}
+                                                                    controlProps={
+                                                                      Object {
+                                                                        "hasPlaceholder": true,
+                                                                        "variant": undefined,
+                                                                      }
+                                                                    }
+                                                                    fauxControlRef={[Function]}
+                                                                    onBlur={[Function]}
+                                                                    onClick={[Function]}
+                                                                    onKeyDown={[Function]}
+                                                                    onKeyUp={[Function]}
+                                                                    role="button"
+                                                                    size="large"
+                                                                    tabIndex={0}
+                                                                  >
+                                                                    <FauxControl
+                                                                      aria-describedby="select-1-content"
+                                                                      aria-expanded={false}
+                                                                      aria-haspopup="listbox"
+                                                                      aria-owns="select-1-content"
+                                                                      className="emotion-20"
+                                                                      control={[Function]}
+                                                                      innerRef={[Function]}
+                                                                      onBlur={[Function]}
+                                                                      onClick={[Function]}
+                                                                      onKeyDown={[Function]}
+                                                                      onKeyUp={[Function]}
+                                                                      role="button"
+                                                                      tabIndex={0}
+                                                                    >
+                                                                      <div
+                                                                        aria-describedby="select-1-content"
+                                                                        aria-expanded={false}
+                                                                        aria-haspopup="listbox"
+                                                                        aria-owns="select-1-content"
+                                                                        className="emotion-19"
+                                                                        onBlur={[Function]}
+                                                                        onClick={[Function]}
+                                                                        onKeyDown={[Function]}
+                                                                        onKeyUp={[Function]}
+                                                                        role="button"
+                                                                        tabIndex={0}
+                                                                      >
+                                                                        <Control
+                                                                          controlPropsIn={
+                                                                            Object {
+                                                                              "hasPlaceholder": true,
+                                                                              "variant": undefined,
+                                                                            }
+                                                                          }
+                                                                          hasPlaceholder={true}
+                                                                          key="control"
+                                                                          size="large"
+                                                                        >
+                                                                          <div
+                                                                            className="emotion-13"
+                                                                          >
+                                                                            <TriggerContent>
+                                                                              <span
+                                                                                className="emotion-12"
+                                                                              >
+                                                                                Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide
+                                                                              </span>
+                                                                            </TriggerContent>
+                                                                          </div>
+                                                                        </Control>
+                                                                        <withProps(Styled(IconArrowDropdownDown))
+                                                                          key="arrow"
+                                                                        >
+                                                                          <Styled(IconArrowDropdownDown)
+                                                                            size="1.5em"
+                                                                          >
+                                                                            <IconArrowDropdownDown
+                                                                              className="emotion-15"
+                                                                              size="1.5em"
+                                                                            >
+                                                                              <Icon
+                                                                                className="emotion-15"
+                                                                                rtl={false}
+                                                                                size="1.5em"
+                                                                              >
+                                                                                <Styled(svg)
+                                                                                  aria-hidden={true}
+                                                                                  className="emotion-15"
+                                                                                  focusable="false"
+                                                                                  role="img"
+                                                                                  rtl={false}
+                                                                                  size="1.5em"
+                                                                                  viewBox="0 0 24 24"
+                                                                                >
+                                                                                  <svg
+                                                                                    aria-hidden={true}
+                                                                                    className="emotion-14"
+                                                                                    focusable="false"
+                                                                                    role="img"
+                                                                                    viewBox="0 0 24 24"
+                                                                                  >
+                                                                                    <g>
+                                                                                      <path
+                                                                                        d="M12 17.5l-8-8h16z"
+                                                                                      />
+                                                                                    </g>
+                                                                                  </svg>
+                                                                                </Styled(svg)>
+                                                                              </Icon>
+                                                                            </IconArrowDropdownDown>
+                                                                          </Styled(IconArrowDropdownDown)>
+                                                                        </withProps(Styled(IconArrowDropdownDown))>
+                                                                        <input
+                                                                          key="input"
+                                                                          onClick={[Function]}
+                                                                          type="hidden"
+                                                                          value=""
+                                                                        />
+                                                                        <Underlay>
+                                                                          <div
+                                                                            className="emotion-18"
+                                                                          />
+                                                                        </Underlay>
+                                                                      </div>
+                                                                    </FauxControl>
+                                                                  </FauxControl>
+                                                                </ThemeProvider>
+                                                              </ThemeProvider>
+                                                            </Themed(FauxControl)>
+                                                          </WithTheme(Themed(FauxControl))>
+                                                        </SelectTrigger>
+                                                      </SelectTrigger>
+                                                    </span>
+                                                  </Target>
+                                                </PopoverTrigger>
+                                              </PopoverTrigger>
+                                            </span>
+                                          </Manager>
+                                        </Popover>
+                                      </Popover>
+                                    </Dropdown>
+                                  </ThemeProvider>
+                                </ThemeProvider>
+                              </Themed(Dropdown)>
+                            </WithTheme(Themed(Dropdown))>
+                          </Select>
+                        </Select>
+                      </div>
+                    </Styled(div)>
+                  </Box>
+                </FlexItem>
+              </FlexItem>
+            </div>
+          </Styled(div)>
+        </Box>
+      </Flex>
+    </Component>
+  </WithTheme(Component)>
+</Flex>
+`;
+
 exports[`FlexItem demo examples Snapshots: responsive 1`] = `
 .emotion-18 {
   outline: 1px dotted #accbfc;

--- a/src/library/Flex/propTypes.js
+++ b/src/library/Flex/propTypes.js
@@ -8,6 +8,7 @@ import {
   oneOfType,
   string
 } from 'prop-types';
+import { spacingPropType } from '../Box/propTypes';
 import {
   ALIGN_ITEMS,
   ALIGN_SELF,
@@ -26,6 +27,7 @@ export const flexPropTypes = {
   children: node.isRequired,
   direction: stringOrArrayOfStringsPropType(DIRECTION),
   gutterWidth: oneOfType([number, string]),
+  minWidth: spacingPropType,
   justifyContent: stringOrArrayOfStringsPropType(JUSTIFY_CONTENT),
   wrap: oneOfType([bool, arrayOf(oneOfType([bool]))])
 };

--- a/src/library/Flex/styled.js
+++ b/src/library/Flex/styled.js
@@ -14,6 +14,11 @@ const getJustification = (value: string): string =>
     ? `space-${value}`
     : getAlignment(value);
 
+const getWidthValue = (value) =>
+  typeof value === 'number' && value < 1 && value !== 0
+    ? `${value * 100}%`
+    : value;
+
 const flexMapValueToProperty = (
   property: string,
   value: StyleValue
@@ -66,12 +71,10 @@ const flexItemMapValueToProperty = (
   const map = {
     alignSelf: (value) =>
       value === 'start' || value === 'end' ? `flex-${value}` : value,
-    flexBasis: (value) =>
-      typeof value === 'number' && value < 1 && value !== 0
-        ? `${value * 100}%`
-        : value,
+    flexBasis: getWidthValue,
     flexGrow: (value) => value,
-    flexShrink: (value) => value
+    flexShrink: (value) => value,
+    minWidth: getWidthValue
   };
 
   return map[property](value);
@@ -84,7 +87,7 @@ export const createFlexItemRootNode: CreateRootNode<FlexItemProps> = (
 
   return createStyledComponent(
     component,
-    ({ alignSelf, breakpoints, grow, shrink, theme, width }) =>
+    ({ alignSelf, breakpoints, grow, minWidth, shrink, theme, width }) =>
       getResponsiveStyles({
         breakpoints,
         mapValueToProperty: flexItemMapValueToProperty,
@@ -92,13 +95,14 @@ export const createFlexItemRootNode: CreateRootNode<FlexItemProps> = (
           alignSelf,
           flexBasis: width || 'auto',
           flexGrow: grow,
-          flexShrink: shrink
+          flexShrink: shrink,
+          minWidth
         },
         theme
       }),
     {
       displayName: 'FlexItem',
-      filterProps: ['inline', 'width']
+      filterProps: ['inline', 'minWidth', 'width']
     }
   );
 };

--- a/src/library/Flex/types.js
+++ b/src/library/Flex/types.js
@@ -7,6 +7,8 @@ import {
   JUSTIFY_CONTENT
 } from './constants';
 
+import type { HeightOrWidthProp } from '../Box/types';
+
 type StringOrArrayOfStrings<T> = $Keys<T> | Array<$Keys<T> | null>;
 
 type AlignItems = StringOrArrayOfStrings<typeof ALIGN_ITEMS>;
@@ -20,6 +22,7 @@ export type FlexProps = {
   children: React$Node,
   direction?: Direction,
   gutterWidth?: GutterWidth,
+  minWidth?: HeightOrWidthProp,
   justifyContent?: JustifyContent,
   wrap?: boolean | Array<boolean | null>
 };

--- a/src/website/app/demos/Dialog/Dialog/examples/composition.js
+++ b/src/website/app/demos/Dialog/Dialog/examples/composition.js
@@ -82,8 +82,8 @@ export default {
                 <FlexItem>
                   <Dropdown data={[{ text: 'Dropdown' }]}><Button>Dropdown</Button></Dropdown>
                 </FlexItem>
-                <FlexItem>
-                  <Select data={data} name="state" />
+                <FlexItem minWidth={0}>
+                  <Select data={data} name="state" placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." />
                 </FlexItem>
               </Flex>
 

--- a/src/website/app/demos/Flex/FlexItem/examples/index.js
+++ b/src/website/app/demos/Flex/FlexItem/examples/index.js
@@ -5,6 +5,7 @@ import flexItem from './flexItem';
 import flexProps from './flexProps';
 import importSyntax from './importSyntax';
 import grow from './grow';
+import minWidth from './minWidth';
 import responsive from './responsive';
 import shrink from './shrink';
 
@@ -13,6 +14,7 @@ export default [
   flexItem,
   grow,
   shrink,
+  minWidth,
   alignSelf,
   flexProps,
   boxProps,

--- a/src/website/app/demos/Flex/FlexItem/examples/minWidth.js
+++ b/src/website/app/demos/Flex/FlexItem/examples/minWidth.js
@@ -1,0 +1,30 @@
+/* @flow */
+import Button from '../../../../../../library/Button';
+import Select from '../../../../../../library/Select';
+import Flex, { FlexItem } from '../../../../../../library/Flex';
+
+const data = [
+  {
+    text:
+      'This example item has some super long text as well, just to make sure this example is still illustrative when it is selected.'
+  }
+];
+
+export default {
+  id: 'min-width',
+  title: 'Min Width',
+  description: `Truncated content inside FlexItem will not truncate as expected,
+because flex items have a
+[default minWidth of \`auto\`](https://www.w3.org/TR/css-flexbox-1/#min-size-auto).
+You can enable truncation by setting \`minWidth\` to 0 on the wrapping FlexItem
+([why does this work?](https://css-tricks.com/flexbox-truncated-text/)).`,
+  scope: { Button, data, Flex, FlexItem, Select },
+  source: `
+    <Flex>
+      <FlexItem><Button>Short Text</Button></FlexItem>
+      <FlexItem><Button>Short Text</Button></FlexItem>
+      <FlexItem minWidth={0}>
+        <Select placeholder="Super long example of text that is specifically formed to force truncation, when minWidth is set to 0, even when the viewport is rather wide" data={data} />
+      </FlexItem>
+    </Flex>`
+};

--- a/src/website/app/demos/Flex/FlexItem/propDocs.js
+++ b/src/website/app/demos/Flex/FlexItem/propDocs.js
@@ -46,6 +46,11 @@ const propDocs: ComponentPropDocs = {
     },
     defaultValue: getDefaultValue('grow')
   },
+  minWidth: {
+    description:
+      'Set the minimum width ([see example](#min-width)) [[Responsive-capable]](#responsive)',
+    type: 'number | string | Array<number | string | null>'
+  },
   shrink: {
     description:
       'Shrink factor along the main axis ([see example](#shrink)) [[Responsive-capable]](#responsive)',


### PR DESCRIPTION
### Description

* Add `minWidth` prop to FlexItem
  * Add demo example
* Fix additional layout issues
  * Ensure DialogBody & FlexItem children do not extend beyond element boundary
* Update Dialog Composition example to illustrate layout scenario

### Motivation and context

Fix issues reported by users in chat.

### Screenshots, videos, or demo, if appropriate

https://layout-bugs--mineral-ui.netlify.com/components/flex-item/min-width

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
1. Navigate to FlexItem > [Min Width example](https://layout-bugs--mineral-ui.netlify.com/components/flex-item/min-width)
1. Confirm that the Select is truncated properly
1. Navigate to Dialog > Composition example (only viewable locally)
1. Confirm that the Select is truncated properly

### Types of changes

- Feature

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support)
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change

<!-- If any of the above need further details, you should include those here. -->
