### PR TITLE
docs(theme): Keep px units for fontSize_base

### DIFF
--- a/src/library/themes/themeFromTokens.js
+++ b/src/library/themes/themeFromTokens.js
@@ -27,7 +27,11 @@ export default function(tokens: Tokens): Theme {
   return Object.keys(tokens).reduce((acc, key) => {
     let value = tokens[key];
     if (typeof value === 'string') {
-      if (value.split('px').length === 2 && !contains(key, 'breakpoint')) {
+      if (
+        value.split('px').length === 2 &&
+        !contains(key, 'breakpoint') &&
+        !contains(key, 'fontSize_base')
+      ) {
         value = pxToEm(value);
       } else if (contains(key, 'fontSize')) {
         value = remToEm(value);


### PR DESCRIPTION
<!--
Thank you for your contribution! Here's a template to help you format your PR.

Your title should look like: "[ComponentName] Clear, brief title using imperative tense" ~or~ "type-of-change(what-is-changed): Clear, brief title using imperative tense" (the latter should follow type convention from Commitizen: https://github.com/commitizen/cz-cli)
Examples:
* [Button] Add support for type=submit
* test(happo): Update to happo v1.0

For a PR to be considered, each item in the checklist must be checked.
-->

### Description
<!-- Describe your changes in detail -->

Currently, the `fontSize_base` theme variable is documented as `'1em'`, despite being used as `'16px'` throughout our styles. This PR updates the docs to display the value as `'16px'`.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here and auto-close them via commit messages: https://help.github.com/articles/closing-issues-via-commit-messages. -->

Closes #826

### Screenshots, videos, or demo, if appropriate
<!-- Please share either a reproduction of your work on CodeSandbox (our Mineral UI Starter https://codesandbox.io/s/v410y75m0 may be useful for setup) or a deploy preview. To record and share a video: http://recordit.co/ -->

https://font-size-base-docs--mineral-ui.netlify.com/theming#typography

### How to test
<!-- Please describe the steps for reviewers to take to cover all facets of this feature. -->

1. `cd mineral-ui && npm start`
2. Navigate to [Theming](https://font-size-base-docs--mineral-ui.netlify.com/theming#typography) and scroll down to fontSize_base, under Typography
3. Confirm that the value displayed is "16px"

### Types of changes
<!-- What types of changes does your code introduce? Remove the lines below that are NOT applicable. Note: Whatever you choose here should match your commit messages. -->
- Other (provide details below)

Just a simple docs update; the functional code is untouched. Not sure if this should be considered a breaking change, as consumers may have attempted to use `em` units for this theme variable prior to this change. Since that would not have worked, I'm assuming no one other than the reporter of the related issue (#826) has attempted this and thus marking it as breaking is probably overkill.

### Checklist
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add "[n/a]" to the end of the line. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] Renders and functions properly in [all supported browsers](https://github.com/mineral-ui/mineral-ui#browser-support) **[n/a]**
* [x] Automated tests written and passing
* [x] [Accessibility](http://webaim.org/intro) and [inclusivity](https://24ways.org/2016/what-the-heck-is-inclusive-design/) considered **[n/a]**
* [x] Rendering performance (initial load time & 60fps) and [perceived performance](http://blog.teamtreehouse.com/perceived-performance) considered **[n/a]**
* [x] Documentation created or updated
* [x] Tested in [sandbox](https://github.com/facebookincubator/create-react-app#getting-started) if new component or breaking change **[n/a]**

<!-- If any of the above need further details, you should include those here. -->
