### PR TITLE
[Navigation] Prevent spread of Navigation parent props onto NavItem

### DIFF
--- a/src/library/Navigation/Navigation.js
+++ b/src/library/Navigation/Navigation.js
@@ -64,16 +64,18 @@ export default class Navigation extends Component<NavigationProps> {
 
   renderItems = (prefixAndType: PrefixAndType): ?Array<React$Node> => {
     const {
+      align,
       children,
       itemAs,
       items: itemsProp,
       maxItemWidth,
       messages,
+      minimal,
       onChange: ignoreOnChange,
       overflowAtIndex,
+      secondary,
       selectedIndex,
-      type: ignoreType,
-      ...restProps
+      type: ignoreType
     } = this.props;
 
     const items: ?NavigationItems = children
@@ -125,20 +127,22 @@ export default class Navigation extends Component<NavigationProps> {
             }
           } else {
             const navItemProps = {
+              align,
               children: text,
               disabled,
               as: as || itemAs || 'a',
               index,
               maxWidth: maxWidth || maxItemWidth,
+              minimal,
               onClick: !disabled
                 ? composeEventHandlers(onClick, (event) => {
                     this.handleClick(event, index);
                   })
                 : preventDefaultEventFn,
+              secondary,
               selected: selected || index === selectedIndex,
               ...prefixAndType,
-              ...restItem,
-              ...restProps
+              ...restItem
             };
 
             return child ? (


### PR DESCRIPTION
<!--
Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: "[ComponentName] Clear, brief title using imperative tense" ~or~ "type-of-change(what-is-changed): Clear, brief title using imperative tense" (the latter should follow type convention from Commitizen: https://github.com/commitizen/cz-cli)
Examples:
* [Button] Add support for type=submit
* test(happo): Update to happo v1.0

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->
Update Navigation so that `restProps` is no longer spread onto NavItem children.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->

Closes #827

### Screenshots, videos, or demo, if appropriate
<!-- Please share either a reproduction of your work on CodeSandbox (our Mineral UI Starter https://codesandbox.io/s/v410y75m0 may be useful for setup) or a deploy preview. To record and share a video: http://recordit.co/ -->

https://nav-item-props--mineral-ui.netlify.com/components/primary-nav/basic

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
1. Navigate to [PrimaryNav](https://nav-item-props--mineral-ui.netlify.com/components/primary-nav/basic)
1. Add an undocumented valid prop (e.g. `role="foo"`) to PrimaryNav and confirm that it does not spread onto NavItem children

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

BREAKING CHANGE: PrimaryNav & SecondaryNav no longer passes along 
undocumented props to NavItem

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) **[n/a]**
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered **[n/a]**
* [x] Documentation created or updated **[n/a]**
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change **[n/a]**

<!-- If any of the above need further details, you should include those here. -->
