### PR TITLE
build(packages): Ensure sub-package builds respect babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "scroll-into-view-if-needed": "2.2.20"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.6",
+    "@babel/cli": "7.2.3",
+    "@babel/core": "7.2.2",
     "@babel/plugin-proposal-class-properties": "7.1.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
     "@babel/plugin-syntax-dynamic-import": "7.0.0",

--- a/packages/mineral-ui-icons/package.json
+++ b/packages/mineral-ui-icons/package.json
@@ -22,8 +22,8 @@
     "pack-ls": "cd dist && tar -tvf $(npm pack) && rm *.tgz"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.6",
+    "@babel/cli": "7.2.3",
+    "@babel/core": "7.2.2",
     "fs-extra": "7.0.1",
     "material-design-icons": "3.0.1"
   },

--- a/packages/mineral-ui-icons/scripts/build.js
+++ b/packages/mineral-ui-icons/scripts/build.js
@@ -15,16 +15,22 @@ const exec = (command, env) =>
 
 // components es modules
 console.log('\n\nBuilding ES modules...');
-exec('babel ./src --out-dir ./dist/es --ignore *.spec.js,*.template.js', {
-  NODE_ENV
-});
+exec(
+  'babel ./src --out-dir ./dist/es --ignore *.spec.js,*.template.js --root-mode upward',
+  {
+    NODE_ENV
+  }
+);
 
 // components cjs modules
 console.log('\n\nBuilding CommonJS modules...');
-exec('babel ./src --out-dir ./dist --ignore *.spec.js,*.template.js', {
-  BABEL_ENV: 'cjs',
-  NODE_ENV
-});
+exec(
+  'babel ./src --out-dir ./dist --ignore *.spec.js,*.template.js --root-mode upward',
+  {
+    BABEL_ENV: 'cjs',
+    NODE_ENV
+  }
+);
 
 // Prepare flat package
 const packageJsonFile = path.resolve(__dirname, '../package.json');

--- a/packages/mineral-ui-tokens/package.json
+++ b/packages/mineral-ui-tokens/package.json
@@ -24,8 +24,8 @@
     "pack-ls": "cd dist && tar -tvf $(npm pack)"
   },
   "devDependencies": {
-    "@babel/cli": "7.1.5",
-    "@babel/core": "7.1.6",
+    "@babel/cli": "7.2.3",
+    "@babel/core": "7.2.2",
     "fs-extra": "7.0.1",
     "theo": "7.0.1"
   }

--- a/packages/mineral-ui-tokens/scripts/build.js
+++ b/packages/mineral-ui-tokens/scripts/build.js
@@ -15,13 +15,13 @@ const exec = (command, env) =>
 
 // components es modules
 console.log('\n\nBuilding ES modules...');
-exec('babel ./src --out-dir ./dist/es', {
+exec('babel ./src --out-dir ./dist/es --root-mode upward', {
   NODE_ENV
 });
 
 // components cjs modules
 console.log('\n\nBuilding CommonJS modules...');
-exec('babel ./src --out-dir ./dist', {
+exec('babel ./src --out-dir ./dist --root-mode upward', {
   BABEL_ENV: 'cjs',
   NODE_ENV
 });


### PR DESCRIPTION
### Description

Ensure sub-package (`mineral-ui-icons` and `mineral-ui-tokens`) builds respect root babel config

### Motivation and context

Sub-package build steps were no longer respecting the root `babel.config.js`.  This was broken during a recent babel update.

### Screenshots, videos, or demo, if appropriate

https://babel-packages--mineral-ui.netlify.com/

### How to test

1. `cd packages/mineral-ui-icons` & `cd packages/mineral-ui-tokens`
2. `DEBUG=true npm run build`
3. Build should succeed and debug output should be logged

### Types of changes

- Other (provide details below)

Fixes an issue with the sub-packages build configuration

### Checklist
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) - **[n/a]**
* [x] Automated tests written and passing - **[n/a]**
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered - **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered - **[n/a]**
* [x] Documentation created or updated - **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change - **[n/a]**